### PR TITLE
feat: detect unused pure and immutable-return directives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
 
 > **Important**: User-defined functions that accept `*gorm.DB` are treated as polluting **unless** the function returns `*gorm.DB` and the result is assigned (e.g., `q = helper(q)`). In that case, it's treated like a gorm method assignment. Use `//gormreuse:pure` to mark functions that don't pollute arguments even when result is discarded, and `//gormreuse:immutable-return` to mark functions whose return value can be safely reused (like DB connection helpers).
 
+> **Note**: Unused directives are reported as warnings:
+> - Unused `//gormreuse:ignore` - line/function-level ignores that suppress no violations
+> - Unused `//gormreuse:pure` - directives that don't match any function
+> - Unused `//gormreuse:immutable-return` - directives that don't match any function
+> - For combined directives (`//gormreuse:pure,immutable-return`), if either part is used, no unused warning is reported
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ func useIt(db *gorm.DB) {
 }
 ```
 
+> [!WARNING]
+> Unused `//gormreuse:pure` and `//gormreuse:immutable-return` directives are reported as warnings. This helps identify misplaced or stale directives. For combined directives like `//gormreuse:pure,immutable-return`, if either part is used, no unused warning is reported.
+
 ## Documentation
 
 - [CLAUDE.md](./CLAUDE.md) - AI assistant guidance for development

--- a/testdata/src/gormreuse/closure_directive.go
+++ b/testdata/src/gormreuse/closure_directive.go
@@ -182,7 +182,7 @@ func nestedClosureTripleNested(db *gorm.DB) {
 func nestedClosureInnerImmutableReturn(db *gorm.DB) {
 	//gormreuse:pure
 	outer := func(q *gorm.DB) *gorm.DB {
-		//gormreuse:immutable-return
+		//gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
 		inner := func(q2 *gorm.DB) *gorm.DB {
 			return q2.Session(&gorm.Session{})
 		}
@@ -520,7 +520,7 @@ func multiAssign08(db *gorm.DB) {
 func multiAssign09(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q
-	}, //gormreuse:pure
+	}, //gormreuse:pure // want `unused gormreuse:pure directive`
 		func(q *gorm.DB) {
 			_ = q
 		}, func(q *gorm.DB) { //gormreuse:pure

--- a/testdata/src/gormreuse/closure_directive.go.diff
+++ b/testdata/src/gormreuse/closure_directive.go.diff
@@ -187,7 +187,7 @@
  func nestedClosureInnerImmutableReturn(db *gorm.DB) {
  	//gormreuse:pure
  	outer := func(q *gorm.DB) *gorm.DB {
- 		//gormreuse:immutable-return
+ 		//gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
  		inner := func(q2 *gorm.DB) *gorm.DB {
  			return q2.Session(&gorm.Session{})
  		}
@@ -533,7 +533,7 @@
  func multiAssign09(db *gorm.DB) {
  	a, b, c := func(q *gorm.DB) { //gormreuse:pure
  		_ = q
- 	}, //gormreuse:pure
+ 	}, //gormreuse:pure // want `unused gormreuse:pure directive`
  		func(q *gorm.DB) {
  			_ = q
  		}, func(q *gorm.DB) { //gormreuse:pure

--- a/testdata/src/gormreuse/closure_directive.go.golden
+++ b/testdata/src/gormreuse/closure_directive.go.golden
@@ -182,7 +182,7 @@ func nestedClosureTripleNested(db *gorm.DB) {
 func nestedClosureInnerImmutableReturn(db *gorm.DB) {
 	//gormreuse:pure
 	outer := func(q *gorm.DB) *gorm.DB {
-		//gormreuse:immutable-return
+		//gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
 		inner := func(q2 *gorm.DB) *gorm.DB {
 			return q2.Session(&gorm.Session{})
 		}
@@ -520,7 +520,7 @@ func multiAssign08(db *gorm.DB) {
 func multiAssign09(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q
-	}, //gormreuse:pure
+	}, //gormreuse:pure // want `unused gormreuse:pure directive`
 		func(q *gorm.DB) {
 			_ = q
 		}, func(q *gorm.DB) { //gormreuse:pure

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,992 +1,992 @@
+@@ -1,1033 +1,1033 @@
  package internal
  
  import "gorm.io/gorm"
@@ -988,6 +988,47 @@
  	result.Where("x").Find(nil)
  	result.Where("y").Find(nil) // OK: returns immutable
  	db.Find(nil)                // OK: db not polluted (pure)
+ }
+ 
+ // =============================================================================
+ // UNUSED DIRECTIVE DETECTION
+ // =============================================================================
+ // Note: Pure/immutable-return directives on FuncDecls are always "used" because
+ // the function is analyzed during SSA processing. The only way to have an
+ // "unused" directive is when it doesn't match any function (e.g., wrong placement
+ // like after a closing brace). See closure_directive.go for such cases.
+ //
+ // Combined directives are never reported as unused if either part is used.
+ // This section tests that combined directives work correctly.
+ 
+ // combinedPureNotUsedButImmutableReturnUsed: Combined directive
+ // When only immutable-return is used, pure is NOT reported as unused (combined)
+ //
+ //gormreuse:pure,immutable-return
+ func combinedPureNotUsedButImmutableReturnUsed() *gorm.DB {
+ 	return globalDB.Session(&gorm.Session{})
+ }
+ 
+ func useCombinedOnlyImmutableReturn(db *gorm.DB) {
+ 	q := combinedPureNotUsedButImmutableReturnUsed()
+ 	q.Find(nil)
+ 	q.Count(nil) // OK - q is immutable (immutable-return used)
+ 	// Note: pure is NOT reported as unused because it shares position with immutable-return
+ }
+ 
+ // combinedImmutableReturnNotUsedButPureUsed: Combined directive
+ // When only pure is used, immutable-return is NOT reported as unused (combined)
+ //
+ //gormreuse:pure,immutable-return
+ func combinedImmutableReturnNotUsedButPureUsed(q *gorm.DB) *gorm.DB {
+ 	return q.Session(&gorm.Session{}) // pure: doesn't pollute q
+ }
+ 
+ func useCombinedOnlyPure(db *gorm.DB) {
+ 	q := db.Where("base")
+ 	_ = combinedImmutableReturnNotUsedButPureUsed(q)
+ 	q.Find(nil) // OK - q not polluted (pure used)
+ 	// Note: immutable-return NOT reported as unused because it shares position with pure
  }
  
  // =============================================================================


### PR DESCRIPTION
## Summary

- Add unused directive detection for `//gormreuse:pure` and `//gormreuse:immutable-return`
- Track directive positions during file scanning and mark them as used during SSA analysis
- Handle combined directives (`//gormreuse:pure,immutable-return`): if either part is used, no unused warning is reported for the other
- Update README.md and CLAUDE.md documentation

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Run `golangci-lint run` - no issues
- [x] Verify unused pure directive is reported for orphaned comments (e.g., `}, //gormreuse:pure`)
- [x] Verify combined directives don't report unused when either part is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)