### PR TITLE
chore: sync directive_validation.go.diff with #72 fixtures

### DIFF
--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1033 +1,1033 @@
+@@ -1,1061 +1,1061 @@
  package internal
  
  import "gorm.io/gorm"
@@ -1036,3 +1036,31 @@
  // =============================================================================
  
  var globalDB *gorm.DB
+ 
+ // =============================================================================
+ // #72: directive matching robustness
+ // =============================================================================
+ 
+ // multiAssignPureValidSibling: multi-assignment where one closure matches the
+ // pure signature (*gorm.DB) and a sibling does not (int). The shared directive
+ // must NOT be reported unused — it validly applies to the *gorm.DB closure.
+ func multiAssignPureValidSibling(db *gorm.DB) {
+ 	//gormreuse:pure
+ 	a, b := func(q *gorm.DB) { _ = q }, func(x int) { _ = x }
+ 	_, _ = a, b
+ }
+ 
+ // blockCommentPureBad: block-comment directive form is now recognized, so the
+ // pure contract is enforced (previously a silent no-op).
+ /*gormreuse:pure*/
+ func blockCommentPureBad(db *gorm.DB) *gorm.DB {
+ 	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
+ 	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
+ }
+ 
+ // blockCommentPureGood: valid pure via block-comment form — no violation, and
+ // not reported as an unused directive.
+ /*gormreuse:pure*/
+ func blockCommentPureGood(db *gorm.DB) *gorm.DB {
+ 	return db.Session(&gorm.Session{}).Where("x")
+ }


### PR DESCRIPTION
PR #83 added fixtures to `directive_validation.go` but omitted the regenerated full-context `.diff` artifact. CI didn't catch it because `TestGenerateDiffFiles` rewrites the `.diff` before `TestDiffFilesUpToDate` reads it within the same run (self-healing — the fragility tracked in #77). This commits the up-to-date artifact so the checked-in `.diff` matches source.

No code change. Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)