### PR TITLE
fix: remove false positive for Session() on polluted value

### DIFF
--- a/internal/ssa/pollution/tracker.go
+++ b/internal/ssa/pollution/tracker.go
@@ -223,16 +223,9 @@ func (t *Tracker) DetectViolations() {
 		t.checkViolationsBetween(uses, uses, root, allUses)
 	}
 
-	// Check pure uses against polluting uses
-	// A pure use after a polluting use is a violation
-	for root, pureUses := range t.pureUses {
-		pollutingUses := t.pollutingUses[root]
-		if len(pollutingUses) == 0 {
-			continue
-		}
-		allUses := t.getAllUses(root)
-		t.checkViolationsBetween(pureUses, pollutingUses, root, allUses)
-	}
+	// NOTE: We intentionally do NOT check pure uses (Session, Debug, WithContext)
+	// against polluting uses. Pure/immutable-returning methods are safe to call
+	// on any value regardless of pollution state - they create fresh clones.
 
 	// Check assignment uses against polluting uses
 	// An assignment use after a polluting use is a violation (using polluted root)

--- a/testdata/src/gormreuse/advanced.go
+++ b/testdata/src/gormreuse/advanced.go
@@ -118,21 +118,23 @@ func functionReturnWithSession(db *gorm.DB) {
 }
 
 // =============================================================================
-// SHOULD REPORT - Session on polluted value
+// SHOULD NOT REPORT - Session on polluted value creates fresh copy
 // =============================================================================
 
-// sessionAfterPolluted demonstrates that Session() after pollution doesn't help.
+// sessionAfterPolluted demonstrates that Session() on polluted value is safe.
+// Session() creates a fresh clone with new Statement, so the result is clean
+// regardless of the receiver's pollution state.
 func sessionAfterPolluted(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Count(new(int64))                        // q is polluted
-	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Find(&[]User{}) // OK: Session creates fresh copy
 }
 
-// sessionOnPollutedValue demonstrates Session on already-polluted value.
+// sessionOnPollutedValue demonstrates Session on already-polluted value is safe.
 func sessionOnPollutedValue(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil)
-	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Count(nil) // OK: Session creates fresh copy
 }
 
 // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
@@ -140,7 +142,7 @@ func multipleDirectUsesWithoutSession(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil)
 	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
-	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).First(nil) // OK: Session creates fresh copy
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/advanced.go.diff
+++ b/testdata/src/gormreuse/advanced.go.diff
@@ -1,6 +1,6 @@
 --- advanced.go	1970-01-01 00:00:00
 +++ advanced.go.golden	1970-01-01 00:00:00
-@@ -1,1209 +1,1209 @@
+@@ -1,1211 +1,1211 @@
  package internal
  
  import (
@@ -127,23 +127,23 @@
  }
  
  // =============================================================================
- // SHOULD REPORT - Session on polluted value
+ // SHOULD NOT REPORT - Session on polluted value creates fresh copy
  // =============================================================================
  
- // sessionAfterPolluted demonstrates that Session() after pollution doesn't help.
+ // sessionAfterPolluted demonstrates that Session() on polluted value is safe.
+ // Session() creates a fresh clone with new Statement, so the result is clean
+ // regardless of the receiver's pollution state.
  func sessionAfterPolluted(db *gorm.DB) {
--	q := db.Model(&User{}).Where("active = ?", true)
-+	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
+ 	q := db.Model(&User{}).Where("active = ?", true)
  	q.Count(new(int64))                        // q is polluted
- 	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Session(&gorm.Session{}).Find(&[]User{}) // OK: Session creates fresh copy
  }
  
- // sessionOnPollutedValue demonstrates Session on already-polluted value.
+ // sessionOnPollutedValue demonstrates Session on already-polluted value is safe.
  func sessionOnPollutedValue(db *gorm.DB) {
--	q := db.Where("x = ?", 1)
-+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+ 	q := db.Where("x = ?", 1)
  	q.Find(nil)
- 	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Session(&gorm.Session{}).Count(nil) // OK: Session creates fresh copy
  }
  
  // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
@@ -152,7 +152,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil)
  	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
- 	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Session(&gorm.Session{}).First(nil) // OK: Session creates fresh copy
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/advanced.go.golden
+++ b/testdata/src/gormreuse/advanced.go.golden
@@ -118,21 +118,23 @@ func functionReturnWithSession(db *gorm.DB) {
 }
 
 // =============================================================================
-// SHOULD REPORT - Session on polluted value
+// SHOULD NOT REPORT - Session on polluted value creates fresh copy
 // =============================================================================
 
-// sessionAfterPolluted demonstrates that Session() after pollution doesn't help.
+// sessionAfterPolluted demonstrates that Session() on polluted value is safe.
+// Session() creates a fresh clone with new Statement, so the result is clean
+// regardless of the receiver's pollution state.
 func sessionAfterPolluted(db *gorm.DB) {
-	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
+	q := db.Model(&User{}).Where("active = ?", true)
 	q.Count(new(int64))                        // q is polluted
-	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Find(&[]User{}) // OK: Session creates fresh copy
 }
 
-// sessionOnPollutedValue demonstrates Session on already-polluted value.
+// sessionOnPollutedValue demonstrates Session on already-polluted value is safe.
 func sessionOnPollutedValue(db *gorm.DB) {
-	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	q := db.Where("x = ?", 1)
 	q.Find(nil)
-	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Count(nil) // OK: Session creates fresh copy
 }
 
 // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
@@ -140,7 +142,7 @@ func multipleDirectUsesWithoutSession(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil)
 	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
-	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).First(nil) // OK: Session creates fresh copy
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Remove "pure use after polluting use" violation check
- Session(), Debug(), WithContext() create fresh clones, so calling them on polluted values is safe

## Changes
- `internal/ssa/pollution/tracker.go`: Remove pureUses violation check in DetectViolations()
- `testdata/src/gormreuse/advanced.go`: Update test cases - Session() on polluted value is now OK

## Fixes
- `q.Count(); q = q.Session()` - the recovery pattern no longer reports false positive
- `q.Find(); q.Session().Count()` - chained Session no longer reports false positive

Fixes #46

## Test plan
- [x] All tests pass
- [x] Golden files regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)