### PR TITLE
fix: keep tracking *gorm.DB across interface round-trip (#69)

### DIFF
--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -317,6 +317,17 @@ func (t *RootTracer) traceNonCall(v ssa.Value, visited map[ssa.Value]bool, loopI
 		// ChangeType: type conversion (same underlying type)
 		return t.trace(val.X, visited, loopInfo)
 
+	case *ssa.MakeInterface:
+		// MakeInterface: interface{}(x) boxing — trace through to the boxed value
+		// so a value stored in an interface{} and later extracted stays tracked.
+		return t.trace(val.X, visited, loopInfo)
+
+	case *ssa.TypeAssert:
+		// TypeAssert: i.(*gorm.DB) extraction — trace through to the asserted
+		// operand. Combined with MakeInterface above, this keeps an interface
+		// round-trip (var i interface{} = q; q2 := i.(*gorm.DB)) connected to q.
+		return t.trace(val.X, visited, loopInfo)
+
 	case *ssa.Extract:
 		// Extract: extract element from tuple (multi-return)
 		return t.trace(val.Tuple, visited, loopInfo)

--- a/testdata/src/gormreuse/interface_patterns.go
+++ b/testdata/src/gormreuse/interface_patterns.go
@@ -98,6 +98,40 @@ func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 func acceptVariadic(args ...interface{}) {}
 
 // =============================================================================
+// INTERFACE ROUND-TRIP - EXTRACTION KEEPS TRACKING (#69)
+// Boxing into interface{} then extracting via type assertion yields the SAME
+// underlying *gorm.DB, so reuse of the extracted value must still be detected.
+// =============================================================================
+
+// interfaceRoundtripReuse: box into interface{}, extract, then reuse.
+func interfaceRoundtripReuse(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	var i interface{} = q
+	q2 := i.(*gorm.DB)
+	q2.Find(nil)
+	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
+func interfaceRoundtripCommaOk(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	var i interface{} = q
+	if q2, ok := i.(*gorm.DB); ok {
+		q2.Find(nil)
+		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	}
+}
+
+// interfaceRoundtripSession: extracted value is immutable (Session) - no report.
+func interfaceRoundtripSession(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	var i interface{} = q
+	q2 := i.(*gorm.DB)
+	q2.Find(nil)
+	q2.Count(nil) // OK: extracted value is immutable
+}
+
+// =============================================================================
 // GORM METHODS WITH INTERFACE ARGUMENTS
 // =============================================================================
 

--- a/testdata/src/gormreuse/interface_patterns.go.diff
+++ b/testdata/src/gormreuse/interface_patterns.go.diff
@@ -1,6 +1,6 @@
 --- interface_patterns.go	1970-01-01 00:00:00
 +++ interface_patterns.go.golden	1970-01-01 00:00:00
-@@ -1,345 +1,345 @@
+@@ -1,379 +1,379 @@
  package internal
  
  import "gorm.io/gorm"
@@ -103,6 +103,42 @@
  }
  
  func acceptVariadic(args ...interface{}) {}
+ 
+ // =============================================================================
+ // INTERFACE ROUND-TRIP - EXTRACTION KEEPS TRACKING (#69)
+ // Boxing into interface{} then extracting via type assertion yields the SAME
+ // underlying *gorm.DB, so reuse of the extracted value must still be detected.
+ // =============================================================================
+ 
+ // interfaceRoundtripReuse: box into interface{}, extract, then reuse.
+ func interfaceRoundtripReuse(db *gorm.DB) {
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+ 	var i interface{} = q
+ 	q2 := i.(*gorm.DB)
+ 	q2.Find(nil)
+ 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
+ func interfaceRoundtripCommaOk(db *gorm.DB) {
+-	q := db.Where("x = ?", 1)
++	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+ 	var i interface{} = q
+ 	if q2, ok := i.(*gorm.DB); ok {
+ 		q2.Find(nil)
+ 		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	}
+ }
+ 
+ // interfaceRoundtripSession: extracted value is immutable (Session) - no report.
+ func interfaceRoundtripSession(db *gorm.DB) {
+ 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+ 	var i interface{} = q
+ 	q2 := i.(*gorm.DB)
+ 	q2.Find(nil)
+ 	q2.Count(nil) // OK: extracted value is immutable
+ }
  
  // =============================================================================
  // GORM METHODS WITH INTERFACE ARGUMENTS

--- a/testdata/src/gormreuse/interface_patterns.go.golden
+++ b/testdata/src/gormreuse/interface_patterns.go.golden
@@ -98,6 +98,40 @@ func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 func acceptVariadic(args ...interface{}) {}
 
 // =============================================================================
+// INTERFACE ROUND-TRIP - EXTRACTION KEEPS TRACKING (#69)
+// Boxing into interface{} then extracting via type assertion yields the SAME
+// underlying *gorm.DB, so reuse of the extracted value must still be detected.
+// =============================================================================
+
+// interfaceRoundtripReuse: box into interface{}, extract, then reuse.
+func interfaceRoundtripReuse(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	var i interface{} = q
+	q2 := i.(*gorm.DB)
+	q2.Find(nil)
+	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
+func interfaceRoundtripCommaOk(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	var i interface{} = q
+	if q2, ok := i.(*gorm.DB); ok {
+		q2.Find(nil)
+		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	}
+}
+
+// interfaceRoundtripSession: extracted value is immutable (Session) - no report.
+func interfaceRoundtripSession(db *gorm.DB) {
+	q := db.Where("x = ?", 1).Session(&gorm.Session{})
+	var i interface{} = q
+	q2 := i.(*gorm.DB)
+	q2.Find(nil)
+	q2.Count(nil) // OK: extracted value is immutable
+}
+
+// =============================================================================
 // GORM METHODS WITH INTERFACE ARGUMENTS
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #69 — a **false negative**: storing a `*gorm.DB` in an `interface{}` and extracting it via a type assertion lost the connection to the original value, so subsequent reuse was undetected.

```go
q := db.Where("x")
var i interface{} = q
q2 := i.(*gorm.DB)
q2.Find(nil)
q2.Count(nil) // was silently missed
```

## Fix

`traceNonCall` (root tracer) had no case for `*ssa.TypeAssert` (extraction) or `*ssa.MakeInterface` (boxing). Add both so the tracer follows the round-trip back to the original mutable root. The all-roots path already delegates non-special values to the single-root trace, so it needs no change. The comma-ok form (`q2, ok := i.(*gorm.DB)`) is covered via the existing `*ssa.Extract` case.

## Tests

- New fixtures in `interface_patterns.go`: `interfaceRoundtripReuse`, `interfaceRoundtripCommaOk` (SHOULD REPORT); `interfaceRoundtripSession` (SHOULD NOT REPORT — extracted value is immutable).
- Existing interface-conversion fixtures (`directInterfaceConversion` etc.) unchanged — boxing that is never extracted still doesn't pollute.
- `go test ./...` green; `golangci-lint` clean; E2E verified locally.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
