### PR TITLE
fix: treat any pre-package ignore as file-level (#70)

### DIFF
--- a/internal/directive/ignore.go
+++ b/internal/directive/ignore.go
@@ -54,13 +54,15 @@ func BuildIgnoreMap(fset *token.FileSet, file *ast.File) IgnoreMap {
 		for _, c := range cg.List {
 			pos := fset.Position(c.Pos())
 			if IsIgnoreDirective(c.Text) {
-				// Check if this is a file-level ignore (comment before package declaration)
-				// A comment is considered file-level if it appears on the line immediately
-				// before the package declaration, or within a few lines before it
-				if pos.Line < packageLine && pos.Line >= packageLine-5 {
-					// File-level ignore: mark all lines as ignored
-					// We use line -1 as a special marker
-					// File-level ignores are always considered "used" (no warning for them)
+				// A directive anywhere BEFORE the package clause is a file-level
+				// ignore, regardless of distance: there is no code above the
+				// package clause for a line-level ignore to attach to, so the only
+				// sensible meaning is "ignore this whole file". The previous fixed
+				// 5-line window both missed directives sitting above a long license
+				// header and mis-classified nearby ones.
+				if pos.Line < packageLine {
+					// File-level ignore: mark all lines as ignored (line -1 marker).
+					// File-level ignores are always considered "used" (no warning).
 					m[-1] = &ignoreEntry{pos: c.Pos(), used: true}
 				} else {
 					// Regular line-level ignore

--- a/testdata/src/gormreuse/file_level_ignore_far.go
+++ b/testdata/src/gormreuse/file_level_ignore_far.go
@@ -1,0 +1,24 @@
+//gormreuse:ignore
+//
+// Copyright 2026 The gormreuse Authors.
+// Licensed under the Apache License, Version 2.0 (the "License").
+// This header is deliberately long enough to push the directive more than
+// five lines above the package clause. The old fixed 5-line window failed
+// to treat such a directive as file-level (#70); it now does.
+
+package internal
+
+import "gorm.io/gorm"
+
+// All violations in this file are suppressed by the far file-level ignore.
+func fileLevelIgnoreFar1(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	q.Find(nil)
+	q.Count(nil) // Would be VIOLATION, but suppressed by file-level ignore
+}
+
+func fileLevelIgnoreFar2(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	q.Find(nil)
+	q.First(nil) // Would be VIOLATION, but suppressed
+}

--- a/testdata/src/gormreuse/file_level_ignore_far.go.golden
+++ b/testdata/src/gormreuse/file_level_ignore_far.go.golden
@@ -1,0 +1,24 @@
+//gormreuse:ignore
+//
+// Copyright 2026 The gormreuse Authors.
+// Licensed under the Apache License, Version 2.0 (the "License").
+// This header is deliberately long enough to push the directive more than
+// five lines above the package clause. The old fixed 5-line window failed
+// to treat such a directive as file-level (#70); it now does.
+
+package internal
+
+import "gorm.io/gorm"
+
+// All violations in this file are suppressed by the far file-level ignore.
+func fileLevelIgnoreFar1(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	q.Find(nil)
+	q.Count(nil) // Would be VIOLATION, but suppressed by file-level ignore
+}
+
+func fileLevelIgnoreFar2(db *gorm.DB) {
+	q := db.Where("x = ?", 1)
+	q.Find(nil)
+	q.First(nil) // Would be VIOLATION, but suppressed
+}


### PR DESCRIPTION
## Summary

Fixes #70 — file-level `//gormreuse:ignore` detection used a fixed 5-line window (`packageLine-5 <= line < packageLine`). A directive pushed further above the `package` clause by a long license header was mis-classified as a **line-level** ignore — then reported as an unused directive, and its file's violations were not suppressed.

## Fix

A directive above the `package` clause has no code to attach to as a line-level ignore, so the only sensible meaning is "ignore this whole file". Detect file-level by *position-before-package alone*, regardless of distance. (The reverse mis-classification the issue mentions — a line-level directive within 5 lines above package — is moot: there is nothing above package for a line-level ignore to apply to.)

## Tests

- New fixture `file_level_ignore_far.go`: an ignore directive sitting above a multi-line license header (>5 lines above `package`) now suppresses the whole file with no unused-directive warning.
- Existing `file_level_ignore.go` / `file_level_ignore_doc.go` unchanged.
- `go test ./...` green; `golangci-lint` clean; E2E verified locally.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
