### PR TITLE
fix: gate builtin immutable-return matching on gorm package/receiver (#64)

### DIFF
--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -156,17 +156,40 @@ func (t *RootTracer) IsPureFunction(fn *ssa.Function) bool {
 	if fn == nil {
 		return false
 	}
-	return typeutil.IsImmutableReturningBuiltin(fn.Name()) || t.pureFuncs.Contains(fn)
+	return t.IsImmutableReturningBuiltin(fn) || t.pureFuncs.Contains(fn)
 }
 
 // IsImmutableReturningBuiltin checks if a function is a builtin method that returns immutable *gorm.DB.
 // Builtin methods (Session, WithContext, Debug, etc.) return immutable *gorm.DB.
 // This is used for tracing - only builtin methods have immutable return values.
+//
+// The name lookup is gated on the function actually belonging to gorm.io/gorm
+// (see isGormBuiltinFunc). Without this gate, any user-defined function sharing a
+// builtin name — a method named Session, a helper named Open — would be silently
+// trusted as immutable-returning (and, via IsPureFunction, as pure), disabling
+// reuse detection around it.
 func (t *RootTracer) IsImmutableReturningBuiltin(fn *ssa.Function) bool {
 	if fn == nil {
 		return false
 	}
-	return typeutil.IsImmutableReturningBuiltin(fn.Name())
+	if !typeutil.IsImmutableReturningBuiltin(fn.Name()) {
+		return false
+	}
+	return isGormBuiltinFunc(fn)
+}
+
+// isGormBuiltinFunc reports whether fn is genuinely defined by gorm.io/gorm:
+// either a method whose receiver is gorm.DB (Session, WithContext, Debug, Begin,
+// Transaction), or a package-level function in the gorm.io/gorm package
+// (gorm.Open). User-defined functions that merely share a builtin name return false.
+func isGormBuiltinFunc(fn *ssa.Function) bool {
+	if sig := fn.Signature; sig != nil && sig.Recv() != nil {
+		return typeutil.IsGormDB(sig.Recv().Type())
+	}
+	if obj := fn.Object(); obj != nil {
+		return typeutil.IsGormPackage(obj.Pkg())
+	}
+	return false
 }
 
 // trace is the core tracing function that finds the mutable root for a value.

--- a/internal/typeutil/gorm.go
+++ b/internal/typeutil/gorm.go
@@ -64,6 +64,15 @@ func IsGormDB(t types.Type) bool {
 	return isGormDBNamed(t)
 }
 
+// IsGormPackage reports whether pkg is exactly the gorm.io/gorm package.
+//
+// This is used to distinguish genuine gorm builtins (e.g. the package-level
+// gorm.Open function) from user-defined functions that merely share a name.
+// It uses exact path matching, consistent with isGormDBNamed.
+func IsGormPackage(pkg *types.Package) bool {
+	return pkg != nil && pkg.Path() == gormPkgPath
+}
+
 // isGormDBNamed checks if the type is gorm.DB (named type).
 func isGormDBNamed(t types.Type) bool {
 	named, ok := t.(*types.Named)

--- a/testdata/src/gormreuse/name_collision.go
+++ b/testdata/src/gormreuse/name_collision.go
@@ -1,0 +1,76 @@
+package internal
+
+import "gorm.io/gorm"
+
+// Regression fixtures for #64: builtin immutable-returning methods were matched
+// by name only, so any user-defined function or method sharing a name
+// (Session, Open, Debug, Begin, Transaction, WithContext) was silently trusted
+// as immutable-returning and pure — disabling reuse detection around it.
+//
+// The name lookup is now gated on the function genuinely belonging to
+// gorm.io/gorm (a method on *gorm.DB, or a package-level gorm function).
+
+// =============================================================================
+// SHOULD REPORT - user-defined names colliding with gorm builtins
+// =============================================================================
+
+// Open is a user-defined package-level function that happens to share a name
+// with gorm.Open. It returns a mutable (mid-chain) value; reuse must be caught.
+func Open(db *gorm.DB) *gorm.DB { return db.Where("x = ?", 1) }
+
+func collisionFreeFuncOpen(db *gorm.DB) {
+	q := Open(db)
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// Debug is a user-defined package-level function sharing a name with the gorm
+// Debug method. It pollutes its argument; the discarded call must pollute q.
+func Debug(db *gorm.DB) { db.Find(&[]User{}) }
+
+func collisionFreeFuncDebug(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	Debug(q)
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// collisionRepo has methods whose names collide with gorm builtins.
+type collisionRepo struct{ db *gorm.DB }
+
+// Session is a user-defined method sharing a name with (*gorm.DB).Session.
+// It returns a mutable value; reuse of that value must be caught.
+func (r *collisionRepo) Session() *gorm.DB { return r.db.Where("tenant = ?", 1) }
+
+// Begin is a user-defined method sharing a name with (*gorm.DB).Begin.
+func (r *collisionRepo) Begin() *gorm.DB { return r.db.Where("open = ?", true) }
+
+func collisionMethodSession(r *collisionRepo) {
+	q := r.Session()
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+func collisionMethodBegin(r *collisionRepo) {
+	q := r.Begin()
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// =============================================================================
+// SHOULD NOT REPORT - genuine gorm builtins keep their immutable semantics
+// =============================================================================
+
+// realSessionStillImmutable confirms the gate did not break real gorm builtins:
+// the result of (*gorm.DB).Session is immutable and may be branched freely.
+func realSessionStillImmutable(db *gorm.DB) {
+	q := db.Session(&gorm.Session{})
+	q.Where("a = ?", 1).Find(&[]User{})
+	q.Where("b = ?", 2).Find(&[]User{}) // OK: Session result is immutable
+}
+
+// realDebugStillImmutable confirms (*gorm.DB).Debug stays immutable-returning.
+func realDebugStillImmutable(db *gorm.DB) {
+	q := db.Debug()
+	q.Where("a = ?", 1).Find(&[]User{})
+	q.Where("b = ?", 2).Find(&[]User{}) // OK: Debug result is immutable
+}

--- a/testdata/src/gormreuse/name_collision.go.golden
+++ b/testdata/src/gormreuse/name_collision.go.golden
@@ -1,0 +1,76 @@
+package internal
+
+import "gorm.io/gorm"
+
+// Regression fixtures for #64: builtin immutable-returning methods were matched
+// by name only, so any user-defined function or method sharing a name
+// (Session, Open, Debug, Begin, Transaction, WithContext) was silently trusted
+// as immutable-returning and pure — disabling reuse detection around it.
+//
+// The name lookup is now gated on the function genuinely belonging to
+// gorm.io/gorm (a method on *gorm.DB, or a package-level gorm function).
+
+// =============================================================================
+// SHOULD REPORT - user-defined names colliding with gorm builtins
+// =============================================================================
+
+// Open is a user-defined package-level function that happens to share a name
+// with gorm.Open. It returns a mutable (mid-chain) value; reuse must be caught.
+func Open(db *gorm.DB) *gorm.DB { return db.Where("x = ?", 1) }
+
+func collisionFreeFuncOpen(db *gorm.DB) {
+	q := Open(db).Session(&gorm.Session{})
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// Debug is a user-defined package-level function sharing a name with the gorm
+// Debug method. It pollutes its argument; the discarded call must pollute q.
+func Debug(db *gorm.DB) { db.Find(&[]User{}) }
+
+func collisionFreeFuncDebug(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	Debug(q)
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// collisionRepo has methods whose names collide with gorm builtins.
+type collisionRepo struct{ db *gorm.DB }
+
+// Session is a user-defined method sharing a name with (*gorm.DB).Session.
+// It returns a mutable value; reuse of that value must be caught.
+func (r *collisionRepo) Session() *gorm.DB { return r.db.Where("tenant = ?", 1) }
+
+// Begin is a user-defined method sharing a name with (*gorm.DB).Begin.
+func (r *collisionRepo) Begin() *gorm.DB { return r.db.Where("open = ?", true) }
+
+func collisionMethodSession(r *collisionRepo) {
+	q := r.Session().Session(&gorm.Session{})
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+func collisionMethodBegin(r *collisionRepo) {
+	q := r.Begin().Session(&gorm.Session{})
+	q.Find(&[]User{})
+	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// =============================================================================
+// SHOULD NOT REPORT - genuine gorm builtins keep their immutable semantics
+// =============================================================================
+
+// realSessionStillImmutable confirms the gate did not break real gorm builtins:
+// the result of (*gorm.DB).Session is immutable and may be branched freely.
+func realSessionStillImmutable(db *gorm.DB) {
+	q := db.Session(&gorm.Session{})
+	q.Where("a = ?", 1).Find(&[]User{})
+	q.Where("b = ?", 2).Find(&[]User{}) // OK: Session result is immutable
+}
+
+// realDebugStillImmutable confirms (*gorm.DB).Debug stays immutable-returning.
+func realDebugStillImmutable(db *gorm.DB) {
+	q := db.Debug()
+	q.Where("a = ?", 1).Find(&[]User{})
+	q.Where("b = ?", 2).Find(&[]User{}) // OK: Debug result is immutable
+}


### PR DESCRIPTION
## Summary

Fixes #64 — a **false negative**: builtin immutable-returning methods (`Session`, `WithContext`, `Debug`, `Open`, `Begin`, `Transaction`) were matched by **function name only**, so any user-defined function or method sharing one of those names was silently trusted as immutable-returning and (via `IsPureFunction`) pure — disabling `*gorm.DB` reuse detection around it.

Confirmed hands-on during the 2026-07-06 audit: `Repo.Begin()`, `Repo.Transaction()`, a helper named `Open`, etc. are ordinary names that quietly switch off the linter.

## Fix

Gate the name lookup on the function genuinely belonging to `gorm.io/gorm`:
- a method whose receiver is `gorm.DB` (Session/WithContext/Debug/Begin/Transaction), or
- a package-level function in the `gorm.io/gorm` package (`gorm.Open`).

`internal/ssa/handler/call.go` and `internal/ssa/purity/validator.go` already verify the receiver is `gorm.DB` before their name checks, so the fix is confined to `internal/ssa/tracer/root.go` (`IsImmutableReturningBuiltin` + `IsPureFunction`) plus a new `typeutil.IsGormPackage` helper.

## Tests

- New fixture `testdata/src/gormreuse/name_collision.go`: user-defined `Open`/`Debug` free functions and `Session`/`Begin` methods that collide with builtin names are now correctly flagged (SHOULD REPORT), while genuine `(*gorm.DB).Session`/`.Debug` keep their immutable semantics (SHOULD NOT REPORT).
- `go test ./...` green; no existing golden changed (zero regression on other fixtures).
- `golangci-lint run ./...` clean.
- E2E module (`e2e/internal`, not run in CI) verified locally: green.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
