### PR TITLE
feat: add -debug-filter flag for violation debugging

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -33,6 +33,7 @@
 package gormreuse
 
 import (
+	"flag"
 	"go/ast"
 	"go/token"
 
@@ -42,6 +43,12 @@ import (
 	"github.com/mpyw/gormreuse/internal"
 	"github.com/mpyw/gormreuse/internal/directive"
 )
+
+var debugFilter string
+
+func init() {
+	Analyzer.Flags.StringVar(&debugFilter, "debug-filter", "", "enable debug output for functions matching regex (e.g., 'TestFunc|Helper')")
+}
 
 // Analyzer is the main analyzer for gormreuse.
 //
@@ -60,6 +67,7 @@ var Analyzer = &analysis.Analyzer{
 	Doc:      "detects unsafe *gorm.DB instance reuse after chain methods",
 	Requires: []*analysis.Analyzer{buildssa.Analyzer},
 	Run:      run,
+	Flags:    flag.FlagSet{},
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -94,7 +102,7 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	// Run SSA-based analysis
-	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, skipFiles)
+	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, skipFiles, debugFilter)
 
 	return nil, nil
 }

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -29,7 +29,7 @@ func TestNewChecker(t *testing.T) {
 	pureFuncs := directive.NewPureFuncSet(nil)
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(nil)
 
-	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs)
+	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil)
 
 	if chk.pass != nil {
 		t.Error("Expected pass to be nil")
@@ -46,13 +46,16 @@ func TestNewChecker(t *testing.T) {
 	if chk.reported == nil {
 		t.Error("Expected reported to be initialized")
 	}
+	if chk.debugFilterRegex != nil {
+		t.Error("Expected debugFilterRegex to be nil")
+	}
 }
 
 func TestAnalyzer_Analyze_NilFunction(t *testing.T) {
 	analyzer := ssautil.NewAnalyzer(nil, nil, nil)
 
 	// Should not panic with nil function
-	violations := analyzer.Analyze()
+	violations := analyzer.Analyze(false)
 	if len(violations) != 0 {
 		t.Errorf("Expected 0 violations for nil function, got %d", len(violations))
 	}
@@ -62,7 +65,7 @@ func TestAnalyzer_Analyze_EmptyFunction(t *testing.T) {
 	fn := &ssa.Function{}
 	analyzer := ssautil.NewAnalyzer(fn, nil, nil)
 
-	violations := analyzer.Analyze()
+	violations := analyzer.Analyze(false)
 	if len(violations) != 0 {
 		t.Errorf("Expected 0 violations for empty function, got %d", len(violations))
 	}

--- a/internal/debug/collector.go
+++ b/internal/debug/collector.go
@@ -1,0 +1,81 @@
+package debug
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/mpyw/gormreuse/internal/typeutil"
+)
+
+// Collector encapsulates debug information collection.
+// This keeps debug logic isolated from the main analysis code.
+type Collector struct {
+	rootDebugInfo map[ssa.Value]RootInfo
+	usagesByPos   map[token.Pos][]usageEntry
+}
+
+// usageEntry holds debug info for a single usage.
+type usageEntry struct {
+	root       ssa.Value
+	methodName string
+	callType   string
+}
+
+// NewCollector creates a new Collector.
+func NewCollector() *Collector {
+	return &Collector{
+		rootDebugInfo: make(map[ssa.Value]RootInfo),
+		usagesByPos:   make(map[token.Pos][]usageEntry),
+	}
+}
+
+// RecordUsage stores debug info for a usage site.
+// This is called from handlers to record method names and call types.
+func (c *Collector) RecordUsage(root ssa.Value, pos token.Pos, methodName, callType string) {
+	// Store root info if not already stored
+	if _, exists := c.rootDebugInfo[root]; !exists {
+		c.rootDebugInfo[root] = NewRootInfo(root)
+	}
+
+	// Store usage debug info indexed by position
+	c.usagesByPos[pos] = append(c.usagesByPos[pos], usageEntry{
+		root:       root,
+		methodName: methodName,
+		callType:   callType,
+	})
+}
+
+// BuildViolationInfoByPos builds debug info by looking up all usages at the given position.
+// This is used when we only have the violation position and need to find the associated debug info.
+func (c *Collector) BuildViolationInfoByPos(pos token.Pos) *Info {
+	// Direct O(1) lookup by position
+	entries := c.usagesByPos[pos]
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Use the first entry's root for the root info
+	root := entries[0].root
+	rootInfo, ok := c.rootDebugInfo[root]
+	if !ok {
+		rootInfo = NewRootInfo(root)
+	}
+
+	// Build branches from all entries at this position
+	branches := make([]BranchInfo, 0, len(entries))
+	for _, entry := range entries {
+		branches = append(branches, BranchInfo{
+			Pos:        pos,
+			MethodName: entry.methodName,
+			IsFinisher: typeutil.IsFinisherBuiltin(entry.methodName),
+			CallType:   entry.callType,
+			Context:    []string{},
+		})
+	}
+
+	return &Info{
+		Root:     rootInfo,
+		Branches: branches,
+	}
+}

--- a/internal/debug/format.go
+++ b/internal/debug/format.go
@@ -1,0 +1,69 @@
+package debug
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+)
+
+// FormatViolation returns a formatted debug string for a violation.
+func FormatViolation(funcName string, info *Info, fset *token.FileSet) string {
+	if info == nil {
+		return ""
+	}
+
+	var buf strings.Builder
+
+	// Function header
+	fmt.Fprintf(&buf, "Function: %s\n", funcName)
+
+	// Root information
+	rootPos := fset.Position(info.Root.Pos)
+	fmt.Fprintf(&buf, "  Root: line %d\n", rootPos.Line)
+	if info.Root.VarName != "" {
+		fmt.Fprintf(&buf, "    %s := ...\n", info.Root.VarName)
+	}
+	if info.Root.IsMutable {
+		fmt.Fprintf(&buf, "    └─ mutable\n")
+	} else {
+		fmt.Fprintf(&buf, "    └─ immutable\n")
+	}
+
+	// Branches
+	if len(info.Branches) > 0 {
+		fmt.Fprintf(&buf, "\n  Branches:\n")
+		for i, branch := range info.Branches {
+			pos := fset.Position(branch.Pos)
+			fmt.Fprintf(&buf, "    %d. line %d", i+1, pos.Line)
+			if branch.MethodName != "" {
+				fmt.Fprintf(&buf, ": %s", branch.MethodName)
+			}
+			fmt.Fprintf(&buf, "\n")
+
+			if branch.MethodName != "" {
+				fmt.Fprintf(&buf, "       ├─ method: %s\n", branch.MethodName)
+			}
+
+			finisherStr := "no"
+			if branch.IsFinisher {
+				finisherStr = "yes"
+			}
+			fmt.Fprintf(&buf, "       ├─ finisher: %s\n", finisherStr)
+
+			if branch.CallType != "" {
+				fmt.Fprintf(&buf, "       ├─ call type: %s\n", branch.CallType)
+			}
+
+			if len(branch.Context) > 0 {
+				fmt.Fprintf(&buf, "       └─ context: %s\n", strings.Join(branch.Context, " → "))
+			} else {
+				fmt.Fprintf(&buf, "       └─ context: (none)\n")
+			}
+		}
+	}
+
+	// TODO: Add fix strategy
+	fmt.Fprintf(&buf, "\n  Fix: (strategy TBD)\n")
+
+	return buf.String()
+}

--- a/internal/debug/tracker.go
+++ b/internal/debug/tracker.go
@@ -1,0 +1,59 @@
+package debug
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/mpyw/gormreuse/internal/ssa/pollution"
+)
+
+var _ pollution.DebugCollector = (*Tracker)(nil)
+
+// Tracker wraps pollution.Tracker and adds debug information collection.
+type Tracker struct {
+	pollution.Tracker
+	collector          *Collector
+	enrichedViolations []Violation
+}
+
+// NewTracker creates a debug-enabled tracker that wraps a base tracker.
+func NewTracker(base pollution.Tracker) *Tracker {
+	return &Tracker{
+		Tracker:   base,
+		collector: NewCollector(),
+	}
+}
+
+// CollectDebugInfo implements pollution.DebugCollector interface.
+func (dt *Tracker) CollectDebugInfo(root ssa.Value, pos token.Pos, methodName, callType string) {
+	dt.collector.RecordUsage(root, pos, methodName, callType)
+}
+
+// DetectViolations wraps the base DetectViolations and enriches violations with debug info.
+func (dt *Tracker) DetectViolations() {
+	// Run base detection
+	dt.Tracker.DetectViolations()
+
+	// Get all violations from base
+	baseViolations := dt.Tracker.CollectViolations()
+
+	// Enrich each violation with debug info
+	dt.enrichedViolations = make([]Violation, 0, len(baseViolations))
+	for _, v := range baseViolations {
+		dt.enrichedViolations = append(dt.enrichedViolations, &violation{
+			pos:       v.Pos(),
+			message:   v.Message(),
+			debugInfo: dt.collector.BuildViolationInfoByPos(v.Pos()),
+		})
+	}
+}
+
+// CollectViolations returns debug-enriched violations.
+func (dt *Tracker) CollectViolations() []pollution.Violation {
+	result := make([]pollution.Violation, len(dt.enrichedViolations))
+	for i, v := range dt.enrichedViolations {
+		result[i] = v
+	}
+	return result
+}

