### PR TITLE
docs: fix pure example to satisfy the strict pure contract (#73)

### DIFF
--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -42,7 +42,9 @@
 //
 //	//gormreuse:pure
 //	func applyFilters(db *gorm.DB) *gorm.DB {
-//	    return db.Where("active = ?", true)
+//	    // Session() first: chaining directly on the parameter (return
+//	    // db.Where(...)) consumes the caller's branch and is NOT pure.
+//	    return db.Session(&gorm.Session{}).Where("active = ?", true)
 //	}
 //
 // Immutable-return function (returns immutable, like Session/WithContext):


### PR DESCRIPTION
## Summary

Fixes #73. Semantics were decided **strict** (see the [decision comment](https://github.com/mpyw/gormreuse/issues/73)): `//gormreuse:pure` means "consumes zero of the caller's branch budget", so `return db.Where(...)` on the parameter is correctly rejected. The validator was already correct; the **documentation** contradicted it.

The only contradictory example was the package doc comment in `internal/directive/directive.go` (it showed `return db.Where(...)` as valid pure). README and CLAUDE.md already use the correct `db.Session(&gorm.Session{}).Where(...)` form. Fixed the doc example to match.

`go test ./...` green; `golangci-lint` clean.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
