### PR TITLE
fix: resolve false positives for single-return closure + method chain in loop

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -48,6 +48,8 @@ func TestGenerateDiffFiles(t *testing.T) {
 		"file_level_ignore_doc.go",
 		"directive_validation.go",
 		"nested_chaos.go",
+		"interface_patterns.go",
+		"closure_loop.go",
 	}
 
 	for _, filename := range testFiles {
@@ -188,6 +190,8 @@ func TestDiffFilesUpToDate(t *testing.T) {
 		"file_level_ignore_doc.go",
 		"directive_validation.go",
 		"nested_chaos.go",
+		"interface_patterns.go",
+		"closure_loop.go",
 	}
 
 	for _, filename := range testFiles {

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -30,8 +30,9 @@ func TestNewChecker(t *testing.T) {
 	pureFuncs := directive.NewPureFuncSet(nil)
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(nil)
 	reported := make(map[token.Pos]bool)
+	suggestedEdits := make(map[editKey]bool)
 
-	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, reported)
+	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, reported, suggestedEdits)
 
 	if chk.pass != nil {
 		t.Error("Expected pass to be nil")
@@ -47,6 +48,9 @@ func TestNewChecker(t *testing.T) {
 	}
 	if chk.reported == nil {
 		t.Error("Expected reported to be initialized")
+	}
+	if chk.suggestedEdits == nil {
+		t.Error("Expected suggestedEdits to be initialized")
 	}
 }
 

--- a/testdata/src/gormreuse/closure_loop.go
+++ b/testdata/src/gormreuse/closure_loop.go
@@ -1,0 +1,164 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// CLOSURE IN LOOP - User's original pattern
+// =============================================================================
+
+type bannerRepo struct {
+	db *gorm.DB
+}
+
+func (r *bannerRepo) DB() *gorm.DB {
+	return r.db.Session(&gorm.Session{})
+}
+
+// whereStatusFixed: User's pattern - closure in loop with switch
+// Each closure call should be independent, no false positives.
+func (r *bannerRepo) whereStatusFixed(statuses []int) (*gorm.DB, error) {
+	publishedQueryFunc := func(isPublished bool) (*gorm.DB, error) {
+		if isPublished {
+			return r.DB().Where("published = ?", true), nil
+		}
+		return r.DB().Where("published = ?", false), nil
+	}
+
+	condition := r.DB()
+
+	for _, status := range statuses {
+		switch status {
+		case 1:
+			publishedQuery, err := publishedQueryFunc(false)
+			if err != nil {
+				return nil, err
+			}
+			// Each publishedQuery is independent - should NOT report
+			condition = condition.
+				Or(publishedQuery.
+					Where("x").
+					Or("y"))
+		case 2:
+			publishedQuery, err := publishedQueryFunc(true)
+			if err != nil {
+				return nil, err
+			}
+			condition = condition.
+				Or(publishedQuery.
+					Where("a").
+					Where("b"))
+		case 3:
+			condition = condition.Or("z")
+		}
+	}
+
+	return condition, nil
+}
+
+// =============================================================================
+// CONDITIONAL RETURN - Multiple returns in closure
+// =============================================================================
+
+// iifeConditionalReturnSameRoot: IIFE with conditional returns from same root
+func iifeConditionalReturnSameRoot(db *gorm.DB) {
+	q := db.Where("base")
+
+	// Both returns derive from same root (q)
+	_ = func() *gorm.DB {
+		if true {
+			return q.Where("a")
+		}
+		return q.Where("b")
+	}().Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
+func iifeConditionalReturnDifferentRoots(db *gorm.DB) {
+	q1 := db.Where("q1")
+	q2 := db.Where("q2")
+
+	q1.Find(nil) // Pollute q1
+
+	// Returns from different roots - should detect if any root is polluted
+	_ = func() *gorm.DB {
+		if true {
+			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+		}
+		return q2.Where("b") // q2 is clean
+	}().Find(nil)
+}
+
+// storedClosureSingleReturn: Stored closure with single return value
+func storedClosureSingleReturn(db *gorm.DB) {
+	q := db.Where("base")
+
+	getQuery := func() *gorm.DB {
+		return q.Where("inner")
+	}
+
+	// Single return - stored closure result should be independent
+	result := getQuery()
+	result.Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// storedClosureMultiReturn: Stored closure with multi return value
+func storedClosureMultiReturn(db *gorm.DB) {
+	q := db.Where("base")
+
+	getQuery := func() (*gorm.DB, error) {
+		return q.Where("inner"), nil
+	}
+
+	// Multi return with Extract - stored closure result should be independent
+	result, _ := getQuery()
+	result.Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// FIXED: Single-return closure + method chain in loop
+// =============================================================================
+
+// loopWithSingleReturnClosure: Loop with single-return closure
+// Correctly handles single-return closures by detecting the chain flows to MakeInterface
+// (via condition.Or's variadic interface{} argument), treating each call as independent root.
+func loopWithSingleReturnClosure(db *gorm.DB, items []int) {
+	getQuery := func() *gorm.DB {
+		return db.Session(&gorm.Session{}).Where("fresh")
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q := getQuery()
+		// Each getQuery() call is treated as independent root
+		// because q.Where("x") flows to MakeInterface for condition.Or()
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}
+
+// loopWithMultiReturnClosure: Loop with multi-return closure
+// Multi-return goes through Extract, so isClosureResultStored returns true,
+// treating each call as independent root.
+func loopWithMultiReturnClosure(db *gorm.DB, items []int) {
+	getQuery := func() (*gorm.DB, error) {
+		return db.Session(&gorm.Session{}).Where("fresh"), nil
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q, _ := getQuery()
+		// Each getQuery() call is independent root (via Extract)
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}

--- a/testdata/src/gormreuse/closure_loop.go.diff
+++ b/testdata/src/gormreuse/closure_loop.go.diff
@@ -1,0 +1,171 @@
+--- closure_loop.go	1970-01-01 00:00:00
++++ closure_loop.go.golden	1970-01-01 00:00:00
+@@ -1,164 +1,164 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // =============================================================================
+ // CLOSURE IN LOOP - User's original pattern
+ // =============================================================================
+ 
+ type bannerRepo struct {
+ 	db *gorm.DB
+ }
+ 
+ func (r *bannerRepo) DB() *gorm.DB {
+ 	return r.db.Session(&gorm.Session{})
+ }
+ 
+ // whereStatusFixed: User's pattern - closure in loop with switch
+ // Each closure call should be independent, no false positives.
+ func (r *bannerRepo) whereStatusFixed(statuses []int) (*gorm.DB, error) {
+ 	publishedQueryFunc := func(isPublished bool) (*gorm.DB, error) {
+ 		if isPublished {
+ 			return r.DB().Where("published = ?", true), nil
+ 		}
+ 		return r.DB().Where("published = ?", false), nil
+ 	}
+ 
+ 	condition := r.DB()
+ 
+ 	for _, status := range statuses {
+ 		switch status {
+ 		case 1:
+ 			publishedQuery, err := publishedQueryFunc(false)
+ 			if err != nil {
+ 				return nil, err
+ 			}
+ 			// Each publishedQuery is independent - should NOT report
+ 			condition = condition.
+ 				Or(publishedQuery.
+ 					Where("x").
+ 					Or("y"))
+ 		case 2:
+ 			publishedQuery, err := publishedQueryFunc(true)
+ 			if err != nil {
+ 				return nil, err
+ 			}
+ 			condition = condition.
+ 				Or(publishedQuery.
+ 					Where("a").
+ 					Where("b"))
+ 		case 3:
+ 			condition = condition.Or("z")
+ 		}
+ 	}
+ 
+ 	return condition, nil
+ }
+ 
+ // =============================================================================
+ // CONDITIONAL RETURN - Multiple returns in closure
+ // =============================================================================
+ 
+ // iifeConditionalReturnSameRoot: IIFE with conditional returns from same root
+ func iifeConditionalReturnSameRoot(db *gorm.DB) {
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
+ 
+ 	// Both returns derive from same root (q)
+ 	_ = func() *gorm.DB {
+ 		if true {
+ 			return q.Where("a")
+ 		}
+ 		return q.Where("b")
+ 	}().Find(nil)
+ 
+ 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
+ func iifeConditionalReturnDifferentRoots(db *gorm.DB) {
+-	q1 := db.Where("q1")
++	q1 := db.Where("q1").Session(&gorm.Session{})
+ 	q2 := db.Where("q2")
+ 
+ 	q1.Find(nil) // Pollute q1
+ 
+ 	// Returns from different roots - should detect if any root is polluted
+ 	_ = func() *gorm.DB {
+ 		if true {
+ 			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+ 		}
+ 		return q2.Where("b") // q2 is clean
+ 	}().Find(nil)
+ }
+ 
+ // storedClosureSingleReturn: Stored closure with single return value
+ func storedClosureSingleReturn(db *gorm.DB) {
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
+ 
+ 	getQuery := func() *gorm.DB {
+ 		return q.Where("inner")
+ 	}
+ 
+ 	// Single return - stored closure result should be independent
+ 	result := getQuery()
+ 	result.Find(nil)
+ 
+ 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // storedClosureMultiReturn: Stored closure with multi return value
+ func storedClosureMultiReturn(db *gorm.DB) {
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
+ 
+ 	getQuery := func() (*gorm.DB, error) {
+ 		return q.Where("inner"), nil
+ 	}
+ 
+ 	// Multi return with Extract - stored closure result should be independent
+ 	result, _ := getQuery()
+ 	result.Find(nil)
+ 
+ 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // FIXED: Single-return closure + method chain in loop
+ // =============================================================================
+ 
+ // loopWithSingleReturnClosure: Loop with single-return closure
+ // Correctly handles single-return closures by detecting the chain flows to MakeInterface
+ // (via condition.Or's variadic interface{} argument), treating each call as independent root.
+ func loopWithSingleReturnClosure(db *gorm.DB, items []int) {
+ 	getQuery := func() *gorm.DB {
+ 		return db.Session(&gorm.Session{}).Where("fresh")
+ 	}
+ 
+ 	condition := db.Session(&gorm.Session{})
+ 
+ 	for range items {
+ 		q := getQuery()
+ 		// Each getQuery() call is treated as independent root
+ 		// because q.Where("x") flows to MakeInterface for condition.Or()
+ 		condition = condition.Or(q.Where("x"))
+ 	}
+ 
+ 	condition.Find(nil)
+ }
+ 
+ // loopWithMultiReturnClosure: Loop with multi-return closure
+ // Multi-return goes through Extract, so isClosureResultStored returns true,
+ // treating each call as independent root.
+ func loopWithMultiReturnClosure(db *gorm.DB, items []int) {
+ 	getQuery := func() (*gorm.DB, error) {
+ 		return db.Session(&gorm.Session{}).Where("fresh"), nil
+ 	}
+ 
+ 	condition := db.Session(&gorm.Session{})
+ 
+ 	for range items {
+ 		q, _ := getQuery()
+ 		// Each getQuery() call is independent root (via Extract)
+ 		condition = condition.Or(q.Where("x"))
+ 	}
+ 
+ 	condition.Find(nil)
+ }

--- a/testdata/src/gormreuse/closure_loop.go.golden
+++ b/testdata/src/gormreuse/closure_loop.go.golden
@@ -1,0 +1,164 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// CLOSURE IN LOOP - User's original pattern
+// =============================================================================
+
+type bannerRepo struct {
+	db *gorm.DB
+}
+
+func (r *bannerRepo) DB() *gorm.DB {
+	return r.db.Session(&gorm.Session{})
+}
+
+// whereStatusFixed: User's pattern - closure in loop with switch
+// Each closure call should be independent, no false positives.
+func (r *bannerRepo) whereStatusFixed(statuses []int) (*gorm.DB, error) {
+	publishedQueryFunc := func(isPublished bool) (*gorm.DB, error) {
+		if isPublished {
+			return r.DB().Where("published = ?", true), nil
+		}
+		return r.DB().Where("published = ?", false), nil
+	}
+
+	condition := r.DB()
+
+	for _, status := range statuses {
+		switch status {
+		case 1:
+			publishedQuery, err := publishedQueryFunc(false)
+			if err != nil {
+				return nil, err
+			}
+			// Each publishedQuery is independent - should NOT report
+			condition = condition.
+				Or(publishedQuery.
+					Where("x").
+					Or("y"))
+		case 2:
+			publishedQuery, err := publishedQueryFunc(true)
+			if err != nil {
+				return nil, err
+			}
+			condition = condition.
+				Or(publishedQuery.
+					Where("a").
+					Where("b"))
+		case 3:
+			condition = condition.Or("z")
+		}
+	}
+
+	return condition, nil
+}
+
+// =============================================================================
+// CONDITIONAL RETURN - Multiple returns in closure
+// =============================================================================
+
+// iifeConditionalReturnSameRoot: IIFE with conditional returns from same root
+func iifeConditionalReturnSameRoot(db *gorm.DB) {
+	q := db.Where("base").Session(&gorm.Session{})
+
+	// Both returns derive from same root (q)
+	_ = func() *gorm.DB {
+		if true {
+			return q.Where("a")
+		}
+		return q.Where("b")
+	}().Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
+func iifeConditionalReturnDifferentRoots(db *gorm.DB) {
+	q1 := db.Where("q1").Session(&gorm.Session{})
+	q2 := db.Where("q2")
+
+	q1.Find(nil) // Pollute q1
+
+	// Returns from different roots - should detect if any root is polluted
+	_ = func() *gorm.DB {
+		if true {
+			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+		}
+		return q2.Where("b") // q2 is clean
+	}().Find(nil)
+}
+
+// storedClosureSingleReturn: Stored closure with single return value
+func storedClosureSingleReturn(db *gorm.DB) {
+	q := db.Where("base").Session(&gorm.Session{})
+
+	getQuery := func() *gorm.DB {
+		return q.Where("inner")
+	}
+
+	// Single return - stored closure result should be independent
+	result := getQuery()
+	result.Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// storedClosureMultiReturn: Stored closure with multi return value
+func storedClosureMultiReturn(db *gorm.DB) {
+	q := db.Where("base").Session(&gorm.Session{})
+
+	getQuery := func() (*gorm.DB, error) {
+		return q.Where("inner"), nil
+	}
+
+	// Multi return with Extract - stored closure result should be independent
+	result, _ := getQuery()
+	result.Find(nil)
+
+	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// FIXED: Single-return closure + method chain in loop
+// =============================================================================
+
+// loopWithSingleReturnClosure: Loop with single-return closure
+// Correctly handles single-return closures by detecting the chain flows to MakeInterface
+// (via condition.Or's variadic interface{} argument), treating each call as independent root.
+func loopWithSingleReturnClosure(db *gorm.DB, items []int) {
+	getQuery := func() *gorm.DB {
+		return db.Session(&gorm.Session{}).Where("fresh")
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q := getQuery()
+		// Each getQuery() call is treated as independent root
+		// because q.Where("x") flows to MakeInterface for condition.Or()
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}
+
+// loopWithMultiReturnClosure: Loop with multi-return closure
+// Multi-return goes through Extract, so isClosureResultStored returns true,
+// treating each call as independent root.
+func loopWithMultiReturnClosure(db *gorm.DB, items []int) {
+	getQuery := func() (*gorm.DB, error) {
+		return db.Session(&gorm.Session{}).Where("fresh"), nil
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q, _ := getQuery()
+		// Each getQuery() call is independent root (via Extract)
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -832,17 +832,18 @@ func doublePointer(db *gorm.DB) {
 }
 
 // =============================================================================
-// SHOULD REPORT - Type Assertions
+// SHOULD NOT REPORT - Interface Conversion (Ownership Transfer)
 // =============================================================================
 
-// typeAssertionPollution demonstrates pollution through interface conversion.
-// Converting *gorm.DB to interface{} is assumed to pollute it.
-func typeAssertionPollution(db *gorm.DB) {
+// interfaceConversionOwnershipTransfer demonstrates that interface conversion
+// does NOT pollute the source. It's just type wrapping (ownership transfer).
+// Pollution only happens when the interface value is actually used.
+func interfaceConversionOwnershipTransfer(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
-	var i interface{} = q // Converting to interface{} marks q as polluted
+	var i interface{} = q // Just ownership transfer, does NOT pollute q
 	_ = i
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // First use of q - should NOT report
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -1,6 +1,6 @@
 --- evil.go	1970-01-01 00:00:00
 +++ evil.go.golden	1970-01-01 00:00:00
-@@ -1,3165 +1,3165 @@
+@@ -1,3166 +1,3166 @@
  package internal
  
  import "gorm.io/gorm"
@@ -235,7 +235,8 @@
  // loopReuse demonstrates reuse in a loop.
  // Loop detection: terminal call in loop with root defined outside = violation.
  func loopReuse(db *gorm.DB, items []string) {
- 	q := db.Where("base = ?", 1)
+-	q := db.Where("base = ?", 1)
++	q := db.Where("base = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		// Second iteration reuses polluted q
@@ -245,7 +246,8 @@
  
  // forLoopReuse demonstrates reuse in a for loop.
  func forLoopReuse(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for i := 0; i < 3; i++ {
  		// Second iteration reuses polluted q
@@ -281,7 +283,8 @@
  
  // deferReuse demonstrates reuse with defer.
  func deferReuse(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	// Defer is processed in second pass, after q.Find pollutes q
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -292,7 +295,8 @@
  // deferFunctionCallWithDB demonstrates defer with function call passing *gorm.DB.
  // Tests lines 669-678: defer with *gorm.DB argument to function.
  func deferFunctionCallWithDB(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
  	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
@@ -438,7 +442,8 @@
  // goroutineDirectMethodCall demonstrates direct method call in goroutine.
  // This tests the processCallCommonForGo path for method calls.
  func goroutineDirectMethodCall(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
  	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -447,7 +452,8 @@
  // goroutineFunctionCallWithDB demonstrates passing *gorm.DB to function in goroutine.
  // This tests the processCallCommonForGo path for function calls with *gorm.DB argument.
  func goroutineFunctionCallWithDB(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
  	go helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
@@ -457,7 +463,8 @@
  // Tests line 487: isPollutedAt cross-function pollution check.
  // Pollution happens in closure, then goroutine checks isPollutedAt.
  func goroutineCrossFunctionPollution(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	// Pollute q inside a closure (IIFE)
  	func() {
@@ -691,7 +698,8 @@
  
  // multipleDefers demonstrates multiple defers using same q.
  func multipleDefers(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  	defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -869,18 +877,18 @@
  }
  
  // =============================================================================
- // SHOULD REPORT - Type Assertions
+ // SHOULD NOT REPORT - Interface Conversion (Ownership Transfer)
  // =============================================================================
  
- // typeAssertionPollution demonstrates pollution through interface conversion.
- // Converting *gorm.DB to interface{} is assumed to pollute it.
- func typeAssertionPollution(db *gorm.DB) {
--	q := db.Where("x = ?", 1)
-+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
- 	var i interface{} = q // Converting to interface{} marks q as polluted
+ // interfaceConversionOwnershipTransfer demonstrates that interface conversion
+ // does NOT pollute the source. It's just type wrapping (ownership transfer).
+ // Pollution only happens when the interface value is actually used.
+ func interfaceConversionOwnershipTransfer(db *gorm.DB) {
+ 	q := db.Where("x = ?", 1)
+ 	var i interface{} = q // Just ownership transfer, does NOT pollute q
  	_ = i
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // First use of q - should NOT report
  }
  
  // =============================================================================
@@ -1273,7 +1281,8 @@
  
  // ifInsideFor demonstrates if inside for loop.
  func ifInsideFor(db *gorm.DB, items []string) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item != "" {
@@ -1284,7 +1293,8 @@
  
  // ifElseInsideFor demonstrates if-else inside for loop.
  func ifElseInsideFor(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1297,7 +1307,8 @@
  
  // nestedIfInsideFor demonstrates nested if inside for.
  func nestedIfInsideFor(db *gorm.DB, items []int, flag bool) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1350,7 +1361,8 @@
  
  // nestedFor demonstrates nested for loops.
  func nestedFor(db *gorm.DB, outer, inner []string) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, o := range outer {
  		for _, i := range inner {
@@ -1361,7 +1373,8 @@
  
  // tripleNestedFor demonstrates 3-level nested for.
  func tripleNestedFor(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for i := 0; i < 3; i++ {
  		for j := 0; j < 3; j++ {
@@ -1374,7 +1387,8 @@
  
  // forWithBreakContinue demonstrates for with break and continue.
  func forWithBreakContinue(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item < 0 {
@@ -1395,7 +1409,8 @@
  
  // deferInsideIf demonstrates defer inside if.
  func deferInsideIf(db *gorm.DB, flag bool) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
  		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1407,7 +1422,8 @@
  // deferInsideIfElse demonstrates defer inside if-else.
  // Find executes FIRST, then defers execute at function exit.
  func deferInsideIfElse(db *gorm.DB, flag bool) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
  		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1421,7 +1437,8 @@
  // deferInsideNestedIf demonstrates defer inside nested if.
  // Find executes FIRST, then defer executes at function exit.
  func deferInsideNestedIf(db *gorm.DB, a, b bool) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if a {
  		if b {
@@ -1434,7 +1451,8 @@
  
  // multipleDeferInsideIf demonstrates multiple defers inside if.
  func multipleDeferInsideIf(db *gorm.DB, flag bool) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
  		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1451,7 +1469,8 @@
  // deferInsideFor demonstrates defer inside for loop.
  // Note: Each iteration adds a defer, all execute at function return.
  func deferInsideFor(db *gorm.DB, items []string) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for range items {
  		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1462,7 +1481,8 @@
  
  // deferInsideForWithCondition demonstrates defer inside for with condition.
  func deferInsideForWithCondition(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1476,7 +1496,8 @@
  
  // deferInsideNestedFor demonstrates defer inside nested for.
  func deferInsideNestedFor(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for i := 0; i < 2; i++ {
  		for j := 0; j < 2; j++ {
@@ -1580,7 +1601,8 @@
  
  // ifForDefer demonstrates if containing for containing defer.
  func ifForDefer(db *gorm.DB, flag bool, items []string) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
  		for range items {
@@ -1593,7 +1615,8 @@
  
  // forIfDefer demonstrates for containing if containing defer.
  func forIfDefer(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1659,7 +1682,8 @@
  // tripleNestingForIfDefer demonstrates 3-level nesting: for -> if -> defer.
  // [LIMITATION] Same as tripleNestingIfForDefer - defer execution order not tracked.
  func tripleNestingForIfDefer(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1710,7 +1734,8 @@
  
  // quadNestingIfForIfDefer demonstrates 4-level: if -> for -> if -> defer.
  func quadNestingIfForIfDefer(db *gorm.DB, a bool, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if a {
  		for _, item := range items {
@@ -1725,7 +1750,8 @@
  
  // quadNestingForIfForDefer demonstrates 4-level: for -> if -> for -> defer.
  func quadNestingForIfForDefer(db *gorm.DB, outer []bool, inner []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, flag := range outer {
  		if flag {
@@ -1780,7 +1806,8 @@
  
  // multipleDefersInDifferentBranches demonstrates multiple defers in different if branches.
  func multipleDefersInDifferentBranches(db *gorm.DB, level int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if level == 0 {
  		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1795,7 +1822,8 @@
  
  // multipleDefersInLoopBranches demonstrates multiple defers in loop branches.
  func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		if item > 0 {
@@ -1831,7 +1859,8 @@
  
  // earlyReturnInLoopWithDefer demonstrates early return in loop with defer.
  func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  
@@ -1850,7 +1879,8 @@
  
  // labeledBreakWithDefer demonstrates labeled break with defer.
  func labeledBreakWithDefer(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  
@@ -1868,7 +1898,8 @@
  
  // labeledContinueWithDefer demonstrates labeled continue with defer.
  func labeledContinueWithDefer(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  
@@ -2001,7 +2032,8 @@
  
  // rangeOverChannelWithDefer demonstrates range over channel with defer.
  func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  
@@ -2034,7 +2066,8 @@
  
  // typeSwitchInsideFor demonstrates type switch inside for.
  func typeSwitchInsideFor(db *gorm.DB, items []interface{}) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for _, item := range items {
  		switch item.(type) {
@@ -2585,7 +2618,8 @@
  // reassignDeferredUse demonstrates reassignment with deferred use.
  // The defer evaluates q immediately - Count pollutes, then defer uses polluted q.
  func reassignDeferredUse(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
  
@@ -2745,7 +2779,8 @@
  
  // whereOnlyDefer demonstrates defer with Where-only.
  func whereOnlyDefer(db *gorm.DB) {
- 	q := db.Where("x = ?", 1)
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	defer q.Where("deferred") // want `\*gorm\.DB instance reused after chain method`
  
@@ -3101,7 +3136,8 @@
  // or vice versa, there's an ordering bug in traceFieldStore.
  func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
  	q1 := db.Where("a")
- 	q2 := db.Where("b")
+-	q2 := db.Where("b")
++	q2 := db.Where("b").Session(&gorm.Session{})
  	q2.Find(nil) // Pollute q2 (reversed from above)
  
  	h := &conditionalFieldAssignHolderForTest{}
@@ -3119,7 +3155,8 @@
  // where both branches assign polluted values.
  func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
  	q1 := db.Where("a")
- 	q2 := db.Where("b")
+-	q2 := db.Where("b")
++	q2 := db.Where("b").Session(&gorm.Session{})
  	q1.Find(nil) // Pollute q1
  	q2.Find(nil) // Pollute q2
  

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -220,7 +220,7 @@ func switchReuse(db *gorm.DB, mode int) {
 // loopReuse demonstrates reuse in a loop.
 // Loop detection: terminal call in loop with root defined outside = violation.
 func loopReuse(db *gorm.DB, items []string) {
-	q := db.Where("base = ?", 1)
+	q := db.Where("base = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		// Second iteration reuses polluted q
@@ -230,7 +230,7 @@ func loopReuse(db *gorm.DB, items []string) {
 
 // forLoopReuse demonstrates reuse in a for loop.
 func forLoopReuse(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for i := 0; i < 3; i++ {
 		// Second iteration reuses polluted q
@@ -266,7 +266,7 @@ func loopNewChainEachIteration(db *gorm.DB, items []string) {
 
 // deferReuse demonstrates reuse with defer.
 func deferReuse(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	// Defer is processed in second pass, after q.Find pollutes q
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -277,7 +277,7 @@ func deferReuse(db *gorm.DB) {
 // deferFunctionCallWithDB demonstrates defer with function call passing *gorm.DB.
 // Tests lines 669-678: defer with *gorm.DB argument to function.
 func deferFunctionCallWithDB(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
 	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
@@ -418,7 +418,7 @@ func goroutineClosureReuse(db *gorm.DB) {
 // goroutineDirectMethodCall demonstrates direct method call in goroutine.
 // This tests the processCallCommonForGo path for method calls.
 func goroutineDirectMethodCall(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -427,7 +427,7 @@ func goroutineDirectMethodCall(db *gorm.DB) {
 // goroutineFunctionCallWithDB demonstrates passing *gorm.DB to function in goroutine.
 // This tests the processCallCommonForGo path for function calls with *gorm.DB argument.
 func goroutineFunctionCallWithDB(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
 	go helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
@@ -437,7 +437,7 @@ func goroutineFunctionCallWithDB(db *gorm.DB) {
 // Tests line 487: isPollutedAt cross-function pollution check.
 // Pollution happens in closure, then goroutine checks isPollutedAt.
 func goroutineCrossFunctionPollution(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	// Pollute q inside a closure (IIFE)
 	func() {
@@ -663,7 +663,7 @@ func nestedDeferGoroutineDefer(db *gorm.DB) {
 
 // multipleDefers demonstrates multiple defers using same q.
 func multipleDefers(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 	defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -832,17 +832,18 @@ func doublePointer(db *gorm.DB) {
 }
 
 // =============================================================================
-// SHOULD REPORT - Type Assertions
+// SHOULD NOT REPORT - Interface Conversion (Ownership Transfer)
 // =============================================================================
 
-// typeAssertionPollution demonstrates pollution through interface conversion.
-// Converting *gorm.DB to interface{} is assumed to pollute it.
-func typeAssertionPollution(db *gorm.DB) {
-	q := db.Where("x = ?", 1).Session(&gorm.Session{})
-	var i interface{} = q // Converting to interface{} marks q as polluted
+// interfaceConversionOwnershipTransfer demonstrates that interface conversion
+// does NOT pollute the source. It's just type wrapping (ownership transfer).
+// Pollution only happens when the interface value is actually used.
+func interfaceConversionOwnershipTransfer(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	var i interface{} = q // Just ownership transfer, does NOT pollute q
 	_ = i
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // First use of q - should NOT report
 }
 
 // =============================================================================
@@ -1219,7 +1220,7 @@ func ifElseChain(db *gorm.DB, level int) {
 
 // ifInsideFor demonstrates if inside for loop.
 func ifInsideFor(db *gorm.DB, items []string) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item != "" {
@@ -1230,7 +1231,7 @@ func ifInsideFor(db *gorm.DB, items []string) {
 
 // ifElseInsideFor demonstrates if-else inside for loop.
 func ifElseInsideFor(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1243,7 +1244,7 @@ func ifElseInsideFor(db *gorm.DB, items []int) {
 
 // nestedIfInsideFor demonstrates nested if inside for.
 func nestedIfInsideFor(db *gorm.DB, items []int, flag bool) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1294,7 +1295,7 @@ func forInsideIfElse(db *gorm.DB, items []string, flag bool) {
 
 // nestedFor demonstrates nested for loops.
 func nestedFor(db *gorm.DB, outer, inner []string) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, o := range outer {
 		for _, i := range inner {
@@ -1305,7 +1306,7 @@ func nestedFor(db *gorm.DB, outer, inner []string) {
 
 // tripleNestedFor demonstrates 3-level nested for.
 func tripleNestedFor(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
@@ -1318,7 +1319,7 @@ func tripleNestedFor(db *gorm.DB) {
 
 // forWithBreakContinue demonstrates for with break and continue.
 func forWithBreakContinue(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item < 0 {
@@ -1339,7 +1340,7 @@ func forWithBreakContinue(db *gorm.DB, items []int) {
 
 // deferInsideIf demonstrates defer inside if.
 func deferInsideIf(db *gorm.DB, flag bool) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1351,7 +1352,7 @@ func deferInsideIf(db *gorm.DB, flag bool) {
 // deferInsideIfElse demonstrates defer inside if-else.
 // Find executes FIRST, then defers execute at function exit.
 func deferInsideIfElse(db *gorm.DB, flag bool) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1365,7 +1366,7 @@ func deferInsideIfElse(db *gorm.DB, flag bool) {
 // deferInsideNestedIf demonstrates defer inside nested if.
 // Find executes FIRST, then defer executes at function exit.
 func deferInsideNestedIf(db *gorm.DB, a, b bool) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if a {
 		if b {
@@ -1378,7 +1379,7 @@ func deferInsideNestedIf(db *gorm.DB, a, b bool) {
 
 // multipleDeferInsideIf demonstrates multiple defers inside if.
 func multipleDeferInsideIf(db *gorm.DB, flag bool) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1395,7 +1396,7 @@ func multipleDeferInsideIf(db *gorm.DB, flag bool) {
 // deferInsideFor demonstrates defer inside for loop.
 // Note: Each iteration adds a defer, all execute at function return.
 func deferInsideFor(db *gorm.DB, items []string) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for range items {
 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1406,7 +1407,7 @@ func deferInsideFor(db *gorm.DB, items []string) {
 
 // deferInsideForWithCondition demonstrates defer inside for with condition.
 func deferInsideForWithCondition(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1420,7 +1421,7 @@ func deferInsideForWithCondition(db *gorm.DB, items []int) {
 
 // deferInsideNestedFor demonstrates defer inside nested for.
 func deferInsideNestedFor(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for i := 0; i < 2; i++ {
 		for j := 0; j < 2; j++ {
@@ -1521,7 +1522,7 @@ func nestedIfInsideDefer(db *gorm.DB, a, b bool) {
 
 // ifForDefer demonstrates if containing for containing defer.
 func ifForDefer(db *gorm.DB, flag bool, items []string) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
 		for range items {
@@ -1534,7 +1535,7 @@ func ifForDefer(db *gorm.DB, flag bool, items []string) {
 
 // forIfDefer demonstrates for containing if containing defer.
 func forIfDefer(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1599,7 +1600,7 @@ func tripleNestingIfForDefer(db *gorm.DB, flag bool, items []string) {
 // tripleNestingForIfDefer demonstrates 3-level nesting: for -> if -> defer.
 // [LIMITATION] Same as tripleNestingIfForDefer - defer execution order not tracked.
 func tripleNestingForIfDefer(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1650,7 +1651,7 @@ func tripleNestingDeferForIf(db *gorm.DB, items []int) {
 
 // quadNestingIfForIfDefer demonstrates 4-level: if -> for -> if -> defer.
 func quadNestingIfForIfDefer(db *gorm.DB, a bool, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if a {
 		for _, item := range items {
@@ -1665,7 +1666,7 @@ func quadNestingIfForIfDefer(db *gorm.DB, a bool, items []int) {
 
 // quadNestingForIfForDefer demonstrates 4-level: for -> if -> for -> defer.
 func quadNestingForIfForDefer(db *gorm.DB, outer []bool, inner []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, flag := range outer {
 		if flag {
@@ -1720,7 +1721,7 @@ func quadNestingDeferForIfFor(db *gorm.DB, outer []bool) {
 
 // multipleDefersInDifferentBranches demonstrates multiple defers in different if branches.
 func multipleDefersInDifferentBranches(db *gorm.DB, level int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if level == 0 {
 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1735,7 +1736,7 @@ func multipleDefersInDifferentBranches(db *gorm.DB, level int) {
 
 // multipleDefersInLoopBranches demonstrates multiple defers in loop branches.
 func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		if item > 0 {
@@ -1770,7 +1771,7 @@ func earlyReturnWithDefer(db *gorm.DB, flag bool) {
 
 // earlyReturnInLoopWithDefer demonstrates early return in loop with defer.
 func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 
@@ -1789,7 +1790,7 @@ func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
 
 // labeledBreakWithDefer demonstrates labeled break with defer.
 func labeledBreakWithDefer(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 
@@ -1807,7 +1808,7 @@ outer:
 
 // labeledContinueWithDefer demonstrates labeled continue with defer.
 func labeledContinueWithDefer(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 
@@ -1935,7 +1936,7 @@ func nestedDeferWithFor(db *gorm.DB) {
 
 // rangeOverChannelWithDefer demonstrates range over channel with defer.
 func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 
@@ -1967,7 +1968,7 @@ func typeSwitchWithDefer(db *gorm.DB, v interface{}) {
 
 // typeSwitchInsideFor demonstrates type switch inside for.
 func typeSwitchInsideFor(db *gorm.DB, items []interface{}) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for _, item := range items {
 		switch item.(type) {
@@ -2491,7 +2492,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 // reassignDeferredUse demonstrates reassignment with deferred use.
 // The defer evaluates q immediately - Count pollutes, then defer uses polluted q.
 func reassignDeferredUse(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
 
@@ -2639,7 +2640,7 @@ func whereOnlyConditional(db *gorm.DB, flag bool) {
 
 // whereOnlyDefer demonstrates defer with Where-only.
 func whereOnlyDefer(db *gorm.DB) {
-	q := db.Where("x = ?", 1)
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	defer q.Where("deferred") // want `\*gorm\.DB instance reused after chain method`
 
@@ -2962,7 +2963,7 @@ func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 // or vice versa, there's an ordering bug in traceFieldStore.
 func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
-	q2 := db.Where("b")
+	q2 := db.Where("b").Session(&gorm.Session{})
 	q2.Find(nil) // Pollute q2 (reversed from above)
 
 	h := &conditionalFieldAssignHolderForTest{}
@@ -2980,7 +2981,7 @@ func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 // where both branches assign polluted values.
 func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
-	q2 := db.Where("b")
+	q2 := db.Where("b").Session(&gorm.Session{})
 	q1.Find(nil) // Pollute q1
 	q2.Find(nil) // Pollute q2
 

--- a/testdata/src/gormreuse/interface_patterns.go.diff
+++ b/testdata/src/gormreuse/interface_patterns.go.diff
@@ -1,0 +1,363 @@
+--- interface_patterns.go	1970-01-01 00:00:00
++++ interface_patterns.go.golden	1970-01-01 00:00:00
+@@ -1,345 +1,345 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // =============================================================================
+ // INTERFACE CONVERSION PATTERNS
+ // Tests for MakeInterface handling
+ //
+ // KEY CONCEPT: Interface conversion (MakeInterface) is just type conversion.
+ // It does NOT pollute the source *gorm.DB - it's ownership transfer, like assignment.
+ // Pollution happens when:
+ // - *gorm.DB is passed to non-pure functions (handled by checkFunctionCallPollution)
+ // - *gorm.DB is stored in slice/map (handled by StoreHandler/MapUpdateHandler)
+ // - *gorm.DB is sent to channel (handled by SendHandler)
+ // =============================================================================
+ 
+ // =============================================================================
+ // INTERFACE CONVERSION - DOES NOT POLLUTE
+ // =============================================================================
+ 
+ // directInterfaceConversion: Direct conversion to interface{}
+ // Interface conversion is just type wrapping - doesn't pollute source
+ func directInterfaceConversion(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	// Direct interface conversion - does NOT pollute q
+ 	_ = interface{}(q)
+ 
+ 	// First use of q - should NOT report (no prior pollution)
+ 	q.Find(nil)
+ }
+ 
+ // anyTypeConversion: Conversion to 'any' (alias for interface{})
+ func anyTypeConversion(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	// 'any' is alias for interface{} - doesn't pollute
+ 	var a any = q
+ 	_ = a
+ 
+ 	// First use of q - should NOT report
+ 	q.Find(nil)
+ }
+ 
+ // multipleInterfaceConversions: Multiple interface conversions
+ func multipleInterfaceConversions(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	// Multiple conversions - none pollute q
+ 	_ = interface{}(q)
+ 	_ = interface{}(q)
+ 	var a any = q
+ 	_ = a
+ 
+ 	// First use of q - should NOT report
+ 	q.Find(nil)
+ }
+ 
+ // =============================================================================
+ // FUNCTION CALLS WITH INTERFACE ARGS - DOES POLLUTE
+ // =============================================================================
+ 
+ // variadicInterfaceArgs: Passing to variadic interface{} function
+ // Passing to non-pure function DOES pollute (handled by checkFunctionCallPollution)
+ func variadicInterfaceArgs(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	// Passing to non-pure function - marks q as polluted
+ 	acceptVariadic(q)
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // variadicInterfaceArgsMultiple: Multiple args to variadic
+ func variadicInterfaceArgsMultiple(db *gorm.DB) {
+-	q1 := db.Where("x")
+-	q2 := db.Where("y")
++	q1 := db.Where("x").Session(&gorm.Session{})
++	q2 := db.Where("y").Session(&gorm.Session{})
+ 
+ 	// Both passed to non-pure function - both polluted
+ 	acceptVariadic(q1, q2)
+ 
+ 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
+ func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
+-	q1 := db.Where("x")
++	q1 := db.Where("x").Session(&gorm.Session{})
+ 	q2 := db.Where("y")
+ 
+ 	// Only q1 is passed to function
+ 	acceptVariadic(q1)
+ 
+ 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q2.Find(nil) // q2 is fresh - should NOT report
+ }
+ 
+ func acceptVariadic(args ...interface{}) {}
+ 
+ // =============================================================================
+ // GORM METHODS WITH INTERFACE ARGUMENTS
+ // =============================================================================
+ 
+ // gormOrMethodReceiver: GORM's Or method - receiver pollution
+ // Calling Or on base pollutes base (receiver usage)
+ func gormOrMethodReceiver(db *gorm.DB) {
+ 	base := db.Where("base")
+ 
+ 	// Or takes interface{} - base is polluted by method call
+-	base.Or("x = ?", 1)
++	base = base.Or("x = ?", 1)
+ 
+ 	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // gormOrMethodArg: GORM's Or method - argument pollution
+ // Passing *gorm.DB to Or's interface{} arg pollutes it
+ func gormOrMethodArg(db *gorm.DB) {
+ 	base := db.Session(&gorm.Session{}) // immutable base
+ 	q := db.Where("x")
+ 
+ 	// q is passed to Or as interface{} - pollutes q
+-	base.Or(q)
++	base = base.Or(q)
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // gormOrMethodChain: Chain passed to Or
+ // q.Where("y") pollutes q, and the chain result is passed to Or
+ func gormOrMethodChain(db *gorm.DB) {
+ 	base := db.Session(&gorm.Session{}) // immutable base
+ 	q := db.Where("x")
+ 
+ 	// q is polluted by .Where("y") chain call
+-	base.Or(q.Where("y"))
++	base = base.Or(q.Where("y"))
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // gormOrMethodFresh: Fresh query passed to Or (no reuse)
+ func gormOrMethodFresh(db *gorm.DB) {
+ 	base := db.Where("base")
+ 
+ 	// Fresh query passed to Or - no reuse issue for the fresh query
+-	base.Or(db.Where("x"))
++	base = base.Or(db.Where("x"))
+ 
+ 	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // INTERFACE SLICE PATTERNS - DOES POLLUTE (storage)
+ // =============================================================================
+ 
+ // interfaceSliceLiteral: *gorm.DB in []interface{} literal
+ // Storing in slice DOES pollute (handled by general slice storage)
+ func interfaceSliceLiteral(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	// Slice literal - storage pollutes
+ 	_ = []interface{}{q}
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // interfaceSliceMultiple: Multiple *gorm.DB in slice
+ func interfaceSliceMultiple(db *gorm.DB) {
+-	q1 := db.Where("x")
+-	q2 := db.Where("y")
++	q1 := db.Where("x").Session(&gorm.Session{})
++	q2 := db.Where("y").Session(&gorm.Session{})
+ 
+ 	_ = []interface{}{q1, q2}
+ 
+ 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // INTERFACE MAP PATTERNS - DOES POLLUTE (storage)
+ // =============================================================================
+ 
+ // interfaceMapLiteral: *gorm.DB as map[string]interface{} value
+ func interfaceMapLiteral(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	_ = map[string]interface{}{"query": q}
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // CLOSURE WITH INTERFACE PATTERNS
+ // =============================================================================
+ 
+ // closureReturnsInterface: Closure returning interface{}
+ // The closure captures q and returns it as interface{}
+ // Calling the closure doesn't pollute q (just returns it)
+ func closureReturnsInterface(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	getQuery := func() interface{} {
+ 		return q // Just returns q wrapped in interface{}
+ 	}
+ 
+ 	_ = getQuery()
+ 
+ 	// q was just returned from closure, not used
+ 	q.Find(nil) // Should NOT report - q wasn't polluted
+ }
+ 
+ // closureAcceptsInterface: Closure accepting interface{} parameter
+ // Passing to closure that takes interface{} - treated like function call
+ func closureAcceptsInterface(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	process := func(v interface{}) {
+ 		_ = v
+ 	}
+ 
+ 	// Passing to non-pure closure - pollutes q
+ 	process(q)
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // LOOP WITH INTERFACE PATTERNS
+ // =============================================================================
+ 
+ // loopWithInterfaceSlice: Loop building []interface{} with queries
+ func loopWithInterfaceSlice(db *gorm.DB, items []int) {
+ 	var queries []interface{}
+ 
+ 	for _, item := range items {
+ 		// Each iteration creates a fresh query
+ 		q := db.Session(&gorm.Session{}).Where("x = ?", item)
+ 		queries = append(queries, q)
+ 	}
+ 
+ 	// Use the collected queries
+ 	_ = queries
+ }
+ 
+ // loopWithClosureAndInterface: Closure in loop passing to interface
+ func loopWithClosureAndInterface(db *gorm.DB, items []int) {
+ 	getQuery := func() *gorm.DB {
+ 		return db.Session(&gorm.Session{}).Where("fresh")
+ 	}
+ 
+ 	condition := db.Session(&gorm.Session{})
+ 
+ 	for range items {
+ 		q := getQuery()
+ 		// q.Where("x") flows to condition.Or via MakeInterface
+ 		// Each call should be independent (closure result treated as stored)
+ 		condition = condition.Or(q.Where("x"))
+ 	}
+ 
+ 	condition.Find(nil)
+ }
+ 
+ // loopWithClosureAndInterfaceMultiReturn: Multi-return closure with interface
+ func loopWithClosureAndInterfaceMultiReturn(db *gorm.DB, items []int) {
+ 	getQuery := func() (*gorm.DB, error) {
+ 		return db.Session(&gorm.Session{}).Where("fresh"), nil
+ 	}
+ 
+ 	condition := db.Session(&gorm.Session{})
+ 
+ 	for range items {
+ 		q, _ := getQuery()
+ 		// Each call is independent (via Extract)
+ 		condition = condition.Or(q.Where("x"))
+ 	}
+ 
+ 	condition.Find(nil)
+ }
+ 
+ // =============================================================================
+ // CHANNEL WITH INTERFACE - DOES POLLUTE
+ // =============================================================================
+ 
+ // channelSendInterface: Send *gorm.DB to chan interface{}
+ func channelSendInterface(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	ch := make(chan interface{}, 1)
+ 	ch <- q // Channel send pollutes
+ 
+ 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ }
+ 
+ // =============================================================================
+ // SHOULD NOT REPORT - FRESH QUERIES
+ // =============================================================================
+ 
+ // freshQueryToInterface: Fresh query passed to interface - no prior use
+ func freshQueryToInterface(db *gorm.DB) {
+ 	// Fresh query directly to interface - no reuse
+ 	acceptVariadic(db.Where("x"))
+ }
+ 
+ // freshQueryChainToInterface: Fresh query chain to interface
+ func freshQueryChainToInterface(db *gorm.DB) {
+ 	// Fresh chain directly to interface
+ 	acceptVariadic(db.Session(&gorm.Session{}).Where("x").Where("y"))
+ }
+ 
+ // immutableToInterface: Immutable source to interface
+ func immutableToInterface(db *gorm.DB) {
+ 	// Immutable (Session) result to interface - no issue
+ 	q := db.Session(&gorm.Session{})
+ 	acceptVariadic(q)
+ 	q.Find(nil) // Immutable can be reused
+ }
+ 
+ // =============================================================================
+ // INTERFACE CONVERSION THEN USE - ORDER MATTERS
+ // =============================================================================
+ 
+ // interfaceConversionThenGormUse: Interface conversion then gorm use
+ // Interface conversion doesn't pollute, so subsequent gorm use is first use
+ func interfaceConversionThenGormUse(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	_ = interface{}(q) // Just conversion, doesn't pollute
+ 
+ 	q.Find(nil) // First use - should NOT report
+ }
+ 
+ // gormUseThenInterfaceConversion: Gorm use then interface conversion
+ func gormUseThenInterfaceConversion(db *gorm.DB) {
+ 	q := db.Where("x")
+ 
+ 	q.Find(nil) // First use - pollutes q
+ 
+ 	_ = interface{}(q) // Just conversion, but q was already polluted
+ 	// No second gorm method call, so no violation
+ }
+ 
+ // gormUseThenInterfaceConversionThenGormUse: Use, convert, use again
+ func gormUseThenInterfaceConversionThenGormUse(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 
+ 	q.Find(nil)        // First use - pollutes q
+ 	_ = interface{}(q) // Just conversion
+ 	q.Count(nil)       // want "\\*gorm\\.DB instance reused"
+ }

--- a/testdata/src/gormreuse/interface_patterns.go.golden
+++ b/testdata/src/gormreuse/interface_patterns.go.golden
@@ -1,0 +1,345 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// INTERFACE CONVERSION PATTERNS
+// Tests for MakeInterface handling
+//
+// KEY CONCEPT: Interface conversion (MakeInterface) is just type conversion.
+// It does NOT pollute the source *gorm.DB - it's ownership transfer, like assignment.
+// Pollution happens when:
+// - *gorm.DB is passed to non-pure functions (handled by checkFunctionCallPollution)
+// - *gorm.DB is stored in slice/map (handled by StoreHandler/MapUpdateHandler)
+// - *gorm.DB is sent to channel (handled by SendHandler)
+// =============================================================================
+
+// =============================================================================
+// INTERFACE CONVERSION - DOES NOT POLLUTE
+// =============================================================================
+
+// directInterfaceConversion: Direct conversion to interface{}
+// Interface conversion is just type wrapping - doesn't pollute source
+func directInterfaceConversion(db *gorm.DB) {
+	q := db.Where("x")
+
+	// Direct interface conversion - does NOT pollute q
+	_ = interface{}(q)
+
+	// First use of q - should NOT report (no prior pollution)
+	q.Find(nil)
+}
+
+// anyTypeConversion: Conversion to 'any' (alias for interface{})
+func anyTypeConversion(db *gorm.DB) {
+	q := db.Where("x")
+
+	// 'any' is alias for interface{} - doesn't pollute
+	var a any = q
+	_ = a
+
+	// First use of q - should NOT report
+	q.Find(nil)
+}
+
+// multipleInterfaceConversions: Multiple interface conversions
+func multipleInterfaceConversions(db *gorm.DB) {
+	q := db.Where("x")
+
+	// Multiple conversions - none pollute q
+	_ = interface{}(q)
+	_ = interface{}(q)
+	var a any = q
+	_ = a
+
+	// First use of q - should NOT report
+	q.Find(nil)
+}
+
+// =============================================================================
+// FUNCTION CALLS WITH INTERFACE ARGS - DOES POLLUTE
+// =============================================================================
+
+// variadicInterfaceArgs: Passing to variadic interface{} function
+// Passing to non-pure function DOES pollute (handled by checkFunctionCallPollution)
+func variadicInterfaceArgs(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	// Passing to non-pure function - marks q as polluted
+	acceptVariadic(q)
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// variadicInterfaceArgsMultiple: Multiple args to variadic
+func variadicInterfaceArgsMultiple(db *gorm.DB) {
+	q1 := db.Where("x").Session(&gorm.Session{})
+	q2 := db.Where("y").Session(&gorm.Session{})
+
+	// Both passed to non-pure function - both polluted
+	acceptVariadic(q1, q2)
+
+	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// variadicInterfaceArgsOnlyOne: Only one of multiple is passed
+func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
+	q1 := db.Where("x").Session(&gorm.Session{})
+	q2 := db.Where("y")
+
+	// Only q1 is passed to function
+	acceptVariadic(q1)
+
+	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q2.Find(nil) // q2 is fresh - should NOT report
+}
+
+func acceptVariadic(args ...interface{}) {}
+
+// =============================================================================
+// GORM METHODS WITH INTERFACE ARGUMENTS
+// =============================================================================
+
+// gormOrMethodReceiver: GORM's Or method - receiver pollution
+// Calling Or on base pollutes base (receiver usage)
+func gormOrMethodReceiver(db *gorm.DB) {
+	base := db.Where("base")
+
+	// Or takes interface{} - base is polluted by method call
+	base = base.Or("x = ?", 1)
+
+	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// gormOrMethodArg: GORM's Or method - argument pollution
+// Passing *gorm.DB to Or's interface{} arg pollutes it
+func gormOrMethodArg(db *gorm.DB) {
+	base := db.Session(&gorm.Session{}) // immutable base
+	q := db.Where("x")
+
+	// q is passed to Or as interface{} - pollutes q
+	base = base.Or(q)
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// gormOrMethodChain: Chain passed to Or
+// q.Where("y") pollutes q, and the chain result is passed to Or
+func gormOrMethodChain(db *gorm.DB) {
+	base := db.Session(&gorm.Session{}) // immutable base
+	q := db.Where("x")
+
+	// q is polluted by .Where("y") chain call
+	base = base.Or(q.Where("y"))
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// gormOrMethodFresh: Fresh query passed to Or (no reuse)
+func gormOrMethodFresh(db *gorm.DB) {
+	base := db.Where("base")
+
+	// Fresh query passed to Or - no reuse issue for the fresh query
+	base = base.Or(db.Where("x"))
+
+	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// INTERFACE SLICE PATTERNS - DOES POLLUTE (storage)
+// =============================================================================
+
+// interfaceSliceLiteral: *gorm.DB in []interface{} literal
+// Storing in slice DOES pollute (handled by general slice storage)
+func interfaceSliceLiteral(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	// Slice literal - storage pollutes
+	_ = []interface{}{q}
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// interfaceSliceMultiple: Multiple *gorm.DB in slice
+func interfaceSliceMultiple(db *gorm.DB) {
+	q1 := db.Where("x").Session(&gorm.Session{})
+	q2 := db.Where("y").Session(&gorm.Session{})
+
+	_ = []interface{}{q1, q2}
+
+	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// INTERFACE MAP PATTERNS - DOES POLLUTE (storage)
+// =============================================================================
+
+// interfaceMapLiteral: *gorm.DB as map[string]interface{} value
+func interfaceMapLiteral(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	_ = map[string]interface{}{"query": q}
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// CLOSURE WITH INTERFACE PATTERNS
+// =============================================================================
+
+// closureReturnsInterface: Closure returning interface{}
+// The closure captures q and returns it as interface{}
+// Calling the closure doesn't pollute q (just returns it)
+func closureReturnsInterface(db *gorm.DB) {
+	q := db.Where("x")
+
+	getQuery := func() interface{} {
+		return q // Just returns q wrapped in interface{}
+	}
+
+	_ = getQuery()
+
+	// q was just returned from closure, not used
+	q.Find(nil) // Should NOT report - q wasn't polluted
+}
+
+// closureAcceptsInterface: Closure accepting interface{} parameter
+// Passing to closure that takes interface{} - treated like function call
+func closureAcceptsInterface(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	process := func(v interface{}) {
+		_ = v
+	}
+
+	// Passing to non-pure closure - pollutes q
+	process(q)
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// LOOP WITH INTERFACE PATTERNS
+// =============================================================================
+
+// loopWithInterfaceSlice: Loop building []interface{} with queries
+func loopWithInterfaceSlice(db *gorm.DB, items []int) {
+	var queries []interface{}
+
+	for _, item := range items {
+		// Each iteration creates a fresh query
+		q := db.Session(&gorm.Session{}).Where("x = ?", item)
+		queries = append(queries, q)
+	}
+
+	// Use the collected queries
+	_ = queries
+}
+
+// loopWithClosureAndInterface: Closure in loop passing to interface
+func loopWithClosureAndInterface(db *gorm.DB, items []int) {
+	getQuery := func() *gorm.DB {
+		return db.Session(&gorm.Session{}).Where("fresh")
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q := getQuery()
+		// q.Where("x") flows to condition.Or via MakeInterface
+		// Each call should be independent (closure result treated as stored)
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}
+
+// loopWithClosureAndInterfaceMultiReturn: Multi-return closure with interface
+func loopWithClosureAndInterfaceMultiReturn(db *gorm.DB, items []int) {
+	getQuery := func() (*gorm.DB, error) {
+		return db.Session(&gorm.Session{}).Where("fresh"), nil
+	}
+
+	condition := db.Session(&gorm.Session{})
+
+	for range items {
+		q, _ := getQuery()
+		// Each call is independent (via Extract)
+		condition = condition.Or(q.Where("x"))
+	}
+
+	condition.Find(nil)
+}
+
+// =============================================================================
+// CHANNEL WITH INTERFACE - DOES POLLUTE
+// =============================================================================
+
+// channelSendInterface: Send *gorm.DB to chan interface{}
+func channelSendInterface(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	ch := make(chan interface{}, 1)
+	ch <- q // Channel send pollutes
+
+	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+}
+
+// =============================================================================
+// SHOULD NOT REPORT - FRESH QUERIES
+// =============================================================================
+
+// freshQueryToInterface: Fresh query passed to interface - no prior use
+func freshQueryToInterface(db *gorm.DB) {
+	// Fresh query directly to interface - no reuse
+	acceptVariadic(db.Where("x"))
+}
+
+// freshQueryChainToInterface: Fresh query chain to interface
+func freshQueryChainToInterface(db *gorm.DB) {
+	// Fresh chain directly to interface
+	acceptVariadic(db.Session(&gorm.Session{}).Where("x").Where("y"))
+}
+
+// immutableToInterface: Immutable source to interface
+func immutableToInterface(db *gorm.DB) {
+	// Immutable (Session) result to interface - no issue
+	q := db.Session(&gorm.Session{})
+	acceptVariadic(q)
+	q.Find(nil) // Immutable can be reused
+}
+
+// =============================================================================
+// INTERFACE CONVERSION THEN USE - ORDER MATTERS
+// =============================================================================
+
+// interfaceConversionThenGormUse: Interface conversion then gorm use
+// Interface conversion doesn't pollute, so subsequent gorm use is first use
+func interfaceConversionThenGormUse(db *gorm.DB) {
+	q := db.Where("x")
+
+	_ = interface{}(q) // Just conversion, doesn't pollute
+
+	q.Find(nil) // First use - should NOT report
+}
+
+// gormUseThenInterfaceConversion: Gorm use then interface conversion
+func gormUseThenInterfaceConversion(db *gorm.DB) {
+	q := db.Where("x")
+
+	q.Find(nil) // First use - pollutes q
+
+	_ = interface{}(q) // Just conversion, but q was already polluted
+	// No second gorm method call, so no violation
+}
+
+// gormUseThenInterfaceConversionThenGormUse: Use, convert, use again
+func gormUseThenInterfaceConversionThenGormUse(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+
+	q.Find(nil)        // First use - pollutes q
+	_ = interface{}(q) // Just conversion
+	q.Count(nil)       // want "\\*gorm\\.DB instance reused"
+}

--- a/testdata/src/gormreuse/nested_chaos.go.diff
+++ b/testdata/src/gormreuse/nested_chaos.go.diff
@@ -813,9 +813,11 @@
  
  	// Level 3
  	if c {
- 		q = q.Where("c1") // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("c1") // want `\*gorm\.DB instance reused after chain method`
++		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
  	} else {
- 		q = q.Where("c2") // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("c2") // want `\*gorm\.DB instance reused after chain method`
++		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
  		q.First(nil)
  	}
  	// Phi3: q3 = Phi(Phi2.Where, Phi2.Where.polluted)
@@ -1011,7 +1013,8 @@
  
  // chaosModernSwapLoop demonstrates modern swap syntax in loops.
  func chaosModernSwapLoop(db *gorm.DB, flags []bool) {
- 	q1 := db.Where("q1")
+-	q1 := db.Where("q1")
++	q1 := db.Where("q1").Session(&gorm.Session{})
  	q2 := db.Where("q2")
  
  	q1.Find(nil) // Pollute q1
@@ -1020,7 +1023,8 @@
  		if flag {
  			q1, q2 = q2, q1 // Swap back and forth
  		}
- 		q1 = q1.Where("extend", flag) // want `\*gorm\.DB instance reused after chain method`
+-		q1 = q1.Where("extend", flag) // want `\*gorm\.DB instance reused after chain method`
++		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
  	}
  
  	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1132,7 +1136,8 @@
  
  // chaosWhereChainInLoop demonstrates Where chaining in loop without reassignment.
  func chaosWhereChainInLoop(db *gorm.DB, items []string) {
- 	q := db.Where("base")
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
  
  	for _, item := range items {
  		q.Where("item", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`

--- a/testdata/src/gormreuse/nested_chaos.go.golden
+++ b/testdata/src/gormreuse/nested_chaos.go.golden
@@ -754,9 +754,9 @@ func chaosPhiCascade(db *gorm.DB, a, b, c, d bool) {
 
 	// Level 3
 	if c {
-		q = q.Where("c1") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
 	} else {
-		q = q.Where("c2") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
 		q.First(nil)
 	}
 	// Phi3: q3 = Phi(Phi2.Where, Phi2.Where.polluted)
@@ -944,7 +944,7 @@ func chaosModernSwapConditional(db *gorm.DB, a, b bool) {
 
 // chaosModernSwapLoop demonstrates modern swap syntax in loops.
 func chaosModernSwapLoop(db *gorm.DB, flags []bool) {
-	q1 := db.Where("q1")
+	q1 := db.Where("q1").Session(&gorm.Session{})
 	q2 := db.Where("q2")
 
 	q1.Find(nil) // Pollute q1
@@ -953,7 +953,7 @@ func chaosModernSwapLoop(db *gorm.DB, flags []bool) {
 		if flag {
 			q1, q2 = q2, q1 // Swap back and forth
 		}
-		q1 = q1.Where("extend", flag) // want `\*gorm\.DB instance reused after chain method`
+		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
 	}
 
 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
@@ -1054,7 +1054,7 @@ func chaosWhereChainAfterPollution(db *gorm.DB, a bool) {
 
 // chaosWhereChainInLoop demonstrates Where chaining in loop without reassignment.
 func chaosWhereChainInLoop(db *gorm.DB, items []string) {
-	q := db.Where("base")
+	q := db.Where("base").Session(&gorm.Session{})
 
 	for _, item := range items {
 		q.Where("item", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`


### PR DESCRIPTION
## Summary
- Add MakeInterface flow detection in tracer to treat closure results flowing to interface{} args as independent roots
- Add global edit deduplication in analyzer to prevent duplicate Session() fixes when multiple violations share the same root
- Add comprehensive test files for closure loop patterns and interface conversion behaviors

## Test plan
- [x] All existing tests pass
- [x] New test cases in closure_loop.go verify the fix
- [x] New test cases in interface_patterns.go document interface conversion behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)