### PR TITLE
fix: don't pollute *gorm.DB passed to read-only variadic stdlib calls (#65)

### DIFF
--- a/internal/ssa/handler/call.go
+++ b/internal/ssa/handler/call.go
@@ -512,14 +512,10 @@ func isReadOnlyVariadicArg(idx *ssa.IndexAddr, val ssa.Value) bool {
 // allow-listed read-only package (see readOnlyVariadicPkgs).
 func isReadOnlyStdlibCallee(call *ssa.Call) bool {
 	callee := call.Call.StaticCallee()
-	if callee == nil {
+	if callee == nil || callee.Object() == nil || callee.Object().Pkg() == nil {
 		return false
 	}
-	obj := callee.Object()
-	if obj == nil || obj.Pkg() == nil {
-		return false
-	}
-	return readOnlyVariadicPkgs[obj.Pkg().Path()]
+	return readOnlyVariadicPkgs[callee.Object().Pkg().Path()]
 }
 
 // MapUpdateHandler handles *ssa.MapUpdate instructions.

--- a/internal/ssa/handler/call.go
+++ b/internal/ssa/handler/call.go
@@ -429,7 +429,18 @@ func (h *StoreHandler) Handle(store *ssa.Store, ctx *Context) {
 	}
 
 	// Only stores to IndexAddr (slice element)
-	if _, ok := store.Addr.(*ssa.IndexAddr); !ok {
+	idx, ok := store.Addr.(*ssa.IndexAddr)
+	if !ok {
+		return
+	}
+
+	// Passing a *gorm.DB into a variadic ...interface{} parameter of a known
+	// read-only stdlib function (fmt.Println(q), log.Printf("%v", q),
+	// t.Logf("%v", q)) lowers to packing an interface-boxed value into a varargs
+	// array. Those functions never retain or mutate their arguments, so skip them
+	// to avoid false positives. User-defined variadic functions are intentionally
+	// NOT exempt (they may branch the value), matching the conservative bias.
+	if isReadOnlyVariadicArg(idx, store.Val) {
 		return
 	}
 
@@ -439,6 +450,76 @@ func (h *StoreHandler) Handle(store *ssa.Store, ctx *Context) {
 	}
 
 	ctx.Tracker.MarkPolluted(root, store.Block(), store.Pos())
+}
+
+// readOnlyVariadicPkgs lists packages whose variadic ...interface{} functions
+// are known not to retain or mutate their arguments (formatting/output/logging
+// only). Passing a *gorm.DB into them must not be treated as pollution.
+var readOnlyVariadicPkgs = map[string]bool{
+	"fmt":     true,
+	"log":     true,
+	"testing": true,
+}
+
+// isReadOnlyVariadicArg reports whether the store packs an interface-boxed
+// *gorm.DB into the varargs array of a variadic call to a known read-only
+// stdlib function (see readOnlyVariadicPkgs). In SSA fmt.Println(q) is:
+//
+//	t2 = new [1]any (varargs)   // array alloc
+//	t3 = &t2[0]                 // idx (IndexAddr)
+//	t4 = make any <- *gorm.DB   // val (MakeInterface — interface-boxed)
+//	*t3 = t4                    // the Store
+//	t5 = slice t2[:]            // sliced ...
+//	t6 = fmt.Println(t5...)     // ... and handed to a variadic call
+//
+// It returns true only when the slot is interface-typed (val is a MakeInterface),
+// the array flows into the variadic argument of a call, AND that callee is an
+// allow-listed read-only stdlib function. This deliberately excludes:
+//   - concrete ...*gorm.DB packs (val is the *gorm.DB directly, not boxed),
+//   - user composite slices like []interface{}{q} (no variadic call), and
+//   - user-defined variadic ...interface{} functions (may branch the value),
+//
+// all of which stay conservatively polluting.
+func isReadOnlyVariadicArg(idx *ssa.IndexAddr, val ssa.Value) bool {
+	if _, ok := val.(*ssa.MakeInterface); !ok {
+		return false
+	}
+	alloc, ok := idx.X.(*ssa.Alloc)
+	if !ok || alloc.Referrers() == nil {
+		return false
+	}
+	for _, r := range *alloc.Referrers() {
+		slice, ok := r.(*ssa.Slice)
+		if !ok || slice.Referrers() == nil {
+			continue
+		}
+		for _, sr := range *slice.Referrers() {
+			call, ok := sr.(*ssa.Call)
+			if !ok {
+				continue
+			}
+			sig := call.Call.Signature()
+			args := call.Call.Args
+			if sig != nil && sig.Variadic() && len(args) > 0 && args[len(args)-1] == slice && isReadOnlyStdlibCallee(call) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isReadOnlyStdlibCallee reports whether call targets a function in an
+// allow-listed read-only package (see readOnlyVariadicPkgs).
+func isReadOnlyStdlibCallee(call *ssa.Call) bool {
+	callee := call.Call.StaticCallee()
+	if callee == nil {
+		return false
+	}
+	obj := callee.Object()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return readOnlyVariadicPkgs[obj.Pkg().Path()]
 }
 
 // MapUpdateHandler handles *ssa.MapUpdate instructions.

--- a/testdata/src/gormreuse/readonly_calls.go
+++ b/testdata/src/gormreuse/readonly_calls.go
@@ -53,3 +53,29 @@ func userVariadicPollutes(db *gorm.DB) {
 	userVariadicSink(q)
 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
 }
+
+// Concrete ...*gorm.DB variadic: value is packed directly (not interface-boxed),
+// so it is never treated as a read-only interface arg and still pollutes.
+func concreteVariadicSink(dbs ...*gorm.DB) {}
+
+func concreteVariadicPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	concreteVariadicSink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// A func-value (dynamic) variadic call has no static callee, so it is not on the
+// read-only allow-list and still pollutes.
+func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
+	q := db.Where("x = ?", 1)
+	sink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// A user composite slice literal escapes the value and still pollutes; it does
+// not flow into a variadic call, so the read-only exemption does not apply.
+func sliceLiteralPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	_ = []interface{}{q}
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/gormreuse/readonly_calls.go
+++ b/testdata/src/gormreuse/readonly_calls.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// Regression fixtures for #65: passing a *gorm.DB into a variadic ...interface{}
+// parameter of a known read-only stdlib function (fmt/log/testing) lowered to a
+// varargs pack whose element Store was treated as slice-escape pollution, causing
+// false positives on ordinary logging. Such read-only calls are now exempt, while
+// user-defined variadic functions and real slice/map/chan storage still pollute.
+
+// =============================================================================
+// SHOULD NOT REPORT - read-only stdlib variadic sinks do not pollute
+// =============================================================================
+
+func readonlyFmtPrintln(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	fmt.Println(q)
+	q.Find(&[]User{}) // OK: fmt.Println is read-only
+}
+
+func readonlyFmtSprintf(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	_ = fmt.Sprintf("query=%v", q)
+	q.Find(&[]User{}) // OK: fmt.Sprintf is read-only
+}
+
+func readonlyLogPrintf(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	log.Printf("query=%v", q)
+	q.Find(&[]User{}) // OK: log.Printf is read-only
+}
+
+func readonlyTestingLog(db *gorm.DB, t *testing.T) {
+	q := db.Where("x = ?", 1)
+	t.Logf("query=%v", q)
+	q.Find(&[]User{}) // OK: (*testing.T).Logf is read-only
+}
+
+// =============================================================================
+// SHOULD REPORT - user-defined variadic interface func may branch the value
+// =============================================================================
+
+func userVariadicSink(args ...interface{}) {}
+
+func userVariadicPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	userVariadicSink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/gormreuse/readonly_calls.go.golden
+++ b/testdata/src/gormreuse/readonly_calls.go.golden
@@ -53,3 +53,29 @@ func userVariadicPollutes(db *gorm.DB) {
 	userVariadicSink(q)
 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
 }
+
+// Concrete ...*gorm.DB variadic: value is packed directly (not interface-boxed),
+// so it is never treated as a read-only interface arg and still pollutes.
+func concreteVariadicSink(dbs ...*gorm.DB) {}
+
+func concreteVariadicPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	concreteVariadicSink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// A func-value (dynamic) variadic call has no static callee, so it is not on the
+// read-only allow-list and still pollutes.
+func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	sink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// A user composite slice literal escapes the value and still pollutes; it does
+// not flow into a variadic call, so the read-only exemption does not apply.
+func sliceLiteralPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	_ = []interface{}{q}
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}

--- a/testdata/src/gormreuse/readonly_calls.go.golden
+++ b/testdata/src/gormreuse/readonly_calls.go.golden
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// Regression fixtures for #65: passing a *gorm.DB into a variadic ...interface{}
+// parameter of a known read-only stdlib function (fmt/log/testing) lowered to a
+// varargs pack whose element Store was treated as slice-escape pollution, causing
+// false positives on ordinary logging. Such read-only calls are now exempt, while
+// user-defined variadic functions and real slice/map/chan storage still pollute.
+
+// =============================================================================
+// SHOULD NOT REPORT - read-only stdlib variadic sinks do not pollute
+// =============================================================================
+
+func readonlyFmtPrintln(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	fmt.Println(q)
+	q.Find(&[]User{}) // OK: fmt.Println is read-only
+}
+
+func readonlyFmtSprintf(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	_ = fmt.Sprintf("query=%v", q)
+	q.Find(&[]User{}) // OK: fmt.Sprintf is read-only
+}
+
+func readonlyLogPrintf(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	log.Printf("query=%v", q)
+	q.Find(&[]User{}) // OK: log.Printf is read-only
+}
+
+func readonlyTestingLog(db *gorm.DB, t *testing.T) {
+	q := db.Where("x = ?", 1)
+	t.Logf("query=%v", q)
+	q.Find(&[]User{}) // OK: (*testing.T).Logf is read-only
+}
+
+// =============================================================================
+// SHOULD REPORT - user-defined variadic interface func may branch the value
+// =============================================================================
+
+func userVariadicSink(args ...interface{}) {}
+
+func userVariadicPollutes(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	userVariadicSink(q)
+	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+}


### PR DESCRIPTION
## Summary

Fixes #65 — a **high-noise false positive**: passing a `*gorm.DB` to read-only variadic stdlib functions (`fmt.Println(q)`, `log.Printf("%v", q)`, `t.Logf(...)`) marked it polluted, so a following use was reported as reuse. There is no ergonomic escape (you cannot put `//gormreuse:pure` on stdlib).

## Root cause (verified via SSA dump)

`fmt.Println(q)` lowers to a varargs pack:

```
t2 = new [1]any (varargs)      // array alloc
t3 = &t2[0]                    // IndexAddr
t4 = make any <- *gorm.DB (q)  // MakeInterface (interface-boxed)
*t3 = t4                       // Store  ← StoreHandler treated this as slice escape → pollution
t5 = slice t2[:]
t6 = fmt.Println(t5...)
```

The pollution came from `StoreHandler` (varargs packing), **not** `checkFunctionCallPollution` as the issue originally guessed (there `Args` is the `[]any` slice, which `unwrapGormDB` skips).

## Fix and scope decision

`StoreHandler` now skips the varargs-pack Store when **(a)** the value is interface-boxed (`MakeInterface`), **(b)** the array flows into the variadic argument of a call, and **(c)** that callee is in an allow-listed read-only package (`fmt`, `log`, `testing`).

This is deliberately **narrower than the issue's drafted option 2** (exempt all `...interface{}` calls). An existing intentional fixture — `interface_patterns.go`'s `acceptVariadic(...interface{})` — encodes that a *user-defined* variadic interface function **does** pollute (it may branch the value), which aligns with the project's conservative bias reaffirmed in #59. Blanket-exempting would reverse that and introduce false negatives. The allow-list removes the fmt/log/testing FPs while keeping user functions polluting. Concrete `...*gorm.DB` packs and user composite slices (`[]interface{}{q}`) are also unaffected.

## Tests

- New fixture `testdata/src/gormreuse/readonly_calls.go`: fmt/log/testing read-only sinks are clean (SHOULD NOT REPORT); a user variadic sink still pollutes (SHOULD REPORT).
- `go test ./...` green; only the new golden added, no existing golden changed (zero regression; `interface_patterns.go` still passes).
- `golangci-lint run ./...` clean. E2E (`e2e/internal`, not in CI) verified locally.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
