### PR TITLE
fix: detect reuse across defer/goroutine-only branches (#67)

### DIFF
--- a/internal/ssa/handler/call.go
+++ b/internal/ssa/handler/call.go
@@ -382,7 +382,7 @@ type GoHandler struct{}
 // Handle processes a Go instruction.
 func (h *GoHandler) Handle(g *ssa.Go, ctx *Context) {
 	block := g.Block()
-	processGormDBCallCommonWith(&g.Call, g.Pos(), ctx, func(root ssa.Value) bool {
+	processGormDBCallCommonWith(&g.Call, g.Pos(), block, ctx, func(root ssa.Value) bool {
 		return ctx.Tracker.IsPollutedAt(root, block)
 	})
 }
@@ -393,7 +393,7 @@ type DeferHandler struct{}
 // Handle processes a Defer instruction.
 // Defer uses IsPollutedAnywhere because it executes at function exit.
 func (h *DeferHandler) Handle(d *ssa.Defer, ctx *Context) {
-	processGormDBCallCommonWith(&d.Call, d.Pos(), ctx, func(root ssa.Value) bool {
+	processGormDBCallCommonWith(&d.Call, d.Pos(), d.Block(), ctx, func(root ssa.Value) bool {
 		return ctx.Tracker.IsPollutedAnywhere(root)
 	})
 }
@@ -556,7 +556,14 @@ func (h *MakeInterfaceHandler) Handle(mi *ssa.MakeInterface, ctx *Context) {
 type pollutionChecker func(root ssa.Value) bool
 
 // processGormDBCallCommonWith processes gorm calls with a custom pollution checker.
-func processGormDBCallCommonWith(callCommon *ssa.CallCommon, pos token.Pos, ctx *Context, isPolluted pollutionChecker) {
+//
+// Used by the defer and goroutine handlers. In addition to CHECKING whether the
+// receiver/argument root is already polluted (and reporting a violation if so),
+// it RECORDS each use as a branch use. Recording lets a later defer/goroutine
+// observe an earlier one, so patterns whose ONLY uses are deferred/spawned —
+// e.g. `defer q.Find(nil); defer q.Count(nil)` — are detected. Branch uses are
+// excluded from position-ordered detection (see pollution.Tracker.branchUses).
+func processGormDBCallCommonWith(callCommon *ssa.CallCommon, pos token.Pos, block *ssa.BasicBlock, ctx *Context, isPolluted pollutionChecker) {
 	callee := callCommon.StaticCallee()
 	if callee == nil {
 		return
@@ -590,6 +597,9 @@ func processGormDBCallCommonWith(callCommon *ssa.CallCommon, pos token.Pos, ctx 
 				ctx.Tracker.AddViolationWithRoot(pos, r)
 			}
 		}
+
+		// Record this deferred/spawned use so a later defer/go sees it.
+		ctx.Tracker.RecordBranchUse(root, block, pos)
 		return
 	}
 
@@ -618,6 +628,9 @@ func processGormDBCallCommonWith(callCommon *ssa.CallCommon, pos token.Pos, ctx 
 				ctx.Tracker.AddViolationWithRoot(pos, r)
 			}
 		}
+
+		// Record this deferred/spawned use so a later defer/go sees it.
+		ctx.Tracker.RecordBranchUse(root, block, pos)
 	}
 }
 

--- a/internal/ssa/pollution/tracker.go
+++ b/internal/ssa/pollution/tracker.go
@@ -74,6 +74,15 @@ type Tracker struct {
 	// Example: q = q.Where() creates new root from original q
 	assignmentUses map[ssa.Value][]UsageInfo
 
+	// branchUses maps roots to deferred/goroutine usage sites. Like polluting
+	// uses they consume the root, but they are recorded so that a LATER defer/go
+	// can see an EARLIER one (defer q.Find(); defer q.Count() with no direct use).
+	// They are intentionally NOT scanned by DetectViolations: defer/go run at a
+	// different time than their textual position, so position-ordered detection
+	// would misfire. Violations among them are reported inline at record time via
+	// IsPolluted/IsPollutedAt, which do consult this map.
+	branchUses map[ssa.Value][]UsageInfo
+
 	// violations tracks detected violations.
 	violations []Violation
 
@@ -92,6 +101,7 @@ func New(cfgAnalyzer CFGAnalyzer) *Tracker {
 		pollutingUses:  make(map[ssa.Value][]UsageInfo),
 		pureUses:       make(map[ssa.Value][]UsageInfo),
 		assignmentUses: make(map[ssa.Value][]UsageInfo),
+		branchUses:     make(map[ssa.Value][]UsageInfo),
 		cfgAnalyzer:    cfgAnalyzer,
 	}
 }
@@ -116,6 +126,14 @@ func (t *Tracker) RecordPureUse(root ssa.Value, block *ssa.BasicBlock, pos token
 // Caller must ensure root is not nil.
 func (t *Tracker) RecordAssignment(root ssa.Value, block *ssa.BasicBlock, pos token.Pos) {
 	t.assignmentUses[root] = append(t.assignmentUses[root], UsageInfo{Block: block, Pos: pos})
+}
+
+// RecordBranchUse records a deferred/goroutine polluting usage of a root.
+// Recorded so a later defer/go can observe an earlier one; excluded from
+// DetectViolations (see the branchUses field doc). Caller must ensure root is
+// not nil.
+func (t *Tracker) RecordBranchUse(root ssa.Value, block *ssa.BasicBlock, pos token.Pos) {
+	t.branchUses[root] = append(t.branchUses[root], UsageInfo{Block: block, Pos: pos})
 }
 
 // isReachable checks if pollution can reach the target block.
@@ -144,14 +162,21 @@ func (t *Tracker) addViolationWithContext(pos token.Pos, root ssa.Value, allUses
 }
 
 // IsPolluted checks if a root has been polluted (for defer).
+// Includes deferred/goroutine branch uses so multiple defers/goroutines that
+// reuse the same root (with no direct use) are detected.
 func (t *Tracker) IsPolluted(root ssa.Value) bool {
-	uses := t.pollutingUses[root]
-	return len(uses) > 0
+	return len(t.pollutingUses[root]) > 0 || len(t.branchUses[root]) > 0
 }
 
 // IsPollutedAt checks if a root has polluting usage that can reach the target block.
+// Includes deferred/goroutine branch uses (see IsPolluted).
 func (t *Tracker) IsPollutedAt(root ssa.Value, targetBlock *ssa.BasicBlock) bool {
 	for _, use := range t.pollutingUses[root] {
+		if t.isReachable(use.Block, targetBlock) {
+			return true
+		}
+	}
+	for _, use := range t.branchUses[root] {
 		if t.isReachable(use.Block, targetBlock) {
 			return true
 		}

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -283,6 +283,14 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
 }
 
+// twoDefersNoDirectUse: two deferred branches from the same root with NO direct
+// use. Neither defer used to record pollution, so the reuse was missed (#67).
+func twoDefersNoDirectUse(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	defer q.Find(nil)
+	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
 // =============================================================================
 // SHOULD NOT REPORT - Defer safe patterns
 // =============================================================================
@@ -446,6 +454,14 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 
 	// Start goroutine that uses the already-polluted q
 	// isPollutedAt should detect pollution from different function (closure)
+	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
+// direct use. Neither go statement recorded pollution, so the reuse was missed (#67).
+func twoGoroutinesNoDirectUse(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	go q.Find(nil)
 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 }
 

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -1,6 +1,6 @@
 --- evil.go	1970-01-01 00:00:00
 +++ evil.go.golden	1970-01-01 00:00:00
-@@ -1,3166 +1,3166 @@
+@@ -1,3182 +1,3182 @@
  package internal
  
  import "gorm.io/gorm"
@@ -302,6 +302,14 @@
  	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
  }
  
+ // twoDefersNoDirectUse: two deferred branches from the same root with NO direct
+ // use. Neither defer used to record pollution, so the reuse was missed (#67).
+ func twoDefersNoDirectUse(db *gorm.DB) {
+ 	q := db.Where("x = ?", 1)
+ 	defer q.Find(nil)
+ 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
  // =============================================================================
  // SHOULD NOT REPORT - Defer safe patterns
  // =============================================================================
@@ -473,6 +481,14 @@
  
  	// Start goroutine that uses the already-polluted q
  	// isPollutedAt should detect pollution from different function (closure)
+ 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
+ // direct use. Neither go statement recorded pollution, so the reuse was missed (#67).
+ func twoGoroutinesNoDirectUse(db *gorm.DB) {
+ 	q := db.Where("x = ?", 1)
+ 	go q.Find(nil)
  	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
  }
  

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -283,6 +283,14 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
 }
 
+// twoDefersNoDirectUse: two deferred branches from the same root with NO direct
+// use. Neither defer used to record pollution, so the reuse was missed (#67).
+func twoDefersNoDirectUse(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	defer q.Find(nil)
+	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
 // =============================================================================
 // SHOULD NOT REPORT - Defer safe patterns
 // =============================================================================
@@ -446,6 +454,14 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 
 	// Start goroutine that uses the already-polluted q
 	// isPollutedAt should detect pollution from different function (closure)
+	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
+// direct use. Neither go statement recorded pollution, so the reuse was missed (#67).
+func twoGoroutinesNoDirectUse(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	go q.Find(nil)
 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
 }
 


### PR DESCRIPTION
## Summary

Fixes #67 — a **false negative**: when a mutable `*gorm.DB` root's only uses are two `defer`s or two `go` statements (no direct use), the reuse was silently missed:

```go
func twoDefers(db *gorm.DB) {
    q := db.Where("x")
    defer q.Find(nil)
    defer q.Count(nil) // was NOT reported
}
```

## Root cause

Deferred and spawned calls (`DeferHandler`/`GoHandler` → `processGormDBCallCommonWith`) only **checked** whether the root was already polluted; they never **recorded** their own use. Existing defer/goroutine fixtures are detected only because they also contain a direct use that records the first pollution. The defer/go-only shape had no recorder.

## Fix

Add a `branchUses` bucket to `pollution.Tracker` for deferred/spawned uses:
- `IsPolluted` / `IsPollutedAt` now consult it, so a later defer/go observes an earlier one and reports inline (defers run in a pass after direct calls, goroutines in their own pass, so ordering is right).
- It is **deliberately excluded** from `DetectViolations`' position-ordered scan. `defer`/`go` execute at a different time than their textual position, so position ordering would misreport — this also preserves the existing single-defer/goroutine behavior (e.g. `deferReuse`) exactly.

## Tests

- New fixtures in `evil.go`: `twoDefersNoDirectUse`, `twoGoroutinesNoDirectUse` (SHOULD REPORT).
- Manually verified single-defer and `Session()`-guarded defer/goroutine stay clean.
- `go test ./...` green (all existing defer/goroutine fixtures unchanged); `golangci-lint` clean; E2E (`e2e/internal`, not in CI) verified locally.

Note: these branch-only violations currently carry no suggested fix (empty use set for the fixer); the report itself fires. Suggested-fix quality is tracked separately in #71.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
