### PR TITLE
fix: correct Session edit position and add gorm import when missing

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -30,6 +30,11 @@ func TestSuggestedFixes(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, gormreuse.Analyzer, "gormreuse")
 }
 
+func TestSuggestedFixesWithImport(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, gormreuse.Analyzer, "noimport")
+}
+
 func TestGenerateDiffFiles(t *testing.T) {
 	testdata := analysistest.TestData()
 	srcDir := filepath.Join(testdata, "src", "gormreuse")

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -1,6 +1,6 @@
 --- evil.go	1970-01-01 00:00:00
 +++ evil.go.golden	1970-01-01 00:00:00
-@@ -1,2883 +1,2883 @@
+@@ -1,2925 +1,2925 @@
  package internal
  
  import "gorm.io/gorm"
@@ -3016,4 +3016,49 @@
  
  	q.Find(nil)
  	q.Count(nil) // OK: all branches immutable
+ }
+ 
+ // =============================================================================
+ // FIX GENERATOR EDGE CASE - Callback wrapper functions
+ // These test cases verify that Session is NOT added to wrapper function calls
+ // =============================================================================
+ 
+ // wrapperFunc is a helper that takes a callback (like t.Run or Transaction).
+ func wrapperFunc(fn func()) bool {
+ 	fn()
+ 	return true
+ }
+ 
+ // callbackViolationInWrapper demonstrates violation inside callback.
+ // Session should be added to `db.Where("x")` call, NOT to wrapperFunc call.
+ func callbackViolationInWrapper(db *gorm.DB) {
+ 	wrapperFunc(func() {
+-		q := db.Where("x")
++		q := db.Where("x").Session(&gorm.Session{})
+ 		q.Find(nil)
+ 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	})
+ }
+ 
+ // callbackMultipleViolationsInWrapper demonstrates multiple violations.
+ func callbackMultipleViolationsInWrapper(db *gorm.DB) {
+ 	wrapperFunc(func() {
+-		q := db.Where("base")
++		q := db.Where("base").Session(&gorm.Session{})
+ 		q.Find(nil)
+ 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	})
+ }
+ 
+ // callbackNestedWrappers demonstrates nested wrapper functions.
+ func callbackNestedWrappers(db *gorm.DB) {
+ 	wrapperFunc(func() {
+ 		wrapperFunc(func() {
+-			q := db.Where("nested")
++			q := db.Where("nested").Session(&gorm.Session{})
+ 			q.Find(nil)
+ 			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		})
+ 	})
  }

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -2881,3 +2881,45 @@ func phiSwitchAllImmutable(db *gorm.DB, mode int) {
 	q.Find(nil)
 	q.Count(nil) // OK: all branches immutable
 }
+
+// =============================================================================
+// FIX GENERATOR EDGE CASE - Callback wrapper functions
+// These test cases verify that Session is NOT added to wrapper function calls
+// =============================================================================
+
+// wrapperFunc is a helper that takes a callback (like t.Run or Transaction).
+func wrapperFunc(fn func()) bool {
+	fn()
+	return true
+}
+
+// callbackViolationInWrapper demonstrates violation inside callback.
+// Session should be added to `db.Where("x")` call, NOT to wrapperFunc call.
+func callbackViolationInWrapper(db *gorm.DB) {
+	wrapperFunc(func() {
+		q := db.Where("x").Session(&gorm.Session{})
+		q.Find(nil)
+		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// callbackMultipleViolationsInWrapper demonstrates multiple violations.
+func callbackMultipleViolationsInWrapper(db *gorm.DB) {
+	wrapperFunc(func() {
+		q := db.Where("base").Session(&gorm.Session{})
+		q.Find(nil)
+		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// callbackNestedWrappers demonstrates nested wrapper functions.
+func callbackNestedWrappers(db *gorm.DB) {
+	wrapperFunc(func() {
+		wrapperFunc(func() {
+			q := db.Where("nested").Session(&gorm.Session{})
+			q.Find(nil)
+			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		})
+	})
+}

--- a/testdata/src/gormreuse/export.go
+++ b/testdata/src/gormreuse/export.go
@@ -1,0 +1,9 @@
+package internal
+
+import "gorm.io/gorm"
+
+// GetDB returns the global DB instance.
+// This is used by noimport package to test fix generation without gorm import.
+func GetDB() *gorm.DB {
+	return DB
+}

--- a/testdata/src/noimport/grouped.go
+++ b/testdata/src/noimport/grouped.go
@@ -1,0 +1,17 @@
+// Package noimport tests fix generation when gorm is not directly imported.
+package noimport
+
+import (
+	"fmt"
+
+	internal "gormreuse"
+)
+
+// violationWithGroupedImport demonstrates a violation with grouped imports.
+// The fix should append gorm to the existing import group.
+func violationWithGroupedImport() {
+	fmt.Println("test")
+	q := internal.GetDB()
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/noimport/grouped.go.golden
+++ b/testdata/src/noimport/grouped.go.golden
@@ -1,0 +1,18 @@
+// Package noimport tests fix generation when gorm is not directly imported.
+package noimport
+
+import (
+	"fmt"
+
+	internal "gormreuse"
+	"gorm.io/gorm"
+)
+
+// violationWithGroupedImport demonstrates a violation with grouped imports.
+// The fix should append gorm to the existing import group.
+func violationWithGroupedImport() {
+	fmt.Println("test")
+	q := internal.GetDB().Session(&gorm.Session{})
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/noimport/noimport.go
+++ b/testdata/src/noimport/noimport.go
@@ -1,0 +1,13 @@
+// Package noimport tests fix generation when gorm is not directly imported.
+// The fix should add `import "gorm.io/gorm"` when Session is added.
+package noimport
+
+import internal "gormreuse"
+
+// violationWithoutGormImport demonstrates a violation in a file that doesn't import gorm.
+// The fix adds `.Session(&gorm.Session{})` which requires gorm import.
+func violationWithoutGormImport() {
+	q := internal.GetDB()
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/noimport/noimport.go.golden
+++ b/testdata/src/noimport/noimport.go.golden
@@ -1,0 +1,14 @@
+// Package noimport tests fix generation when gorm is not directly imported.
+// The fix should add `import "gorm.io/gorm"` when Session is added.
+package noimport
+
+import internal "gormreuse"
+import "gorm.io/gorm"
+
+// violationWithoutGormImport demonstrates a violation in a file that doesn't import gorm.
+// The fix adds `.Session(&gorm.Session{})` which requires gorm import.
+func violationWithoutGormImport() {
+	q := internal.GetDB().Session(&gorm.Session{})
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}


### PR DESCRIPTION
## Summary

- Fix `getCallExprEndPos` to find innermost CallExpr instead of outermost
  - Prevents Session being added to wrapper functions like `t.Run()` or `Transaction()`
  - Session now correctly added to the actual `*gorm.DB` method call
- Add gorm import when Session fix requires it
  - Handles both single imports and grouped imports

## Test plan

- [x] Existing tests pass
- [x] Added test cases for callback wrapper functions (`callbackViolationInWrapper`, etc.)
- [x] Added test cases for gorm import addition (single and grouped imports)
- [x] `golangci-lint run --fix` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)