--- a/internal/debug/types.go
+++ b/internal/debug/types.go
@@ -1,0 +1,40 @@
+package debug
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// Info contains collected debug information for a violation.
+type Info struct {
+	Root     RootInfo
+	Branches []BranchInfo
+}
+
+// BranchInfo contains information about a single branch usage.
+type BranchInfo struct {
+	Pos        token.Pos
+	MethodName string
+	IsFinisher bool
+	CallType   string
+	Context    []string // Control flow context: ["for-range", "if"], etc.
+}
+
+// RootInfo contains information about a mutable root.
+type RootInfo struct {
+	Pos       token.Pos
+	VarName   string
+	IsMutable bool
+	SSAValue  string
+}
+
+// NewRootInfo creates RootInfo from an SSA value.
+func NewRootInfo(root ssa.Value) RootInfo {
+	return RootInfo{
+		Pos:       root.Pos(),
+		VarName:   root.Name(),
+		IsMutable: true, // Assume mutable if we're tracking it
+		SSAValue:  root.String(),
+	}
+}

--- a/internal/debug/violation.go
+++ b/internal/debug/violation.go
@@ -1,0 +1,26 @@
+package debug
+
+import (
+	"go/token"
+
+	"github.com/mpyw/gormreuse/internal/ssa/pollution"
+)
+
+var _ Violation = (*violation)(nil)
+
+// Violation represents a violation with debug information.
+type Violation interface {
+	pollution.Violation
+	DebugInfo() *Info
+}
+
+// violation is the debug-enabled implementation.
+type violation struct {
+	pos       token.Pos
+	message   string
+	debugInfo *Info
+}
+
+func (v *violation) Pos() token.Pos   { return v.pos }
+func (v *violation) Message() string  { return v.message }
+func (v *violation) DebugInfo() *Info { return v.debugInfo }

