### PR TITLE
fix: directive matching — multi-assign poisoning and block comments (#72)

### DIFF
--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -61,7 +61,14 @@ const directivePrefix = "gormreuse:"
 // Supports comma-separated directives: "//gormreuse:pure,immutable-return".
 // Trailing comments use "//": "//gormreuse:ignore // reason here".
 func hasDirective(text, name string) bool {
-	text = strings.TrimPrefix(text, "//")
+	// Accept both line (//gormreuse:...) and block (/*gormreuse:...*/) comment
+	// forms. Without the block form, `/*gormreuse:pure*/` was a silent no-op:
+	// neither applied nor reported as unused.
+	if strings.HasPrefix(text, "/*") {
+		text = strings.TrimSuffix(strings.TrimPrefix(text, "/*"), "*/")
+	} else {
+		text = strings.TrimPrefix(text, "//")
+	}
 	text = strings.TrimSpace(text)
 	if !strings.HasPrefix(text, directivePrefix) {
 		return false

--- a/internal/directive/pure.go
+++ b/internal/directive/pure.go
@@ -178,16 +178,31 @@ func (s *DirectiveFuncSet) collectDirectivePositions(file *ast.File) {
 		}
 	})
 
-	// Check FuncLit directives (next-line and same-line patterns)
+	// Check FuncLit directives (next-line and same-line patterns).
+	//
+	// A single directive position can be shared by multiple FuncLits in a
+	// multi-assignment: `a, b := func(q *gorm.DB){}, func(x int){}`. The directive
+	// is valid as long as AT LEAST ONE of those FuncLits has a matching signature,
+	// so track validity per position and mark a position invalid only when NONE of
+	// its FuncLits are valid. (Marking invalid on the first non-matching sibling
+	// would spuriously flag the whole directive unused.)
+	funcLitSeen := make(map[token.Pos]bool)
+	funcLitValid := make(map[token.Pos]bool)
 	insp.Preorder(funcLitTypes, func(n ast.Node) {
 		fl := n.(*ast.FuncLit)
 		if pos := s.findDirectiveForFuncLit(fl); pos.IsValid() {
 			s.processedDirectives[pos] = struct{}{}
-			if !s.validateFuncLitSignature(fl) {
-				s.invalidDirectives[pos] = struct{}{}
+			funcLitSeen[pos] = true
+			if s.validateFuncLitSignature(fl) {
+				funcLitValid[pos] = true
 			}
 		}
 	})
+	for pos := range funcLitSeen {
+		if !funcLitValid[pos] {
+			s.invalidDirectives[pos] = struct{}{}
+		}
+	}
 
 	// Find orphan directives (not associated with any function)
 	// These are always invalid

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -1031,3 +1031,31 @@ func useCombinedOnlyPure(db *gorm.DB) {
 // =============================================================================
 
 var globalDB *gorm.DB
+
+// =============================================================================
+// #72: directive matching robustness
+// =============================================================================
+
+// multiAssignPureValidSibling: multi-assignment where one closure matches the
+// pure signature (*gorm.DB) and a sibling does not (int). The shared directive
+// must NOT be reported unused — it validly applies to the *gorm.DB closure.
+func multiAssignPureValidSibling(db *gorm.DB) {
+	//gormreuse:pure
+	a, b := func(q *gorm.DB) { _ = q }, func(x int) { _ = x }
+	_, _ = a, b
+}
+
+// blockCommentPureBad: block-comment directive form is now recognized, so the
+// pure contract is enforced (previously a silent no-op).
+/*gormreuse:pure*/
+func blockCommentPureBad(db *gorm.DB) *gorm.DB {
+	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
+	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
+}
+
+// blockCommentPureGood: valid pure via block-comment form — no violation, and
+// not reported as an unused directive.
+/*gormreuse:pure*/
+func blockCommentPureGood(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{}).Where("x")
+}

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -1031,3 +1031,31 @@ func useCombinedOnlyPure(db *gorm.DB) {
 // =============================================================================
 
 var globalDB *gorm.DB
+
+// =============================================================================
+// #72: directive matching robustness
+// =============================================================================
+
+// multiAssignPureValidSibling: multi-assignment where one closure matches the
+// pure signature (*gorm.DB) and a sibling does not (int). The shared directive
+// must NOT be reported unused — it validly applies to the *gorm.DB closure.
+func multiAssignPureValidSibling(db *gorm.DB) {
+	//gormreuse:pure
+	a, b := func(q *gorm.DB) { _ = q }, func(x int) { _ = x }
+	_, _ = a, b
+}
+
+// blockCommentPureBad: block-comment directive form is now recognized, so the
+// pure contract is enforced (previously a silent no-op).
+/*gormreuse:pure*/
+func blockCommentPureBad(db *gorm.DB) *gorm.DB {
+	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
+	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
+}
+
+// blockCommentPureGood: valid pure via block-comment form — no violation, and
+// not reported as an unused directive.
+/*gormreuse:pure*/
+func blockCommentPureGood(db *gorm.DB) *gorm.DB {
+	return db.Session(&gorm.Session{}).Where("x")
+}


### PR DESCRIPTION
## Summary

Addresses **#72** — two confirmed directive-matching gaps (gaps 1 and 3). Two lower-value gaps remain tracked on the issue (see below).

### Gap 1 — multi-assignment poisoning (spurious "unused" warning)

```go
//gormreuse:pure
a, b := func(q *gorm.DB) { _ = q }, func(x int) { _ = x }
```

The two FuncLits share one directive position. The non-matching sibling (`func(x int)`) marked the position invalid and it was never cleared, so the directive was wrongly reported **unused** even though it validly applies to the `*gorm.DB` closure. Now a shared position is invalid only when **none** of its FuncLits match.

### Gap 3 — block-comment directives silently ignored

`/*gormreuse:pure*/` had no effect **and** no warning. `hasDirective` now accepts both `//` and `/* */` comment forms.

## Tests

New fixtures in `directive_validation.go`: `multiAssignPureValidSibling` (no spurious unused), `blockCommentPureBad` (block-form pure contract now enforced), `blockCommentPureGood`. `go test ./...` green; `golangci-lint` clean; E2E verified locally.

## Deferred on #72 (lower value / higher risk)

- **Gap 2** — package-level `var f = func(q *gorm.DB){}` next-line directive association: the FuncLit has no enclosing `ast.Stmt` (it's under a `GenDecl`), needs dedicated `ValueSpec` handling.
- **Gap 4** — interface-only signatures in unused-directive detection: `containsGormDB` returns true for any interface **by design** for pollution analysis; tightening only the unused-detection path needs a separate strict predicate.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
