### PR TITLE
fix: detect pure directive in external packages by parsing source files

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -36,7 +36,7 @@ func run(pass *analysis.Pass) (any, error) {
 	// Build ignore maps for each file (excluding skipped files)
 	ignoreMaps := make(map[string]internal.IgnoreMap)
 	funcIgnores := make(map[string]map[token.Pos]struct{})
-	pureFuncs := make(internal.PureFuncSet)
+	pureFuncs := internal.NewPureFuncSet(pass.Fset)
 
 	pkgPath := pass.Pkg.Path()
 	for _, file := range pass.Files {
@@ -49,7 +49,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 		// Build pure function set for this file
 		for key := range internal.BuildPureFunctionSet(pass.Fset, file, pkgPath) {
-			pureFuncs[key] = struct{}{}
+			pureFuncs.Add(key)
 		}
 	}
 

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -19,7 +19,7 @@ func RunSSA(
 	ssaInfo *buildssa.SSA,
 	ignoreMaps map[string]IgnoreMap,
 	funcIgnores map[string]map[token.Pos]struct{},
-	pureFuncs PureFuncSet,
+	pureFuncs *PureFuncSet,
 	skipFiles map[string]bool,
 ) {
 	for _, fn := range ssaInfo.SrcFuncs {
@@ -72,11 +72,11 @@ func RunSSA(
 type checker struct {
 	pass      *analysis.Pass
 	ignoreMap IgnoreMap
-	pureFuncs PureFuncSet
+	pureFuncs *PureFuncSet
 	reported  map[token.Pos]bool
 }
 
-func newChecker(pass *analysis.Pass, ignoreMap IgnoreMap, pureFuncs PureFuncSet) *checker {
+func newChecker(pass *analysis.Pass, ignoreMap IgnoreMap, pureFuncs *PureFuncSet) *checker {
 	return &checker{
 		pass:      pass,
 		ignoreMap: ignoreMap,
@@ -133,7 +133,7 @@ type Analyzer struct {
 }
 
 // NewAnalyzer creates a new Analyzer for the given function.
-func NewAnalyzer(fn *ssa.Function, pureFuncs PureFuncSet) *Analyzer {
+func NewAnalyzer(fn *ssa.Function, pureFuncs *PureFuncSet) *Analyzer {
 	return &Analyzer{
 		fn:           fn,
 		rootTracer:   NewRootTracer(pureFuncs),

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 func TestNewAnalyzer(t *testing.T) {
-	pureFuncs := PureFuncSet{
-		{PkgPath: "test", FuncName: "Pure"}: {},
-	}
+	pureFuncs := NewPureFuncSet(nil)
+	pureFuncs.Add(PureFuncKey{PkgPath: "test", FuncName: "Pure"})
 	analyzer := NewAnalyzer(nil, pureFuncs)
 
 	if analyzer.fn != nil {
@@ -144,7 +143,7 @@ func TestRootTracer_IsPureFunction_NilPureFuncs(t *testing.T) {
 
 func TestNewChecker(t *testing.T) {
 	ignoreMap := make(IgnoreMap)
-	pureFuncs := make(PureFuncSet)
+	pureFuncs := NewPureFuncSet(nil)
 
 	chk := newChecker(nil, ignoreMap, pureFuncs)
 

--- a/internal/root_tracer.go
+++ b/internal/root_tracer.go
@@ -24,11 +24,11 @@ import (
 // RootTracer traces SSA values to find mutable *gorm.DB roots.
 type RootTracer struct {
 	ssaTracer *SSATracer
-	pureFuncs PureFuncSet
+	pureFuncs *PureFuncSet
 }
 
 // NewRootTracer creates a new RootTracer with the given pure functions.
-func NewRootTracer(pureFuncs PureFuncSet) *RootTracer {
+func NewRootTracer(pureFuncs *PureFuncSet) *RootTracer {
 	return &RootTracer{
 		ssaTracer: NewSSATracer(),
 		pureFuncs: pureFuncs,

--- a/testdata/src/external_pure_test/external.go
+++ b/testdata/src/external_pure_test/external.go
@@ -1,0 +1,55 @@
+package external_pure_test
+
+import (
+	"context"
+
+	"purelib"
+)
+
+// =============================================================================
+// SHOULD NOT REPORT - External package pure method (new(T).Method pattern)
+// =============================================================================
+
+// externalPureMethodWithNew demonstrates that new(T).Method() pattern works
+// with pure directive from external package.
+func externalPureMethodWithNew() {
+	db := new(purelib.Orm).GetDB()
+	db.Find(nil)
+	db.Find(nil) // OK: pure method from external package returns immutable
+}
+
+// externalPureMethodWithNewAndContext demonstrates new(T).DB(ctx) pattern
+// from external package.
+func externalPureMethodWithNewAndContext() {
+	ctx := context.Background()
+	db := new(purelib.Orm).DB(ctx)
+	db.Find(nil)
+	db.Find(nil) // OK: pure method from external package with ctx returns immutable
+}
+
+// externalPureMethodWithVariable demonstrates pure method via variable.
+func externalPureMethodWithVariable() {
+	orm := &purelib.Orm{}
+	db := orm.GetDB()
+	db.Find(nil)
+	db.Find(nil) // OK: pure method from external package returns immutable
+}
+
+// externalPureFunction demonstrates pure function from external package.
+func externalPureFunction() {
+	db := purelib.PureFactory()
+	db.Find(nil)
+	db.Find(nil) // OK: pure function from external package returns immutable
+}
+
+// =============================================================================
+// SHOULD REPORT - Non-pure usage (chain methods pollute)
+// =============================================================================
+
+// externalChainReuse demonstrates that chain methods still pollute.
+func externalChainReuse() {
+	db := new(purelib.Orm).GetDB()
+	q := db.Where("x = ?", 1) // Chain method creates mutable
+	q.Find(nil)
+	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/purelib/orm.go
+++ b/testdata/src/purelib/orm.go
@@ -1,0 +1,35 @@
+package purelib
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// DB is a global database connection.
+var DB *gorm.DB
+
+// Orm is a wrapper type that provides pure DB access.
+type Orm struct{}
+
+// DB is a pure method that returns a new *gorm.DB with context.
+// This simulates the pattern: new(orm.Orm).DB(ctx)
+//
+//gormreuse:pure
+func (o *Orm) DB(ctx context.Context) *gorm.DB {
+	return DB.WithContext(ctx)
+}
+
+// GetDB is a pure method that returns a new *gorm.DB.
+//
+//gormreuse:pure
+func (o *Orm) GetDB() *gorm.DB {
+	return DB.WithContext(nil)
+}
+
+// PureFactory is a pure function that returns a new *gorm.DB.
+//
+//gormreuse:pure
+func PureFactory() *gorm.DB {
+	return DB.WithContext(nil)
+}


### PR DESCRIPTION
## Summary

Fixes the issue where `//gormreuse:pure` directives in external packages were not detected.

### Problem

When using a pattern like:

```go
// In internal/orm/gorm.go
//gormreuse:pure
func (m *Orm) DB(ctx context.Context) *gorm.DB {
    return DB.WithContext(ctx)
}

// In another package
db := new(orm.Orm).DB(ctx)
db.Find(nil)
db.Find(nil) // False positive: reported as reuse violation
```

The linter incorrectly reported violations because it couldn't detect the `//gormreuse:pure` directive in the external `internal/orm` package.

### Root Cause

`PureFuncSet` was only scanning files in the package being analyzed via `pass.Files`. When checking if a function is pure, `fn.Syntax()` returns `nil` for functions defined in external packages (SSA doesn't retain syntax for imported packages).

### Previous Attempts (Failed)

- **#10** `feat: treat pure function return values as immutable` - Added immutable return handling but didn't address cross-package pure detection
- **#11** `fix: use structured key matching for pure functions instead of string comparison` - Improved key matching within analyzed package but external packages still not scanned

### Solution

1. Convert `PureFuncSet` from `map[PureFuncKey]struct{}` to a struct with:
   - `known` map for pre-built pure functions (current package)
   - `fset *token.FileSet` for position resolution
   - `cache sync.Map` for parsed file caching

2. Add `hasPureDirective()` method that:
   - First tries `fn.Syntax()` (works for current package)
   - Falls back to `fn.Object().Pos()` to get the source filename
   - Parses the source file with `parser.ParseComments`
   - Searches for the function declaration and checks its doc comments

3. Cache parsed files to avoid repeated parsing overhead

## Test plan

- [x] Add `testdata/src/purelib/` - Library package with pure functions
- [x] Add `testdata/src/external_pure_test/` - Test package calling pure functions from external package
- [x] Verify `new(purelib.Orm).DB(ctx)` pattern works correctly
- [x] Verify existing tests pass
- [x] Manual verification on real codebase (kadokawa-cw-be)

🤖 Generated with [Claude Code](https://claude.com/claude-code)