### PR TITLE
feat: support pure and immutable-return directives on closures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,29 @@ The linter detects when a mutable `*gorm.DB` branches into multiple code paths:
 ### Directives
 
 - `//gormreuse:ignore` - Suppress warnings for the next line or same line
-- `//gormreuse:pure` - Mark function/method as not polluting its `*gorm.DB` argument
-- `//gormreuse:immutable-return` - Mark function/method as returning immutable `*gorm.DB` (like Session/WithContext)
+- `//gormreuse:pure` - Mark function/method/closure as not polluting its `*gorm.DB` argument
+- `//gormreuse:immutable-return` - Mark function/method/closure as returning immutable `*gorm.DB` (like Session/WithContext)
 
 Directives can be combined with commas: `//gormreuse:pure,immutable-return`
 
 Trailing comments use `//`: `//gormreuse:ignore // reason here`
+
+**Directive placement for closures:**
+
+```go
+// Next-line pattern (before closure):
+//gormreuse:pure
+helper := func(q *gorm.DB) { ... }
+
+// Same-line pattern (after opening brace):
+helper := func(q *gorm.DB) { //gormreuse:pure
+    ...
+}
+
+// Multi-assignment (all direct closures get the directive):
+//gormreuse:pure
+a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
+```
 
 > **Important**: User-defined functions that accept `*gorm.DB` are treated as polluting **unless** the function returns `*gorm.DB` and the result is assigned (e.g., `q = helper(q)`). In that case, it's treated like a gorm method assignment. Use `//gormreuse:pure` to mark functions that don't pollute arguments even when result is discarded, and `//gormreuse:immutable-return` to mark functions whose return value can be safely reused (like DB connection helpers).
 

--- a/README.md
+++ b/README.md
@@ -312,12 +312,20 @@ package mypackage
 
 ### `//gormreuse:pure`
 
