### PR TITLE
refactor: reduce code duplication and improve maintainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ go run github.com/mpyw/gormreuse/cmd/gormreuse@latest ./...
 ```
 
 > [!CAUTION]
-> To prevent supply chain attacks, pin to a specific version tag instead of `@latest` in CI/CD pipelines (e.g., `@v0.11.0`).
+> To prevent supply chain attacks, pin to a specific version tag instead of `@latest` in CI/CD pipelines (e.g., `@v0.11.1`).
 > All versions prior to v0.11.0 have been retracted due to critical bugs.
 
 ## Flags


### PR DESCRIPTION
## Summary

- Extract `processGormDBCallCommonWith` to unify Go/Defer handlers (-36 lines)
- Extract `checkViolationsBetween` to unify DetectViolations loops (-51 lines)
- Extract `isLoopVariableSwap` to unify swap-phi detection (-75 lines)
- Update README version suggestion to v0.11.1

## Results

| File | Before | After | Diff |
|------|--------|-------|------|
| handler/call.go | 1291 | 1255 | -36 |
| pollution/tracker.go | 312 | 261 | -51 |
| tracer/root.go | 1304 | 1229 | -75 |
| **Total** | 6059 | 5897 | **-162** |

Coverage: 88.8% → 89.4% (+0.6%)

## Test plan

- [x] All existing tests pass
- [x] Golden files unchanged
- [x] Coverage maintained/improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)