--- a/internal/ssa/pollution/debug.go
+++ b/internal/ssa/pollution/debug.go
@@ -1,0 +1,13 @@
+package pollution
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// DebugCollector interface for optional debug information collection.
+// Only debug.Tracker implements this interface.
+type DebugCollector interface {
+	CollectDebugInfo(root ssa.Value, pos token.Pos, methodName, callType string)
+}

--- a/internal/ssa/pollution/violation.go
+++ b/internal/ssa/pollution/violation.go
@@ -1,0 +1,18 @@
+package pollution
+
+import "go/token"
+
+// Violation represents a detected reuse violation.
+type Violation interface {
+	Pos() token.Pos
+	Message() string
+}
+
+// violation is the basic implementation without debug info.
+type violation struct {
+	pos     token.Pos
+	message string
+}
+
+func (v *violation) Pos() token.Pos  { return v.pos }
+func (v *violation) Message() string { return v.message }

--- a/internal/typeutil/gorm.go
+++ b/internal/typeutil/gorm.go
@@ -98,3 +98,34 @@ func IsImmutableReturningBuiltin(name string) bool {
 	_, ok := immutableReturningMethods[name]
 	return ok
 }
+
+// finisherMethods are methods that execute queries and interact with the database.
+// These are "terminal" operations that typically end a method chain.
+var finisherMethods = map[string]struct{}{
+	// Query finishers
+	"Find":  {},
+	"First": {},
+	"Last":  {},
+	"Take":  {},
+	// Aggregate finishers
+	"Count": {},
+	"Pluck": {},
+	"Scan":  {},
+	// Mutation finishers
+	"Create":  {},
+	"Save":    {},
+	"Update":  {},
+	"Updates": {},
+	"Delete":  {},
+	// Raw SQL finishers
+	"Row":  {},
+	"Rows": {},
+	"Exec": {},
+}
+
+// IsFinisherBuiltin returns true if the method is a finisher that executes queries.
+// Finisher methods interact with the database and are typically terminal operations.
+func IsFinisherBuiltin(name string) bool {
+	_, ok := finisherMethods[name]
+	return ok
+}

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -264,6 +264,7 @@ func purePollutesConditionally(db *gorm.DB, cond bool) {
 // Both branches return valid states:
 //   - if cond: Session() returns Clean
 //   - else: return db returns Depends(db)
+//
 // Merged state: Depends(db) - valid for pure function
 //
 //gormreuse:pure
@@ -521,8 +522,8 @@ func pureCallsNoGormArgs() int {
 //
 //gormreuse:pure
 func pureCallsWithDependsArg(db *gorm.DB) *gorm.DB {
-	intermediate := pureHelperReturns(db)      // intermediate is Clean
-	return pureHelperReturns(intermediate)     // tests InferValue path with Clean arg
+	intermediate := pureHelperReturns(db)  // intermediate is Clean
+	return pureHelperReturns(intermediate) // tests InferValue path with Clean arg
 }
 
 // PV232: Tests inferCall path where function has no *gorm.DB args
@@ -539,8 +540,8 @@ func pureCallsRegularFunc() int {
 //
 //gormreuse:pure
 func pureCallsWithPollutedArg(db *gorm.DB) *gorm.DB {
-	polluted := db.Where("x")           // want `pure function pollutes \*gorm\.DB argument by calling Where`
-	return pureHelperReturns(polluted)  // OK now - return value purity not checked
+	polluted := db.Where("x")          // want `pure function pollutes \*gorm\.DB argument by calling Where`
+	return pureHelperReturns(polluted) // OK now - return value purity not checked
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -837,8 +837,8 @@ func methodValue(db *gorm.DB) {
 func methodValueSameBlock(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	find := q.Find
-	find(nil)  // First use - pollutes q
-	find(nil)  // want `\*gorm\.DB instance reused after chain method`
+	find(nil) // First use - pollutes q
+	find(nil) // want `\*gorm\.DB instance reused after chain method`
 }
 
 // methodValueInLoop demonstrates method value in loop.
@@ -2162,9 +2162,9 @@ func storedClosureChain(db *gorm.DB) {
 	fn := func() *gorm.DB {
 		return q1.Where("from closure", 1)
 	}
-	q2 := fn()         // q2 holds first branch from q1
-	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q2 := fn()       // q2 holds first branch from q1
+	q2.Where("y", 2) // Continues q2's chain (OK)
+	q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
 }
 
 // storedClosureReordered demonstrates order of calls with stored closure.
@@ -2191,8 +2191,8 @@ func iifeStoredResult(db *gorm.DB) {
 	q2 := func() *gorm.DB {
 		return q1.Where("from iife", 1)
 	}()
-	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q2.Where("y", 2) // Continues q2's chain (OK)
+	q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
 }
 
 // =============================================================================
@@ -2692,9 +2692,9 @@ func whereOnlyMultipleBranches(db *gorm.DB) {
 // from README: each separate statement creates a branch from q.
 func chainingWithoutReassignmentViolation(db *gorm.DB) {
 	q := db.Where("base")
-	q.Where("a")     // first branch - OK
-	q.Where("b")     // want `\*gorm\.DB instance reused after chain method`
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Where("a") // first branch - OK
+	q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)  // want `\*gorm\.DB instance reused after chain method`
 }
 
 // chainingWithReassignmentSafe demonstrates the solution: reassign each step.


### PR DESCRIPTION
## Summary

Add debug infrastructure to help determine fix strategies for #20:

- Add `-debug-filter` flag to filter debug output by function name regex (like `go test -run`)
- Implement `debug.Tracker` to wrap `pollution.Tracker` with debug info collection
- Display violation structure: root info, branch methods, finisher status, control flow context
- Zero performance impact when debugging is disabled

## Architecture

```
internal/debug/
├── tracker.go     # Tracker: wraps pollution.Tracker, adds debug collection
├── collector.go   # Collector: collects usage info with O(1) lookup
├── violation.go   # Violation: debug-enriched violation type
├── types.go       # Info, RootInfo, BranchInfo + constructors
└── format.go      # FormatViolation: formatting utility
```

## Example Output

```
Function: main.badFunction
  Root: line 10
    q := ...
    └─ mutable

  Branches:
    1. line 11: Where
       ├─ method: Where
       ├─ finisher: no
       ├─ call type: method
       └─ context: (none)
    2. line 12: Find
       ├─ method: Find
       ├─ finisher: yes
       ├─ call type: method
       └─ context: (none)

  Fix: (strategy TBD)
```

## Changes

- Add `-debug-filter` flag to analyzer
- Create `internal/debug` package with clean architecture
- Optimize data structure for O(1) position lookup (instead of O(n) iteration)
- Split `pollution` package into `violation.go`, `debug.go`, `tracker.go`
- Remove dead code (function option pattern for Context)
- Remove global variable (enrichedViolations → Tracker field)
- Add finisher method detection (`IsFinisherBuiltin`)

## Test Plan

- [x] All existing tests pass
- [ ] Manual testing with real violations
- [ ] Add snapshot tests with [STRUCTURE TEST] comments

## Related

- Towards #20 (SuggestedFixes implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)