-Mark a function as not polluting its [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) argument:
+Mark a function or closure as not polluting its [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) argument:
 
 ```go
 //gormreuse:pure
 func withTenant(db *gorm.DB, tenantID int) *gorm.DB {
     return db.Session(&gorm.Session{}).Where("tenant_id = ?", tenantID)
+}
+
+// Also works on closures (next-line or same-line pattern):
+//gormreuse:pure
+helper := func(q *gorm.DB) { _ = q }
+
+helper2 := func(q *gorm.DB) { //gormreuse:pure
+    _ = q
 }
 ```
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -83,6 +83,10 @@ func run(pass *analysis.Pass) (any, error) {
 		ignoreMaps[filename] = directive.BuildIgnoreMap(pass.Fset, file)
 		funcIgnores[filename] = directive.BuildFunctionIgnoreSet(pass.Fset, file)
 
+		// Add original file to sets (for position-correct directive detection)
+		pureFuncs.AddFile(file)
+		immutableReturnFuncs.AddFile(file)
+
 		// Build pure function set for this file
 		for key := range directive.BuildPureFunctionSet(file, pkgPath) {
 			pureFuncs.Add(key)

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -50,6 +50,7 @@ func TestGenerateDiffFiles(t *testing.T) {
 		"nested_chaos.go",
 		"interface_patterns.go",
 		"closure_loop.go",
+		"closure_directive.go",
 	}
 
 	for _, filename := range testFiles {
@@ -192,6 +193,7 @@ func TestDiffFilesUpToDate(t *testing.T) {
 		"nested_chaos.go",
 		"interface_patterns.go",
 		"closure_loop.go",
+		"closure_directive.go",
 	}
 
 	for _, filename := range testFiles {

--- a/internal/directive/pure.go
+++ b/internal/directive/pure.go
@@ -7,6 +7,7 @@ import (
 	"go/types"
 	"strings"
 
+	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -71,7 +72,8 @@ type directiveChecker func(text string) bool
 type DirectiveFuncSet struct {
 	known       map[FuncKey]struct{}
 	fset        *token.FileSet
-	cache       map[string]*ast.File
+	files       map[string]*ast.File // Original parsed files (from analysis)
+	cache       map[string]*ast.File // Cache for external files (re-parsed)
 	isDirective directiveChecker
 }
 
@@ -80,8 +82,21 @@ func newDirectiveFuncSet(fset *token.FileSet, isDirective directiveChecker) *Dir
 	return &DirectiveFuncSet{
 		known:       make(map[FuncKey]struct{}),
 		fset:        fset,
+		files:       make(map[string]*ast.File),
 		cache:       make(map[string]*ast.File),
 		isDirective: isDirective,
+	}
+}
+
+// AddFile adds an original parsed file to the set.
+// This should be called for all files in the current package to avoid re-parsing.
+func (s *DirectiveFuncSet) AddFile(file *ast.File) {
+	if s == nil || s.fset == nil || file == nil {
+		return
+	}
+	filename := s.fset.Position(file.Pos()).Filename
+	if filename != "" {
+		s.files[filename] = file
 	}
 }
 
@@ -123,13 +138,25 @@ func (s *DirectiveFuncSet) hasDirective(fn *ssa.Function) bool {
 	}
 
 	// Try getting syntax from the SSA function (works for current package)
-	if syntax := fn.Syntax(); syntax != nil {
-		if funcDecl, ok := syntax.(*ast.FuncDecl); ok && funcDecl.Doc != nil {
-			for _, c := range funcDecl.Doc.List {
+	switch syntax := fn.Syntax().(type) {
+	case *ast.FuncDecl:
+		// Check Doc comments (next-line pattern)
+		if syntax.Doc != nil {
+			for _, c := range syntax.Doc.List {
 				if s.isDirective(c.Text) {
 					return true
 				}
 			}
+		}
+		// Check same-line pattern (after opening brace)
+		if s.hasDirectiveAfterFuncDeclBrace(syntax) {
+			return true
+		}
+	case *ast.FuncLit:
+		// Closures don't have Doc comments in Go, so we look for comments
+		// immediately before or after the opening brace.
+		if s.hasDirectiveForFuncLit(syntax) {
+			return true
 		}
 	}
 
@@ -160,6 +187,451 @@ func (s *DirectiveFuncSet) hasDirective(fn *ssa.Function) bool {
 		receiverType = formatReceiverType(sig.Recv().Type())
 	}
 	return s.hasDirectiveInFile(file, funcName, receiverType)
+}
+
+// hasMatchingDirective finds a directive comment in the file that satisfies the given predicate.
+//
+// This is a common helper for directive detection. It:
+//  1. Gets the file containing the node
+//  2. Loops through all comments in the file
+//  3. For each comment that has the directive, applies the predicate
+//
+// The predicate receives the file (for nested AST inspection) and the comment group.
+func (s *DirectiveFuncSet) hasMatchingDirective(node ast.Node, predicate func(file *ast.File, cg *ast.CommentGroup) bool) bool {
+	file := s.getFileForNode(node)
+	if file == nil {
+		return false
+	}
+	for _, cg := range file.Comments {
+		if s.commentGroupHasDirective(cg) && predicate(file, cg) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDirectiveAfterFuncDeclBrace checks if a FuncDecl has a directive comment
+// after its opening brace on the same line (same-line pattern).
+//
+// This is simpler than FuncLit handling because FuncDecl cannot be nested
+// within another FuncDecl on the same line, so we don't need innermost detection.
+//
+// Example:
+//
+//	func foo(db *gorm.DB) { //gormreuse:pure
+//	    ...
+//	}
+//
+// Edge case handled:
+// - External function bodies (funcDecl.Body == nil) return false
+func (s *DirectiveFuncSet) hasDirectiveAfterFuncDeclBrace(funcDecl *ast.FuncDecl) bool {
+	if s == nil || s.fset == nil || funcDecl.Body == nil {
+		return false
+	}
+	bracePos := s.fset.Position(funcDecl.Body.Lbrace)
+	return s.hasMatchingDirective(funcDecl, func(_ *ast.File, cg *ast.CommentGroup) bool {
+		return s.isCommentAfterBrace(cg, bracePos)
+	})
+}
+
+// isCommentAfterBrace checks if a comment is on the same line as a brace and appears after it.
+//
+// This is used for same-line directive detection:
+//
+//	func() { //comment  ← comment column > brace column, same line → true
+//	//comment           ← different line → false
+//	{ //comment         ← brace at column 1, comment at column 3 → true
+func (s *DirectiveFuncSet) isCommentAfterBrace(cg *ast.CommentGroup, bracePos token.Position) bool {
+	cgPos := s.fset.Position(cg.Pos())
+	return cgPos.Line == bracePos.Line && cgPos.Column > bracePos.Column
+}
+
+// hasDirectiveForFuncLit checks if a FuncLit has a directive comment.
+//
+// Unlike FuncDecl which has Doc comments, FuncLit (closures) don't have attached
+// documentation, so we need to search the file's comment list for directives.
+//
+// This supports two placement styles:
+//
+// # Next-line pattern
+//
+// Directive alone on its line (no code), applies to all direct FuncLits in the
+// same assignment statement on the next line:
+//
+//	//gormreuse:pure
+//	fn := func(q *gorm.DB) *gorm.DB { return q.Where("x") }
+//
+//	//gormreuse:pure
+//	a, b := func(){}, func(){}  ← both get the directive (same statement)
+//
+//	//gormreuse:pure
+//	a, b.Fn = func(){}, func(){}  ← both get the directive (direct assignment)
+//
+// Edge case: FuncLits inside composite literals (struct, slice, map) are NOT covered:
+//
+//	//gormreuse:pure
+//	a, b := func(){}, &S{Fn: func(){}}  ← only 'a' gets the directive
+//
+// # Same-line pattern
+//
+// Directive after opening brace on same line, applies to that FuncLit:
+//
+//	fn := func(q *gorm.DB) *gorm.DB { //gormreuse:pure
+//	    return q.Where("x")
+//	}
+//
+// Edge case: For nested closures, applies to the innermost FuncLit whose { is
+// immediately before the directive (not the outermost):
+//
+//	outer := func() { inner := func() { //gormreuse:pure  ← applies to inner, not outer
+//	    ...
+//	}}
+//
+// This "innermost" rule prevents ambiguity when closures are on the same line.
+func (s *DirectiveFuncSet) hasDirectiveForFuncLit(funcLit *ast.FuncLit) bool {
+	if s == nil || s.fset == nil {
+		return false
+	}
+	return s.hasMatchingDirective(funcLit, func(file *ast.File, cg *ast.CommentGroup) bool {
+		return s.matchesSameLineDirective(file, funcLit, cg) || s.matchesNextLineDirective(file, funcLit, cg)
+	})
+}
+
+// getFileForNode returns the AST file containing the given node.
+// It first checks for original files (from analysis), then falls back to re-parsing.
+func (s *DirectiveFuncSet) getFileForNode(node ast.Node) *ast.File {
+	pos := node.Pos()
+	if !pos.IsValid() {
+		return nil
+	}
+	filename := s.fset.Position(pos).Filename
+	if filename == "" {
+		return nil
+	}
+	// First, try to use the original file (avoids position mismatch)
+	if file, ok := s.files[filename]; ok {
+		return file
+	}
+	// Fall back to re-parsing (for external packages)
+	return s.parseFile(filename)
+}
+
+// commentGroupHasDirective checks if a comment group contains our directive.
+func (s *DirectiveFuncSet) commentGroupHasDirective(cg *ast.CommentGroup) bool {
+	for _, c := range cg.List {
+		if s.isDirective(c.Text) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesNextLineDirective checks if a directive comment applies to a FuncLit via
+// the "next-line" pattern: directive ends on line N, statement starts on line N+1,
+// and the FuncLit is a direct value in that statement.
+//
+// Requirements:
+//  1. Directive must be the only code on its line (not after }, or other code)
+//  2. Directive line(s) must have NO FuncLit on them (otherwise same-line applies)
+//  3. The FuncLit must be a DIRECT value in an assignment statement (not inside CompositeLit)
+//
+// All direct FuncLits in the same assignment statement get the directive:
+//
+//	//gormreuse:pure
+//	a, b := func(){}, func(){}  ← both get the directive
+//
+//	//gormreuse:pure
+//	a, b.Fn = func(){}, func(){}  ← both get the directive (direct assignment)
+//
+// FuncLits inside composite literals do NOT get the directive:
+//
+//	//gormreuse:pure
+//	a, b := func(){}, &S{Fn: func(){}}  ← only 'a' gets the directive
+//
+// Semicolon-separated statements are separate:
+//
+//	//gormreuse:pure
+//	a := func(){}; b := func(){}  ← only 'a' gets the directive
+//
+// Directive after code does NOT apply to next line:
+//
+//	}, //gormreuse:pure
+//	func(){}  ← does NOT get the directive (directive is not alone on its line)
+func (s *DirectiveFuncSet) matchesNextLineDirective(file *ast.File, funcLit *ast.FuncLit, cg *ast.CommentGroup) bool {
+	cgStartLine := s.fset.Position(cg.Pos()).Line
+	cgEndLine := s.fset.Position(cg.End()).Line
+
+	// Requirement 1: Directive must be alone on its line (no code before it)
+	if s.hasCodeBeforeComment(file, cg) {
+		return false
+	}
+
+	// Requirement 2: If there's any FuncLit on any line of the comment,
+	// this is a same-line pattern, not next-line
+	for line := cgStartLine; line <= cgEndLine; line++ {
+		if s.hasFuncLitOnLine(file, line) {
+			return false
+		}
+	}
+
+	// Find the enclosing assignment statement and check requirements
+	return s.isDirectValueInStatementAfterLine(file, funcLit, cgEndLine)
+}
+
+// matchesSameLineDirective checks if a directive comment applies to a FuncLit via
+// the "same-line" pattern: directive is after the FuncLit's opening brace on the same line.
+//
+// Requirements:
+//  1. Directive must be on the same line as FuncLit's opening brace
+//  2. Directive must be AFTER the brace (column > brace column)
+//  3. No nested FuncLit brace between this FuncLit's brace and the directive
+//
+// The "innermost" rule (requirement 3) is critical for nested closures:
+//
+//	outer := func() { inner := func() { //gormreuse:pure
+//	                  ^                 ^
+//	                  outer's {         inner's { (closer to comment)
+//
+// The directive applies to 'inner' because its { is between outer's { and the comment.
+//
+// Example (matches inner, not outer):
+//
+//	outer := func() { inner := func() { //gormreuse:pure  ← inner matches
+//
+// Example (matches outer - no nested brace):
+//
+//	outer := func() { //gormreuse:pure
+//	    inner := func() {}  ← inner is on different line
+//	}
+func (s *DirectiveFuncSet) matchesSameLineDirective(file *ast.File, funcLit *ast.FuncLit, cg *ast.CommentGroup) bool {
+	if funcLit.Body == nil {
+		return false
+	}
+
+	bracePos := s.fset.Position(funcLit.Body.Lbrace)
+
+	// Requirements 1 & 2: Comment must be after brace on same line
+	if !s.isCommentAfterBrace(cg, bracePos) {
+		return false
+	}
+
+	// Requirement 3: Check there's no nested FuncLit brace between this { and the comment
+	cgColumn := s.fset.Position(cg.Pos()).Column
+	return !s.hasNestedFuncLitBetween(funcLit, bracePos.Column, cgColumn, bracePos.Line)
+}
+
+// isDirectValueInStatementAfterLine checks if the FuncLit is a direct RHS value
+// in an assignment statement that relates to directiveLine+1.
+//
+// This handles both:
+//   - Statement starts on next line: //gormreuse:pure
+//     a, b := func(){}, func(){}  ← all direct FuncLits get directive
+//   - FuncLit starts on next line (multi-line): a, b := func(){},
+//     //gormreuse:pure
+//     func(){}  ← this FuncLit gets directive
+//
+// "Direct value" means not nested inside a composite literal (struct, slice, map).
+//
+// For semicolon-separated statements on the same line, only the FIRST statement applies:
+//
+//	a := func(){}; b := func(){}  ← only 'a' gets the directive
+func (s *DirectiveFuncSet) isDirectValueInStatementAfterLine(file *ast.File, funcLit *ast.FuncLit, directiveLine int) bool {
+	expectedLine := directiveLine + 1
+
+	// Find the path to the FuncLit using astutil
+	path, _ := astutil.PathEnclosingInterval(file, funcLit.Pos(), funcLit.End())
+	if path == nil {
+		return false
+	}
+
+	// Walk up the path to find the enclosing statement
+	var enclosingStmt ast.Stmt
+	for _, node := range path {
+		if stmt, ok := node.(ast.Stmt); ok {
+			enclosingStmt = stmt
+			break
+		}
+	}
+
+	if enclosingStmt == nil {
+		return false
+	}
+
+	stmtLine := s.fset.Position(enclosingStmt.Pos()).Line
+	funcLitLine := s.fset.Position(funcLit.Pos()).Line
+
+	// Case 1: Statement starts on expected line → all direct FuncLits in that statement
+	// Case 2: FuncLit starts on expected line → this specific FuncLit (multi-line assignment)
+	if stmtLine != expectedLine && funcLitLine != expectedLine {
+		return false
+	}
+
+	// For semicolon-separated statements, only the first statement applies
+	// Check based on which line is the expected line
+	checkLine := stmtLine
+	if stmtLine != expectedLine {
+		checkLine = funcLitLine
+	}
+	if !s.isFirstStatementOnLine(file, enclosingStmt, checkLine) {
+		return false
+	}
+
+	// Check if FuncLit is a direct value (not inside CompositeLit)
+	return s.isDirectRHSValue(enclosingStmt, funcLit)
+}
+
+// isFirstStatementOnLine checks if the given statement is the first (leftmost) one on its line.
+// This is important for semicolon-separated statements: `a := f1(); b := f2()`
+func (s *DirectiveFuncSet) isFirstStatementOnLine(file *ast.File, target ast.Stmt, line int) bool {
+	targetColumn := s.fset.Position(target.Pos()).Column
+	isFirst := true
+
+	// Check all function bodies in the file for statements on this line
+	ast.Inspect(file, func(n ast.Node) bool {
+		if !isFirst {
+			return false
+		}
+		if stmt, ok := n.(ast.Stmt); ok && stmt != target {
+			stmtPos := s.fset.Position(stmt.Pos())
+			if stmtPos.Line == line && stmtPos.Column < targetColumn {
+				// Found a statement earlier on the same line
+				isFirst = false
+				return false
+			}
+		}
+		return true
+	})
+	return isFirst
+}
+
+// isDirectRHSValue checks if the FuncLit is a direct RHS value in the statement,
+// not nested inside a composite literal (struct, slice, map, array).
+//
+// Note: We use position matching because the target FuncLit may be from a different
+// AST parse than stmt (SSA analysis vs our re-parsed file).
+func (s *DirectiveFuncSet) isDirectRHSValue(stmt ast.Stmt, target *ast.FuncLit) bool {
+	var rhsExprs []ast.Expr
+
+	switch st := stmt.(type) {
+	case *ast.AssignStmt:
+		rhsExprs = st.Rhs
+	case *ast.DeclStmt:
+		if gd, ok := st.Decl.(*ast.GenDecl); ok {
+			for _, spec := range gd.Specs {
+				if vs, ok := spec.(*ast.ValueSpec); ok {
+					rhsExprs = append(rhsExprs, vs.Values...)
+				}
+			}
+		}
+	default:
+		return false
+	}
+
+	targetPos := target.Pos()
+	targetEnd := target.End()
+
+	// Check if target is one of the direct RHS expressions
+	for _, rhs := range rhsExprs {
+		if s.isDirectExprOrUnaryByPos(rhs, targetPos, targetEnd) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDirectExprOrUnaryByPos checks if expr contains a FuncLit at the given position,
+// and that FuncLit is a direct expression or inside unary/paren (not inside CompositeLit).
+func (s *DirectiveFuncSet) isDirectExprOrUnaryByPos(expr ast.Expr, targetPos, targetEnd token.Pos) bool {
+	switch e := expr.(type) {
+	case *ast.FuncLit:
+		// Use position matching instead of identity
+		return e.Pos() == targetPos && e.End() == targetEnd
+	case *ast.UnaryExpr:
+		// Handle &func(){} case
+		return s.isDirectExprOrUnaryByPos(e.X, targetPos, targetEnd)
+	case *ast.ParenExpr:
+		// Handle (func(){}) case
+		return s.isDirectExprOrUnaryByPos(e.X, targetPos, targetEnd)
+	default:
+		// CompositeLit, CallExpr, IndexExpr, etc. - target is nested, not direct
+		return false
+	}
+}
+
+// hasFuncLitOnLine checks if there's any FuncLit that starts on the given line.
+func (s *DirectiveFuncSet) hasFuncLitOnLine(file *ast.File, line int) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if fl, ok := n.(*ast.FuncLit); ok {
+			if s.fset.Position(fl.Pos()).Line == line {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// hasCodeBeforeComment checks if there's any code (non-whitespace) before the comment on the same line.
+// This is used to determine if a directive is "alone" on its line or follows other code like "}, //gormreuse:pure".
+func (s *DirectiveFuncSet) hasCodeBeforeComment(file *ast.File, cg *ast.CommentGroup) bool {
+	cgPos := s.fset.Position(cg.Pos())
+	cgLine := cgPos.Line
+	cgColumn := cgPos.Column
+
+	// Check if any AST node ends on the same line before the comment
+	hasCode := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if hasCode {
+			return false
+		}
+		if n == nil || n == cg {
+			return true
+		}
+		// Skip comment groups
+		if _, ok := n.(*ast.CommentGroup); ok {
+			return true
+		}
+		if _, ok := n.(*ast.Comment); ok {
+			return true
+		}
+
+		nodeEnd := s.fset.Position(n.End())
+		// Node ends on the same line, before the comment
+		if nodeEnd.Line == cgLine && nodeEnd.Column < cgColumn {
+			hasCode = true
+			return false
+		}
+		return true
+	})
+	return hasCode
+}
+
+// hasNestedFuncLitBetween checks if there's a nested FuncLit whose opening brace
+// is between startColumn and endColumn on the given line.
+// This is used for same-line pattern to ensure the directive applies to the innermost FuncLit.
+func (s *DirectiveFuncSet) hasNestedFuncLitBetween(parent *ast.FuncLit, startColumn, endColumn, line int) bool {
+	found := false
+	ast.Inspect(parent.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if nested, ok := n.(*ast.FuncLit); ok && nested != parent {
+			if nested.Body != nil {
+				nestedPos := s.fset.Position(nested.Body.Lbrace)
+				if nestedPos.Line == line && nestedPos.Column > startColumn && nestedPos.Column < endColumn {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // parseFile parses a Go source file with caching.

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -1013,7 +1013,6 @@ func (t *RootTracer) traceIIFEReturns(fn *ssa.Function, visited map[ssa.Value]bo
 	return nil
 }
 
-
 // traceAllIIFEReturns is the multi-root version of traceIIFEReturns.
 // It collects roots from ALL return statements in the closure.
 func (t *RootTracer) traceAllIIFEReturns(fn *ssa.Function, visited map[ssa.Value]bool, loopInfo *cfg.LoopInfo) []ssa.Value {
@@ -1370,7 +1369,6 @@ func isNilConst(v ssa.Value) bool {
 	return ok && c.Value == nil
 }
 
-
 // isClosureResultStored checks if a closure call's result is stored in a variable.
 // This happens when the closure returns multiple values and the result is extracted.
 // Example: `publishedQuery, err := closureFunc()` - result goes through Extract.
@@ -1385,6 +1383,7 @@ func isNilConst(v ssa.Value) bool {
 //
 // Returns false (chained) for IIFE patterns like:
 //   - `closureFunc().Find(nil)` (result directly used as method receiver)
+//
 // isClosureResultStored checks if a closure call's result is stored (assigned to
 // a variable) rather than directly chained in an IIFE pattern.
 //

--- a/testdata/src/gormreuse/closure_directive.go.diff
+++ b/testdata/src/gormreuse/closure_directive.go.diff
@@ -1,0 +1,555 @@
+--- closure_directive.go	1970-01-01 00:00:00
++++ closure_directive.go.golden	1970-01-01 00:00:00
+@@ -1,541 +1,541 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // =============================================================================
+ // CLOSURE DIRECTIVE PATTERNS
+ // Tests for //gormreuse:pure and //gormreuse:immutable-return on closures
+ // =============================================================================
+ 
+ // =============================================================================
+ // PATTERN 1: Directive on line before closure
+ // =============================================================================
+ 
+ // closurePureBefore: Pure directive before closure declaration
+ func closurePureBefore(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	pureHelper := func(q *gorm.DB) {
+ 		_ = q // Just reads, doesn't modify
+ 	}
+ 
+ 	q := db.Where("base")
+ 	pureHelper(q) // pure - doesn't pollute q
+ 	q.Find(nil)   // OK - q is clean
+ }
+ 
+ // closureImmutableReturnBefore: immutable-return directive before closure
+ func closureImmutableReturnBefore(db *gorm.DB) {
+ 	//gormreuse:immutable-return
+ 	getDB := func() *gorm.DB {
+ 		return db.Session(&gorm.Session{}).Where("setup")
+ 	}
+ 
+ 	q := getDB()
+ 	q.Find(nil)
+ 	q.Count(nil) // OK - q is from immutable-return closure
+ }
+ 
+ // =============================================================================
+ // PATTERN 2: Directive after opening brace (inline)
+ // =============================================================================
+ 
+ // closurePureInline: Pure directive after opening brace
+ func closurePureInline(db *gorm.DB) {
+ 	pureHelper := func(q *gorm.DB) { //gormreuse:pure
+ 		_ = q
+ 	}
+ 
+ 	q := db.Where("base")
+ 	pureHelper(q)
+ 	q.Find(nil) // OK - q is clean
+ }
+ 
+ // closureImmutableReturnInline: immutable-return directive after opening brace
+ func closureImmutableReturnInline(db *gorm.DB) {
+ 	getDB := func() *gorm.DB { //gormreuse:immutable-return
+ 		return db.Session(&gorm.Session{}).Where("setup")
+ 	}
+ 
+ 	q := getDB()
+ 	q.Find(nil)
+ 	q.Count(nil) // OK - q is from immutable-return closure
+ }
+ 
+ // =============================================================================
+ // NO DIRECTIVE - SHOULD REPORT
+ // =============================================================================
+ 
+ // closureNoPure: No directive - closure pollutes argument
+ func closureNoPure(db *gorm.DB) {
+ 	impureHelper := func(q *gorm.DB) {
+ 		_ = q
+ 	}
+ 
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
+ 	impureHelper(q)
+ 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // closureNoImmutableReturn: No directive - closure result is mutable
+ func closureNoImmutableReturn(db *gorm.DB) {
+ 	getDB := func() *gorm.DB {
+-		return db.Session(&gorm.Session{}).Where("setup")
++		return db.Session(&gorm.Session{}).Where("setup").Session(&gorm.Session{})
+ 	}
+ 
+ 	q := getDB()
+ 	q.Find(nil)
+ 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // =============================================================================
+ // COMBINED DIRECTIVES
+ // =============================================================================
+ 
+ // closurePureAndImmutableReturn: Both directives on closure
+ func closurePureAndImmutableReturn(db *gorm.DB) {
+ 	//gormreuse:pure,immutable-return
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	q := helper(base) // pure - doesn't pollute base, immutable-return - q is immutable
+ 	base.Find(nil)    // OK - base is clean (helper is pure)
+ 	q.Find(nil)
+ 	q.Count(nil) // OK - q is immutable
+ }
+ 
+ // =============================================================================
+ // NESTED CLOSURES - Directive applies to immediate closure only
+ // =============================================================================
+ 
+ // nestedClosureOuterPure: Directive on outer closure (before pattern)
+ // Inner closure doesn't take *gorm.DB to avoid purity validation complexity
+ func nestedClosureOuterPure(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) {
+ 		inner := func() {
+ 			// do something
+ 		}
+ 		inner()
+ 		_ = q
+ 	}
+ 
+ 	q := db.Where("base")
+ 	outer(q)    // outer is pure
+ 	q.Find(nil) // OK - q is clean
+ }
+ 
+ // nestedClosureOuterPureViolation: Outer is pure but passes *gorm.DB to non-pure inner
+ // This should trigger a purity validation error
+ func nestedClosureOuterPureViolation(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) {
+ 		inner := func(q2 *gorm.DB) {
+ 			_ = q2
+ 		}
+ 		inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+ 	}
+ 
+ 	q := db.Where("base")
+ 	outer(q)    // outer is pure (but has internal violation)
+ 	q.Find(nil) // OK - q is clean (outer is still treated as pure for caller)
+ }
+ 
+ // nestedClosureOuterPureInnerPure: Both outer and inner are pure
+ func nestedClosureOuterPureInnerPure(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) {
+ 		//gormreuse:pure
+ 		inner := func(q2 *gorm.DB) {
+ 			_ = q2
+ 		}
+ 		inner(q) // OK - inner is also pure
+ 	}
+ 
+ 	q := db.Where("base")
+ 	outer(q)    // outer is pure
+ 	q.Find(nil) // OK - q is clean
+ }
+ 
+ // nestedClosureTripleNested: Three levels of nesting
+ // Only outer is pure, so only outer's call to middle triggers violation
+ func nestedClosureTripleNested(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) {
+ 		middle := func(q2 *gorm.DB) {
+ 			inner := func(q3 *gorm.DB) {
+ 				_ = q3
+ 			}
+ 			inner(q2) // middle is not pure, so no violation here
+ 		}
+ 		middle(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+ 	}
+ 
+ 	q := db.Where("base")
+ 	outer(q)
+ 	q.Find(nil) // OK
+ }
+ 
+ // nestedClosureInnerImmutableReturn: Inner returns immutable but is not pure
+ // Outer is pure but passes *gorm.DB to non-pure inner (immutable-return != pure)
+ func nestedClosureInnerImmutableReturn(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) *gorm.DB {
+ 		//gormreuse:immutable-return
+ 		inner := func(q2 *gorm.DB) *gorm.DB {
+ 			return q2.Session(&gorm.Session{})
+ 		}
+ 		return inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+ 	}
+ 
+ 	q := db.Where("base")
+-	result := outer(q)
++	result := outer(q).Session(&gorm.Session{})
+ 	q.Find(nil)      // OK - outer is pure
+ 	result.Find(nil) // outer's return is NOT immutable-return
+ 	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // nestedClosurePureImmutableReturnBoth: Outer has both directives
+ func nestedClosurePureImmutableReturnBoth(db *gorm.DB) {
+ 	//gormreuse:pure,immutable-return
+ 	outer := func(q *gorm.DB) *gorm.DB {
+ 		inner := func(q2 *gorm.DB) *gorm.DB {
+ 			return q2.Session(&gorm.Session{})
+ 		}
+ 		return inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+ 	}
+ 
+ 	q := db.Where("base")
+ 	result := outer(q)
+ 	q.Find(nil)       // OK - outer is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - outer is immutable-return
+ }
+ 
+ // nestedClosureSameLineBeforePattern: Only outer has directive, inner closure is on same line
+ // The directive should apply to outer, not inner (Pattern 1: before line)
+ func nestedClosureSameLineBeforePattern(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	outer := func(q *gorm.DB) { inner := func() {}; inner(); _ = q }
+ 
+ 	q := db.Where("base")
+ 	outer(q)    // outer is pure (directive is before outer)
+ 	q.Find(nil) // OK - q is clean
+ }
+ 
+ // nestedClosureSameLineInnerPure: Same line, directive AFTER inner's {
+ // The directive applies to inner only (innermost), outer is NOT pure
+ func nestedClosureSameLineInnerPure(db *gorm.DB) {
+ 	outer := func(q *gorm.DB) { inner := func(q2 *gorm.DB) { //gormreuse:pure
+ 		_ = q2
+ 	}; inner(q); _ = q }
+ 
+-	q := db.Where("base")
++	q := db.Where("base").Session(&gorm.Session{})
+ 	outer(q)    // outer is NOT pure (directive is for inner)
+ 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // nestedClosureSameLineOuterPure: Same line, directive AFTER outer's { but BEFORE inner's {
+ // The directive applies to outer only
+ func nestedClosureSameLineOuterPure(db *gorm.DB) {
+ 	outer := func(q *gorm.DB) { //gormreuse:pure
+ 		inner := func() {}; inner(); _ = q }
+ 
+ 	q := db.Where("base")
+ 	outer(q)    // outer is pure
+ 	q.Find(nil) // OK - q is clean
+ }
+ 
+ // =============================================================================
+ // COMPLEX DIRECTIVE COMBINATIONS - Multiple directives on closures
+ // =============================================================================
+ 
+ // complexDirective01: pure and immutable-return on separate lines
+ func complexDirective01(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	//gormreuse:immutable-return
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - base is clean (helper is pure)
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective02: pure and immutable-return with unrelated comment in between
+ func complexDirective02(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	//foo - this is just a regular comment
+ 	//gormreuse:immutable-return
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - base is clean (helper is pure)
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective03: pure,immutable-return combined in single directive
+ func complexDirective03(db *gorm.DB) {
+ 	//gormreuse:pure,immutable-return
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - helper is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective04: inline pattern with combined directive
+ func complexDirective04(db *gorm.DB) {
+ 	helper := func(q *gorm.DB) *gorm.DB { //gormreuse:pure,immutable-return
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - helper is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective05: pure only - result should be mutable
+ func complexDirective05(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+-	result := helper(base)
++	result := helper(base).Session(&gorm.Session{})
+ 	base.Find(nil) // OK - helper is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // complexDirective06: immutable-return only - argument should be polluted
+ func complexDirective06(db *gorm.DB) {
+ 	//gormreuse:immutable-return
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+-	base := db.Where("x")
++	base := db.Where("x").Session(&gorm.Session{})
+ 	result := helper(base)
+ 	base.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective07: multiple comments with trailing // comments
+ func complexDirective07(db *gorm.DB) {
+ 	//gormreuse:pure // marks as pure
+ 	//gormreuse:immutable-return // marks return as immutable
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - helper is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // complexDirective08: combined directive with trailing comment
+ func complexDirective08(db *gorm.DB) {
+ 	//gormreuse:pure,immutable-return // both in one
+ 	helper := func(q *gorm.DB) *gorm.DB {
+ 		return q.Session(&gorm.Session{})
+ 	}
+ 
+ 	base := db.Where("x")
+ 	result := helper(base)
+ 	base.Find(nil) // OK - helper is pure
+ 	result.Find(nil)
+ 	result.Count(nil) // OK - result is immutable
+ }
+ 
+ // =============================================================================
+ // MULTI-ASSIGNMENT PATTERNS
+ // Directive on line before multi-assignment covers all direct FuncLits
+ // =============================================================================
+ 
+ // structWithFuncField is used to test field assignment patterns
+ type structWithFuncField struct {
+ 	Fn func(q *gorm.DB)
+ }
+ 
+ // multiAssign01: Both closures in same assignment get the directive
+ func multiAssign01(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+ 	q2 := db.Where("base2")
+ 	b(q2)
+ 	q2.Find(nil) // OK - b is also pure (same statement)
+ }
+ 
+ // multiAssign02: Both variables get directive (direct assignment)
+ func multiAssign02(db *gorm.DB) {
+ 	var a, c func(q *gorm.DB)
+ 
+ 	//gormreuse:pure
+ 	a, c = func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+ 	q2 := db.Where("base2")
+ 	c(q2)
+ 	q2.Find(nil) // OK - c is also pure (same statement)
+ }
+ 
+ // multiAssign03: Only first closure gets directive (second is inside struct literal)
+ func multiAssign03(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a, b := func(q *gorm.DB) { _ = q }, &structWithFuncField{Fn: func(q *gorm.DB) { _ = q }}
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+-	q2 := db.Where("base2")
++	q2 := db.Where("base2").Session(&gorm.Session{})
+ 	b.Fn(q2)
+ 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // multiAssign04: Three closures - first two direct, third in composite literal
+ func multiAssign04(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a, b, c := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }, []func(*gorm.DB){func(q *gorm.DB) { _ = q }}[0]
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+ 	q2 := db.Where("base2")
+ 	b(q2)
+ 	q2.Find(nil) // OK - b is pure
+ 
+-	q3 := db.Where("base3")
++	q3 := db.Where("base3").Session(&gorm.Session{})
+ 	c(q3)
+ 	q3.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // multiAssign05: Separated statements - only first gets directive
+ func multiAssign05(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a := func(q *gorm.DB) { _ = q }
+ 	b := func(q *gorm.DB) { _ = q } // Different statement, no directive
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+-	q2 := db.Where("base2")
++	q2 := db.Where("base2").Session(&gorm.Session{})
+ 	b(q2)
+ 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // multiAssign06: Semicolon-separated on same line - only first statement gets directive
+ func multiAssign06(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a := func(q *gorm.DB) { _ = q }; b := func(q *gorm.DB) { _ = q }
+ 
+ 	q := db.Where("base")
+ 	a(q)
+ 	q.Find(nil) // OK - a is pure
+ 
+-	q2 := db.Where("base2")
++	q2 := db.Where("base2").Session(&gorm.Session{})
+ 	b(q2)
+ 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // multiAssign07: Multi-line assignment - all closures in same statement get directive
+ func multiAssign07(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a, b, c := func(q *gorm.DB) { _ = q },
+ 		func(q *gorm.DB) { _ = q },
+ 		func(q *gorm.DB) { _ = q }
+ 
+ 	q1 := db.Where("base1")
+ 	a(q1)
+ 	q1.Find(nil) // OK - a is pure
+ 
+ 	q2 := db.Where("base2")
+ 	b(q2)
+ 	q2.Find(nil) // OK - b is pure (same statement, different line)
+ 
+ 	q3 := db.Where("base3")
+ 	c(q3)
+ 	q3.Find(nil) // OK - c is pure (same statement, different line)
+ }
+ 
+ 
+ // multiAssign08: Multi-line assignment with comments between closures
+ func multiAssign08(db *gorm.DB) {
+ 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
+ 		_ = q
+ 	},
+ 		//gormreuse:pure
+ 		func(q *gorm.DB) {
+ 			_ = q
+ 		},
+ 		func(q *gorm.DB) { //gormreuse:pure
+ 			_ = q
+ 		}
+ 
+ 	q1 := db.Where("base1")
+ 	a(q1)
+ 	q1.Find(nil) // OK - a is pure
+ 
+ 	q2 := db.Where("base2")
+ 	b(q2)
+ 	q2.Find(nil) // OK - b is pure
+ 
+ 	q3 := db.Where("base3")
+ 	c(q3)
+ 	q3.Find(nil) // OK - c is pure
+ }
+ 
+ 
+ // multiAssign09: Directive after closing brace does NOT apply to next line
+ // }, //gormreuse:pure should not apply to the FuncLit on the next line
+ func multiAssign09(db *gorm.DB) {
+ 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
+ 		_ = q
+ 	}, //gormreuse:pure
+ 		func(q *gorm.DB) {
+ 			_ = q
+ 		}, func(q *gorm.DB) { //gormreuse:pure
+ 		_ = q
+ 	}
+ 
+ 	q1 := db.Where("base1")
+ 	a(q1)
+ 	q1.Find(nil) // OK - a is pure
+ 
+-	q2 := db.Where("base2")
++	q2 := db.Where("base2").Session(&gorm.Session{})
+ 	b(q2)
+ 	q2.Find(nil) // want "reused"
+ 
+ 	q3 := db.Where("base3")
+ 	c(q3)
+ 	q3.Find(nil) // OK - c is pure
+ }

--- a/testdata/src/gormreuse/closure_directive.go.golden
+++ b/testdata/src/gormreuse/closure_directive.go.golden
@@ -1,0 +1,541 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// CLOSURE DIRECTIVE PATTERNS
+// Tests for //gormreuse:pure and //gormreuse:immutable-return on closures
+// =============================================================================
+
+// =============================================================================
+// PATTERN 1: Directive on line before closure
+// =============================================================================
+
+// closurePureBefore: Pure directive before closure declaration
+func closurePureBefore(db *gorm.DB) {
+	//gormreuse:pure
+	pureHelper := func(q *gorm.DB) {
+		_ = q // Just reads, doesn't modify
+	}
+
+	q := db.Where("base")
+	pureHelper(q) // pure - doesn't pollute q
+	q.Find(nil)   // OK - q is clean
+}
+
+// closureImmutableReturnBefore: immutable-return directive before closure
+func closureImmutableReturnBefore(db *gorm.DB) {
+	//gormreuse:immutable-return
+	getDB := func() *gorm.DB {
+		return db.Session(&gorm.Session{}).Where("setup")
+	}
+
+	q := getDB()
+	q.Find(nil)
+	q.Count(nil) // OK - q is from immutable-return closure
+}
+
+// =============================================================================
+// PATTERN 2: Directive after opening brace (inline)
+// =============================================================================
+
+// closurePureInline: Pure directive after opening brace
+func closurePureInline(db *gorm.DB) {
+	pureHelper := func(q *gorm.DB) { //gormreuse:pure
+		_ = q
+	}
+
+	q := db.Where("base")
+	pureHelper(q)
+	q.Find(nil) // OK - q is clean
+}
+
+// closureImmutableReturnInline: immutable-return directive after opening brace
+func closureImmutableReturnInline(db *gorm.DB) {
+	getDB := func() *gorm.DB { //gormreuse:immutable-return
+		return db.Session(&gorm.Session{}).Where("setup")
+	}
+
+	q := getDB()
+	q.Find(nil)
+	q.Count(nil) // OK - q is from immutable-return closure
+}
+
+// =============================================================================
+// NO DIRECTIVE - SHOULD REPORT
+// =============================================================================
+
+// closureNoPure: No directive - closure pollutes argument
+func closureNoPure(db *gorm.DB) {
+	impureHelper := func(q *gorm.DB) {
+		_ = q
+	}
+
+	q := db.Where("base").Session(&gorm.Session{})
+	impureHelper(q)
+	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// closureNoImmutableReturn: No directive - closure result is mutable
+func closureNoImmutableReturn(db *gorm.DB) {
+	getDB := func() *gorm.DB {
+		return db.Session(&gorm.Session{}).Where("setup").Session(&gorm.Session{})
+	}
+
+	q := getDB()
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// =============================================================================
+// COMBINED DIRECTIVES
+// =============================================================================
+
+// closurePureAndImmutableReturn: Both directives on closure
+func closurePureAndImmutableReturn(db *gorm.DB) {
+	//gormreuse:pure,immutable-return
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	q := helper(base) // pure - doesn't pollute base, immutable-return - q is immutable
+	base.Find(nil)    // OK - base is clean (helper is pure)
+	q.Find(nil)
+	q.Count(nil) // OK - q is immutable
+}
+
+// =============================================================================
+// NESTED CLOSURES - Directive applies to immediate closure only
+// =============================================================================
+
+// nestedClosureOuterPure: Directive on outer closure (before pattern)
+// Inner closure doesn't take *gorm.DB to avoid purity validation complexity
+func nestedClosureOuterPure(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) {
+		inner := func() {
+			// do something
+		}
+		inner()
+		_ = q
+	}
+
+	q := db.Where("base")
+	outer(q)    // outer is pure
+	q.Find(nil) // OK - q is clean
+}
+
+// nestedClosureOuterPureViolation: Outer is pure but passes *gorm.DB to non-pure inner
+// This should trigger a purity validation error
+func nestedClosureOuterPureViolation(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) {
+		inner := func(q2 *gorm.DB) {
+			_ = q2
+		}
+		inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+	}
+
+	q := db.Where("base")
+	outer(q)    // outer is pure (but has internal violation)
+	q.Find(nil) // OK - q is clean (outer is still treated as pure for caller)
+}
+
+// nestedClosureOuterPureInnerPure: Both outer and inner are pure
+func nestedClosureOuterPureInnerPure(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) {
+		//gormreuse:pure
+		inner := func(q2 *gorm.DB) {
+			_ = q2
+		}
+		inner(q) // OK - inner is also pure
+	}
+
+	q := db.Where("base")
+	outer(q)    // outer is pure
+	q.Find(nil) // OK - q is clean
+}
+
+// nestedClosureTripleNested: Three levels of nesting
+// Only outer is pure, so only outer's call to middle triggers violation
+func nestedClosureTripleNested(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) {
+		middle := func(q2 *gorm.DB) {
+			inner := func(q3 *gorm.DB) {
+				_ = q3
+			}
+			inner(q2) // middle is not pure, so no violation here
+		}
+		middle(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+	}
+
+	q := db.Where("base")
+	outer(q)
+	q.Find(nil) // OK
+}
+
+// nestedClosureInnerImmutableReturn: Inner returns immutable but is not pure
+// Outer is pure but passes *gorm.DB to non-pure inner (immutable-return != pure)
+func nestedClosureInnerImmutableReturn(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) *gorm.DB {
+		//gormreuse:immutable-return
+		inner := func(q2 *gorm.DB) *gorm.DB {
+			return q2.Session(&gorm.Session{})
+		}
+		return inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+	}
+
+	q := db.Where("base")
+	result := outer(q).Session(&gorm.Session{})
+	q.Find(nil)      // OK - outer is pure
+	result.Find(nil) // outer's return is NOT immutable-return
+	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// nestedClosurePureImmutableReturnBoth: Outer has both directives
+func nestedClosurePureImmutableReturnBoth(db *gorm.DB) {
+	//gormreuse:pure,immutable-return
+	outer := func(q *gorm.DB) *gorm.DB {
+		inner := func(q2 *gorm.DB) *gorm.DB {
+			return q2.Session(&gorm.Session{})
+		}
+		return inner(q) // want `pure function passes \*gorm\.DB argument to non-pure function`
+	}
+
+	q := db.Where("base")
+	result := outer(q)
+	q.Find(nil)       // OK - outer is pure
+	result.Find(nil)
+	result.Count(nil) // OK - outer is immutable-return
+}
+
+// nestedClosureSameLineBeforePattern: Only outer has directive, inner closure is on same line
+// The directive should apply to outer, not inner (Pattern 1: before line)
+func nestedClosureSameLineBeforePattern(db *gorm.DB) {
+	//gormreuse:pure
+	outer := func(q *gorm.DB) { inner := func() {}; inner(); _ = q }
+
+	q := db.Where("base")
+	outer(q)    // outer is pure (directive is before outer)
+	q.Find(nil) // OK - q is clean
+}
+
+// nestedClosureSameLineInnerPure: Same line, directive AFTER inner's {
+// The directive applies to inner only (innermost), outer is NOT pure
+func nestedClosureSameLineInnerPure(db *gorm.DB) {
+	outer := func(q *gorm.DB) { inner := func(q2 *gorm.DB) { //gormreuse:pure
+		_ = q2
+	}; inner(q); _ = q }
+
+	q := db.Where("base").Session(&gorm.Session{})
+	outer(q)    // outer is NOT pure (directive is for inner)
+	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// nestedClosureSameLineOuterPure: Same line, directive AFTER outer's { but BEFORE inner's {
+// The directive applies to outer only
+func nestedClosureSameLineOuterPure(db *gorm.DB) {
+	outer := func(q *gorm.DB) { //gormreuse:pure
+		inner := func() {}; inner(); _ = q }
+
+	q := db.Where("base")
+	outer(q)    // outer is pure
+	q.Find(nil) // OK - q is clean
+}
+
+// =============================================================================
+// COMPLEX DIRECTIVE COMBINATIONS - Multiple directives on closures
+// =============================================================================
+
+// complexDirective01: pure and immutable-return on separate lines
+func complexDirective01(db *gorm.DB) {
+	//gormreuse:pure
+	//gormreuse:immutable-return
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - base is clean (helper is pure)
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective02: pure and immutable-return with unrelated comment in between
+func complexDirective02(db *gorm.DB) {
+	//gormreuse:pure
+	//foo - this is just a regular comment
+	//gormreuse:immutable-return
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - base is clean (helper is pure)
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective03: pure,immutable-return combined in single directive
+func complexDirective03(db *gorm.DB) {
+	//gormreuse:pure,immutable-return
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - helper is pure
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective04: inline pattern with combined directive
+func complexDirective04(db *gorm.DB) {
+	helper := func(q *gorm.DB) *gorm.DB { //gormreuse:pure,immutable-return
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - helper is pure
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective05: pure only - result should be mutable
+func complexDirective05(db *gorm.DB) {
+	//gormreuse:pure
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base).Session(&gorm.Session{})
+	base.Find(nil) // OK - helper is pure
+	result.Find(nil)
+	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// complexDirective06: immutable-return only - argument should be polluted
+func complexDirective06(db *gorm.DB) {
+	//gormreuse:immutable-return
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x").Session(&gorm.Session{})
+	result := helper(base)
+	base.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective07: multiple comments with trailing // comments
+func complexDirective07(db *gorm.DB) {
+	//gormreuse:pure // marks as pure
+	//gormreuse:immutable-return // marks return as immutable
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - helper is pure
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// complexDirective08: combined directive with trailing comment
+func complexDirective08(db *gorm.DB) {
+	//gormreuse:pure,immutable-return // both in one
+	helper := func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{})
+	}
+
+	base := db.Where("x")
+	result := helper(base)
+	base.Find(nil) // OK - helper is pure
+	result.Find(nil)
+	result.Count(nil) // OK - result is immutable
+}
+
+// =============================================================================
+// MULTI-ASSIGNMENT PATTERNS
+// Directive on line before multi-assignment covers all direct FuncLits
+// =============================================================================
+
+// structWithFuncField is used to test field assignment patterns
+type structWithFuncField struct {
+	Fn func(q *gorm.DB)
+}
+
+// multiAssign01: Both closures in same assignment get the directive
+func multiAssign01(db *gorm.DB) {
+	//gormreuse:pure
+	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2")
+	b(q2)
+	q2.Find(nil) // OK - b is also pure (same statement)
+}
+
+// multiAssign02: Both variables get directive (direct assignment)
+func multiAssign02(db *gorm.DB) {
+	var a, c func(q *gorm.DB)
+
+	//gormreuse:pure
+	a, c = func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2")
+	c(q2)
+	q2.Find(nil) // OK - c is also pure (same statement)
+}
+
+// multiAssign03: Only first closure gets directive (second is inside struct literal)
+func multiAssign03(db *gorm.DB) {
+	//gormreuse:pure
+	a, b := func(q *gorm.DB) { _ = q }, &structWithFuncField{Fn: func(q *gorm.DB) { _ = q }}
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2").Session(&gorm.Session{})
+	b.Fn(q2)
+	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// multiAssign04: Three closures - first two direct, third in composite literal
+func multiAssign04(db *gorm.DB) {
+	//gormreuse:pure
+	a, b, c := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }, []func(*gorm.DB){func(q *gorm.DB) { _ = q }}[0]
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2")
+	b(q2)
+	q2.Find(nil) // OK - b is pure
+
+	q3 := db.Where("base3").Session(&gorm.Session{})
+	c(q3)
+	q3.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// multiAssign05: Separated statements - only first gets directive
+func multiAssign05(db *gorm.DB) {
+	//gormreuse:pure
+	a := func(q *gorm.DB) { _ = q }
+	b := func(q *gorm.DB) { _ = q } // Different statement, no directive
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2").Session(&gorm.Session{})
+	b(q2)
+	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// multiAssign06: Semicolon-separated on same line - only first statement gets directive
+func multiAssign06(db *gorm.DB) {
+	//gormreuse:pure
+	a := func(q *gorm.DB) { _ = q }; b := func(q *gorm.DB) { _ = q }
+
+	q := db.Where("base")
+	a(q)
+	q.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2").Session(&gorm.Session{})
+	b(q2)
+	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// multiAssign07: Multi-line assignment - all closures in same statement get directive
+func multiAssign07(db *gorm.DB) {
+	//gormreuse:pure
+	a, b, c := func(q *gorm.DB) { _ = q },
+		func(q *gorm.DB) { _ = q },
+		func(q *gorm.DB) { _ = q }
+
+	q1 := db.Where("base1")
+	a(q1)
+	q1.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2")
+	b(q2)
+	q2.Find(nil) // OK - b is pure (same statement, different line)
+
+	q3 := db.Where("base3")
+	c(q3)
+	q3.Find(nil) // OK - c is pure (same statement, different line)
+}
+
+
+// multiAssign08: Multi-line assignment with comments between closures
+func multiAssign08(db *gorm.DB) {
+	a, b, c := func(q *gorm.DB) { //gormreuse:pure
+		_ = q
+	},
+		//gormreuse:pure
+		func(q *gorm.DB) {
+			_ = q
+		},
+		func(q *gorm.DB) { //gormreuse:pure
+			_ = q
+		}
+
+	q1 := db.Where("base1")
+	a(q1)
+	q1.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2")
+	b(q2)
+	q2.Find(nil) // OK - b is pure
+
+	q3 := db.Where("base3")
+	c(q3)
+	q3.Find(nil) // OK - c is pure
+}
+
+
+// multiAssign09: Directive after closing brace does NOT apply to next line
+// }, //gormreuse:pure should not apply to the FuncLit on the next line
+func multiAssign09(db *gorm.DB) {
+	a, b, c := func(q *gorm.DB) { //gormreuse:pure
+		_ = q
+	}, //gormreuse:pure
+		func(q *gorm.DB) {
+			_ = q
+		}, func(q *gorm.DB) { //gormreuse:pure
+		_ = q
+	}
+
+	q1 := db.Where("base1")
+	a(q1)
+	q1.Find(nil) // OK - a is pure
+
+	q2 := db.Where("base2").Session(&gorm.Session{})
+	b(q2)
+	q2.Find(nil) // want "reused"
+
+	q3 := db.Where("base3")
+	c(q3)
+	q3.Find(nil) // OK - c is pure
+}

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -894,6 +894,98 @@ func useNestedPureImmutable(db *gorm.DB) {
 }
 
 // =============================================================================
+// MULTI-LINE DIRECTIVE COMBINATIONS (FuncDecl)
+//
+// Tests for directives on separate lines for named functions.
+// =============================================================================
+
+// PIR301: pure and immutable-return on separate lines (FuncDecl)
+//
+//gormreuse:pure
+//gormreuse:immutable-return
+func multiLinePureImmutable(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLinePureImmutable(db *gorm.DB) {
+	result := multiLinePureImmutable(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// PIR302: pure and immutable-return with unrelated comment in between (FuncDecl)
+//
+//gormreuse:pure
+// This is an unrelated comment
+//gormreuse:immutable-return
+func multiLinePureImmutableWithComment(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLinePureImmutableWithComment(db *gorm.DB) {
+	result := multiLinePureImmutableWithComment(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// PIR303: directives with trailing comments (FuncDecl)
+//
+//gormreuse:pure // marks as pure
+//gormreuse:immutable-return // marks return as immutable
+func multiLineWithTrailing(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLineWithTrailing(db *gorm.DB) {
+	result := multiLineWithTrailing(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// =============================================================================
+// SAME-LINE DIRECTIVE (FuncDecl)
+//
+// Tests for directives after opening brace on same line for named functions.
+// =============================================================================
+
+// PIR401: pure directive after opening brace (FuncDecl)
+func sameLinePure(db *gorm.DB) { //gormreuse:pure
+	_ = db
+}
+
+func useSameLinePure(db *gorm.DB) {
+	q := db.Where("x")
+	sameLinePure(q)
+	q.Find(nil) // OK: sameLinePure is pure
+}
+
+// PIR402: immutable-return directive after opening brace (FuncDecl)
+func sameLineImmutableReturn(db *gorm.DB) *gorm.DB { //gormreuse:immutable-return
+	return db.Session(&gorm.Session{})
+}
+
+func useSameLineImmutableReturn(db *gorm.DB) {
+	result := sameLineImmutableReturn(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+}
+
+// PIR403: combined directive after opening brace (FuncDecl)
+func sameLinePureImmutable(db *gorm.DB) *gorm.DB { //gormreuse:pure,immutable-return
+	return db.Session(&gorm.Session{})
+}
+
+func useSameLinePureImmutable(db *gorm.DB) {
+	result := sameLinePureImmutable(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// =============================================================================
 // HELPER - Global DB for testing
 // =============================================================================
 

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,900 +1,900 @@
+@@ -1,992 +1,992 @@
  package internal
  
  import "gorm.io/gorm"
@@ -896,6 +896,98 @@
  	result.Where("x").Find(nil)
  	result.Where("y").Find(nil) // OK: returns immutable
  	db.Find(nil)                // OK: db not polluted
+ }
+ 
+ // =============================================================================
+ // MULTI-LINE DIRECTIVE COMBINATIONS (FuncDecl)
+ //
+ // Tests for directives on separate lines for named functions.
+ // =============================================================================
+ 
+ // PIR301: pure and immutable-return on separate lines (FuncDecl)
+ //
+ //gormreuse:pure
+ //gormreuse:immutable-return
+ func multiLinePureImmutable(db *gorm.DB) *gorm.DB {
+ 	return db.Session(&gorm.Session{})
+ }
+ 
+ func useMultiLinePureImmutable(db *gorm.DB) {
+ 	result := multiLinePureImmutable(db)
+ 	result.Where("x").Find(nil)
+ 	result.Where("y").Find(nil) // OK: returns immutable
+ 	db.Find(nil)                // OK: db not polluted (pure)
+ }
+ 
+ // PIR302: pure and immutable-return with unrelated comment in between (FuncDecl)
+ //
+ //gormreuse:pure
+ // This is an unrelated comment
+ //gormreuse:immutable-return
+ func multiLinePureImmutableWithComment(db *gorm.DB) *gorm.DB {
+ 	return db.Session(&gorm.Session{})
+ }
+ 
+ func useMultiLinePureImmutableWithComment(db *gorm.DB) {
+ 	result := multiLinePureImmutableWithComment(db)
+ 	result.Where("x").Find(nil)
+ 	result.Where("y").Find(nil) // OK: returns immutable
+ 	db.Find(nil)                // OK: db not polluted (pure)
+ }
+ 
+ // PIR303: directives with trailing comments (FuncDecl)
+ //
+ //gormreuse:pure // marks as pure
+ //gormreuse:immutable-return // marks return as immutable
+ func multiLineWithTrailing(db *gorm.DB) *gorm.DB {
+ 	return db.Session(&gorm.Session{})
+ }
+ 
+ func useMultiLineWithTrailing(db *gorm.DB) {
+ 	result := multiLineWithTrailing(db)
+ 	result.Where("x").Find(nil)
+ 	result.Where("y").Find(nil) // OK: returns immutable
+ 	db.Find(nil)                // OK: db not polluted (pure)
+ }
+ 
+ // =============================================================================
+ // SAME-LINE DIRECTIVE (FuncDecl)
+ //
+ // Tests for directives after opening brace on same line for named functions.
+ // =============================================================================
+ 
+ // PIR401: pure directive after opening brace (FuncDecl)
+ func sameLinePure(db *gorm.DB) { //gormreuse:pure
+ 	_ = db
+ }
+ 
+ func useSameLinePure(db *gorm.DB) {
+ 	q := db.Where("x")
+ 	sameLinePure(q)
+ 	q.Find(nil) // OK: sameLinePure is pure
+ }
+ 
+ // PIR402: immutable-return directive after opening brace (FuncDecl)
+ func sameLineImmutableReturn(db *gorm.DB) *gorm.DB { //gormreuse:immutable-return
+ 	return db.Session(&gorm.Session{})
+ }
+ 
+ func useSameLineImmutableReturn(db *gorm.DB) {
+ 	result := sameLineImmutableReturn(db)
+ 	result.Where("x").Find(nil)
+ 	result.Where("y").Find(nil) // OK: returns immutable
+ }
+ 
+ // PIR403: combined directive after opening brace (FuncDecl)
+ func sameLinePureImmutable(db *gorm.DB) *gorm.DB { //gormreuse:pure,immutable-return
+ 	return db.Session(&gorm.Session{})
+ }
+ 
+ func useSameLinePureImmutable(db *gorm.DB) {
+ 	result := sameLinePureImmutable(db)
+ 	result.Where("x").Find(nil)
+ 	result.Where("y").Find(nil) // OK: returns immutable
+ 	db.Find(nil)                // OK: db not polluted (pure)
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -894,6 +894,98 @@ func useNestedPureImmutable(db *gorm.DB) {
 }
 
 // =============================================================================
+// MULTI-LINE DIRECTIVE COMBINATIONS (FuncDecl)
+//
+// Tests for directives on separate lines for named functions.
+// =============================================================================
+
+// PIR301: pure and immutable-return on separate lines (FuncDecl)
+//
+//gormreuse:pure
+//gormreuse:immutable-return
+func multiLinePureImmutable(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLinePureImmutable(db *gorm.DB) {
+	result := multiLinePureImmutable(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// PIR302: pure and immutable-return with unrelated comment in between (FuncDecl)
+//
+//gormreuse:pure
+// This is an unrelated comment
+//gormreuse:immutable-return
+func multiLinePureImmutableWithComment(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLinePureImmutableWithComment(db *gorm.DB) {
+	result := multiLinePureImmutableWithComment(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// PIR303: directives with trailing comments (FuncDecl)
+//
+//gormreuse:pure // marks as pure
+//gormreuse:immutable-return // marks return as immutable
+func multiLineWithTrailing(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{})
+}
+
+func useMultiLineWithTrailing(db *gorm.DB) {
+	result := multiLineWithTrailing(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// =============================================================================
+// SAME-LINE DIRECTIVE (FuncDecl)
+//
+// Tests for directives after opening brace on same line for named functions.
+// =============================================================================
+
+// PIR401: pure directive after opening brace (FuncDecl)
+func sameLinePure(db *gorm.DB) { //gormreuse:pure
+	_ = db
+}
+
+func useSameLinePure(db *gorm.DB) {
+	q := db.Where("x")
+	sameLinePure(q)
+	q.Find(nil) // OK: sameLinePure is pure
+}
+
+// PIR402: immutable-return directive after opening brace (FuncDecl)
+func sameLineImmutableReturn(db *gorm.DB) *gorm.DB { //gormreuse:immutable-return
+	return db.Session(&gorm.Session{})
+}
+
+func useSameLineImmutableReturn(db *gorm.DB) {
+	result := sameLineImmutableReturn(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+}
+
+// PIR403: combined directive after opening brace (FuncDecl)
+func sameLinePureImmutable(db *gorm.DB) *gorm.DB { //gormreuse:pure,immutable-return
+	return db.Session(&gorm.Session{})
+}
+
+func useSameLinePureImmutable(db *gorm.DB) {
+	result := sameLinePureImmutable(db)
+	result.Where("x").Find(nil)
+	result.Where("y").Find(nil) // OK: returns immutable
+	db.Find(nil)                // OK: db not polluted (pure)
+}
+
+// =============================================================================
 // HELPER - Global DB for testing
 // =============================================================================
 


### PR DESCRIPTION
## Summary
Add support for `//gormreuse:pure` and `//gormreuse:immutable-return` directives on:
- Function literals (closures)
- Named functions (FuncDecl) - **same-line pattern newly supported**

## Supported Patterns

### Next-line: Directive on line before function/closure
```go
//gormreuse:pure
func foo(db *gorm.DB) { ... }

//gormreuse:pure
fn := func(q *gorm.DB) { ... }
```

### Same-line: Directive after opening brace
```go
func foo(db *gorm.DB) { //gormreuse:pure
    ...
}

fn := func(q *gorm.DB) { //gormreuse:pure
    ...
}
```

### Multi-assignment: All direct closures get the directive
```go
//gormreuse:pure
a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
// Both a and b are marked as pure
```

### Multi-line assignment with individual directives
```go
a, b := func(q *gorm.DB) { //gormreuse:pure
    _ = q
},
    //gormreuse:pure
    func(q *gorm.DB) {
        _ = q
    }
```

### Directive after closing brace does NOT apply to next line
```go
}, //gormreuse:pure   // This is NOT a next-line directive
    func(q *gorm.DB) { ... }  // Does NOT get the directive
```

### Nested Closures
For nested closures, same-line directive applies to the **innermost** FuncLit whose `{` immediately precedes the directive:

```go
outer := func() { inner := func() { //gormreuse:pure  // applies to inner
    ...
}}
```

## Implementation Details

- `hasDirectiveAfterFuncDeclBrace` - Same-line pattern for FuncDecl
- `hasDirectiveForFuncLit` - Next-line and same-line patterns for FuncLit
- `isDirectValueInStatementAfterLine` - Multi-assignment support
- `hasCodeBeforeComment` - Detects `}, //directive` pattern
- Shared helpers for position checking and pattern matching

## Test Plan

### Closure tests
- [x] Next-line pattern with pure directive
- [x] Same-line pattern with pure directive
- [x] immutable-return directive patterns
- [x] Combined directives (pure,immutable-return)
- [x] No directive cases (should report violations)

### Multi-assignment tests
- [x] `a, b := func(){}, func(){}` - both get directive
- [x] `a, b := func(){}, &S{Fn: func(){}}` - only direct closures
- [x] Multi-line assignments with comments between closures
- [x] `}, //gormreuse:pure` does NOT apply to next line

### Edge cases
- [x] Nested closures (innermost rule)
- [x] Triple-nested closures
- [x] Semicolon-separated statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)