### PR TITLE
fix: detect non-call leaks in //gormreuse:pure validation (#66)

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -86,40 +86,61 @@ func RunSSA(
 	// The generator caches AST inspectors internally, so sharing it improves performance.
 	fixGen := fix.New(pass)
 
-	for _, fn := range ssaInfo.SrcFuncs {
+	// skip reports whether a function is in an excluded file or wholly ignored.
+	// When markUsed is true it also records the function-level ignore directive
+	// as used; that side effect must happen exactly once per function, so only
+	// the analysis pass passes markUsed=true.
+	skip := func(fn *ssa.Function, markUsed bool) bool {
 		pos := fn.Pos()
 		if !pos.IsValid() {
-			continue
+			return true
 		}
-
 		filename := pass.Fset.Position(pos).Filename
-
-		// Skip functions in excluded files
 		if skipFiles[filename] {
-			continue
+			return true
 		}
-
-		ignoreMap := ignoreMaps[filename]
-
-		// Check if entire function is ignored
 		if funcIgnoreSet, ok := funcIgnores[filename]; ok {
 			if entry, ignored := funcIgnoreSet[fn.Pos()]; ignored {
-				// Mark the ignore directive as used (use the stored line number)
-				if ignoreMap != nil {
-					ignoreMap.MarkUsed(entry.DirectiveLine)
+				if markUsed {
+					if ignoreMap := ignoreMaps[filename]; ignoreMap != nil {
+						ignoreMap.MarkUsed(entry.DirectiveLine)
+					}
 				}
-				continue
+				return true
 			}
 		}
+		return false
+	}
 
-		// Validate pure function contracts
+	// PASS 1: validate pure function contracts and collect the functions that
+	// definitively leaked their argument. Such a //gormreuse:pure function must
+	// not be trusted as pure at its call sites (issue #66), so this must complete
+	// for ALL functions before the analysis pass runs — a caller may be visited
+	// before its callee.
+	failedPure := make(map[*ssa.Function]bool)
+	for _, fn := range ssaInfo.SrcFuncs {
+		if skip(fn, false) {
+			continue
+		}
 		if pureFuncs != nil && pureFuncs.Contains(fn) {
 			for _, v := range purity.ValidateFunction(fn, pureFuncs) {
 				pass.Reportf(v.Pos, "%s", v.Message)
+				// Only a definitive escape revokes pure-trust at call sites;
+				// conservative func-arg violations do not (avoids FP cascades).
+				if v.Leak {
+					failedPure[fn] = true
+				}
 			}
 		}
+	}
 
-		chk := newChecker(pass, ignoreMap, pureFuncs, immutableReturnFuncs, globalReported, globalSuggestedEdits, fixGen)
+	// PASS 2: run SSA reuse analysis.
+	for _, fn := range ssaInfo.SrcFuncs {
+		if skip(fn, true) {
+			continue
+		}
+
+		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, failedPure, globalReported, globalSuggestedEdits, fixGen)
 		chk.checkFunction(fn)
 	}
 
@@ -173,6 +194,7 @@ type checker struct {
 	ignoreMap            directive.IgnoreMap         // Line-level ignore directives
 	pureFuncs            *directive.DirectiveFuncSet // Pure functions for analysis
 	immutableReturnFuncs *directive.DirectiveFuncSet // Immutable-return functions
+	failedPure           map[*ssa.Function]bool      // Pure functions that failed contract validation
 	reported             map[token.Pos]bool          // Deduplication of reports
 	suggestedEdits       map[editKey]bool            // Global deduplication of suggested fixes
 	fixGen               *fix.Generator              // Cached fix generator for all violations
@@ -190,12 +212,13 @@ type editKey struct {
 // across parent functions and their closures.
 // The suggestedEdits map is shared to avoid duplicate fix edits.
 // The fixGen is shared to avoid recreating the generator for each violation.
-func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
+func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
 	return &checker{
 		pass:                 pass,
 		ignoreMap:            ignoreMap,
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
+		failedPure:           failedPure,
 		reported:             reported,
 		suggestedEdits:       suggestedEdits,
 		fixGen:               fixGen,
@@ -204,7 +227,7 @@ func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, i
 
 // checkFunction runs SSA analysis on a single function and reports violations.
 func (c *checker) checkFunction(fn *ssa.Function) {
-	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs)
+	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.failedPure)
 	violations := analyzer.Analyze()
 
 	// Deduplicate violations by root to avoid generating duplicate fixes.

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -20,7 +20,7 @@ func TestNewAnalyzer(t *testing.T) {
 	pureFuncs := directive.NewPureFuncSet(nil, nil)
 	pureFuncs.Add(directive.FuncKey{PkgPath: "test", FuncName: "Pure"})
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(nil, nil)
-	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs)
+	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs, nil)
 
 	if analyzer == nil {
 		t.Error("Expected analyzer to be initialized")
@@ -36,7 +36,7 @@ func TestNewChecker(t *testing.T) {
 	reported := make(map[token.Pos]bool)
 	suggestedEdits := make(map[editKey]bool)
 
-	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, reported, suggestedEdits, nil)
+	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil, reported, suggestedEdits, nil)
 
 	if chk == nil {
 		t.Error("Expected checker to be initialized")
@@ -46,7 +46,7 @@ func TestNewChecker(t *testing.T) {
 func TestAnalyzer_Analyze_NilFunction(t *testing.T) {
 	t.Parallel()
 
-	analyzer := ssautil.NewAnalyzer(nil, nil, nil)
+	analyzer := ssautil.NewAnalyzer(nil, nil, nil, nil)
 
 	// Should not panic with nil function
 	violations := analyzer.Analyze()
@@ -59,7 +59,7 @@ func TestAnalyzer_Analyze_EmptyFunction(t *testing.T) {
 	t.Parallel()
 
 	fn := &ssa.Function{}
-	analyzer := ssautil.NewAnalyzer(fn, nil, nil)
+	analyzer := ssautil.NewAnalyzer(fn, nil, nil, nil)
 
 	violations := analyzer.Analyze()
 	if len(violations) != 0 {

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -73,10 +73,11 @@ type Analyzer struct {
 //   - fn: The SSA function to analyze (can be nil, will return no violations)
 //   - pureFuncs: Set of functions marked with //gormreuse:pure directive
 //   - immutableReturnFuncs: Set of functions marked with //gormreuse:immutable-return directive
-func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet) *Analyzer {
+//   - failedPure: Pure functions that failed contract validation (not trusted as pure)
+func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool) *Analyzer {
 	return &Analyzer{
 		fn:          fn,
-		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs),
+		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs, failedPure),
 		cfgAnalyzer: cfg.New(),
 	}
 }

--- a/internal/ssa/handler/call.go
+++ b/internal/ssa/handler/call.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/mpyw/gormreuse/internal/ssa/cfg"
 	"github.com/mpyw/gormreuse/internal/ssa/pollution"
+	"github.com/mpyw/gormreuse/internal/ssa/pollutionsource"
 	"github.com/mpyw/gormreuse/internal/ssa/tracer"
 	"github.com/mpyw/gormreuse/internal/typeutil"
 )
@@ -56,24 +57,6 @@ type Context struct {
 	CFG        *cfg.Analyzer      // Control flow graph analysis
 	LoopInfo   *cfg.LoopInfo      // Loop detection results for current function
 	CurrentFn  *ssa.Function      // The function being analyzed
-}
-
-// unwrapGormDB extracts the *gorm.DB value from an SSA value that may be
-// wrapped in MakeInterface. Returns the value and true if it's a *gorm.DB,
-// otherwise returns nil and false.
-//
-// This is needed because when storing *gorm.DB to interface{} containers
-// (slice, map, channel), SSA wraps the value in MakeInterface first.
-// For example: []interface{}{q} generates MakeInterface(q) -> Store.
-func unwrapGormDB(v ssa.Value) (ssa.Value, bool) {
-	if typeutil.IsGormDB(v.Type()) {
-		return v, true
-	}
-	// Check if v is MakeInterface wrapping *gorm.DB
-	if mi, ok := v.(*ssa.MakeInterface); ok && typeutil.IsGormDB(mi.X.Type()) {
-		return mi.X, true
-	}
-	return nil, false
 }
 
 // CallHandler handles *ssa.Call instructions.
@@ -341,7 +324,7 @@ func (h *CallHandler) checkFunctionCallPollution(call *ssa.Call, ctx *Context) {
 
 	for _, arg := range call.Call.Args {
 		// Check if arg is *gorm.DB (directly or wrapped in MakeInterface)
-		gormArg, ok := unwrapGormDB(arg)
+		gormArg, ok := pollutionsource.UnwrapGormDB(arg)
 		if !ok {
 			continue
 		}
@@ -404,8 +387,8 @@ type SendHandler struct{}
 // Handle marks *gorm.DB sent to channels as polluted.
 // Handles both direct sends and sends through MakeInterface (chan interface{}).
 func (h *SendHandler) Handle(send *ssa.Send, ctx *Context) {
-	gormVal, ok := unwrapGormDB(send.X)
-	if !ok {
+	gormVal, kind := pollutionsource.Leak(send)
+	if kind == pollutionsource.KindNone {
 		return
 	}
 
@@ -422,25 +405,12 @@ type StoreHandler struct{}
 
 // Handle marks *gorm.DB stored to slice elements as polluted.
 // Handles both direct stores and stores through MakeInterface ([]interface{}).
+//
+// The read-only variadic stdlib exemption (fmt.Println(q), log.Printf, t.Logf)
+// lives in pollutionsource.Leak so the purity validator honors it too.
 func (h *StoreHandler) Handle(store *ssa.Store, ctx *Context) {
-	gormVal, ok := unwrapGormDB(store.Val)
-	if !ok {
-		return
-	}
-
-	// Only stores to IndexAddr (slice element)
-	idx, ok := store.Addr.(*ssa.IndexAddr)
-	if !ok {
-		return
-	}
-
-	// Passing a *gorm.DB into a variadic ...interface{} parameter of a known
-	// read-only stdlib function (fmt.Println(q), log.Printf("%v", q),
-	// t.Logf("%v", q)) lowers to packing an interface-boxed value into a varargs
-	// array. Those functions never retain or mutate their arguments, so skip them
-	// to avoid false positives. User-defined variadic functions are intentionally
-	// NOT exempt (they may branch the value), matching the conservative bias.
-	if isReadOnlyVariadicArg(idx, store.Val) {
+	gormVal, kind := pollutionsource.Leak(store)
+	if kind == pollutionsource.KindNone {
 		return
 	}
 
@@ -452,80 +422,14 @@ func (h *StoreHandler) Handle(store *ssa.Store, ctx *Context) {
 	ctx.Tracker.MarkPolluted(root, store.Block(), store.Pos())
 }
 
-// readOnlyVariadicPkgs lists packages whose variadic ...interface{} functions
-// are known not to retain or mutate their arguments (formatting/output/logging
-// only). Passing a *gorm.DB into them must not be treated as pollution.
-var readOnlyVariadicPkgs = map[string]bool{
-	"fmt":     true,
-	"log":     true,
-	"testing": true,
-}
-
-// isReadOnlyVariadicArg reports whether the store packs an interface-boxed
-// *gorm.DB into the varargs array of a variadic call to a known read-only
-// stdlib function (see readOnlyVariadicPkgs). In SSA fmt.Println(q) is:
-//
-//	t2 = new [1]any (varargs)   // array alloc
-//	t3 = &t2[0]                 // idx (IndexAddr)
-//	t4 = make any <- *gorm.DB   // val (MakeInterface — interface-boxed)
-//	*t3 = t4                    // the Store
-//	t5 = slice t2[:]            // sliced ...
-//	t6 = fmt.Println(t5...)     // ... and handed to a variadic call
-//
-// It returns true only when the slot is interface-typed (val is a MakeInterface),
-// the array flows into the variadic argument of a call, AND that callee is an
-// allow-listed read-only stdlib function. This deliberately excludes:
-//   - concrete ...*gorm.DB packs (val is the *gorm.DB directly, not boxed),
-//   - user composite slices like []interface{}{q} (no variadic call), and
-//   - user-defined variadic ...interface{} functions (may branch the value),
-//
-// all of which stay conservatively polluting.
-func isReadOnlyVariadicArg(idx *ssa.IndexAddr, val ssa.Value) bool {
-	if _, ok := val.(*ssa.MakeInterface); !ok {
-		return false
-	}
-	alloc, ok := idx.X.(*ssa.Alloc)
-	if !ok || alloc.Referrers() == nil {
-		return false
-	}
-	for _, r := range *alloc.Referrers() {
-		slice, ok := r.(*ssa.Slice)
-		if !ok || slice.Referrers() == nil {
-			continue
-		}
-		for _, sr := range *slice.Referrers() {
-			call, ok := sr.(*ssa.Call)
-			if !ok {
-				continue
-			}
-			sig := call.Call.Signature()
-			args := call.Call.Args
-			if sig != nil && sig.Variadic() && len(args) > 0 && args[len(args)-1] == slice && isReadOnlyStdlibCallee(call) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// isReadOnlyStdlibCallee reports whether call targets a function in an
-// allow-listed read-only package (see readOnlyVariadicPkgs).
-func isReadOnlyStdlibCallee(call *ssa.Call) bool {
-	callee := call.Call.StaticCallee()
-	if callee == nil || callee.Object() == nil || callee.Object().Pkg() == nil {
-		return false
-	}
-	return readOnlyVariadicPkgs[callee.Object().Pkg().Path()]
-}
-
 // MapUpdateHandler handles *ssa.MapUpdate instructions.
 type MapUpdateHandler struct{}
 
 // Handle marks *gorm.DB stored in maps as polluted.
 // Handles both direct stores and stores through MakeInterface (map[K]interface{}).
 func (h *MapUpdateHandler) Handle(mapUpdate *ssa.MapUpdate, ctx *Context) {
-	gormVal, ok := unwrapGormDB(mapUpdate.Value)
-	if !ok {
+	gormVal, kind := pollutionsource.Leak(mapUpdate)
+	if kind == pollutionsource.KindNone {
 		return
 	}
 

--- a/internal/ssa/pollutionsource/pollutionsource.go
+++ b/internal/ssa/pollutionsource/pollutionsource.go
@@ -1,0 +1,172 @@
+// Package pollutionsource is the single source of truth for the SSA
+// instruction shapes that let a *gorm.DB value escape ("leak") a scope.
+//
+// Both the main pollution handler (internal/ssa/handler) and the
+// //gormreuse:pure contract validator (internal/ssa/purity) consume this
+// package so their notions of "what escapes a value" cannot drift apart.
+// Before this package existed the validator inspected only *ssa.Call and
+// silently accepted pure functions that leaked their argument via channel
+// send, slice/array store, or map store (issue #66).
+//
+// # What counts as a leak
+//
+//	┌────────────────┬──────────────────────┬─────────────────────────────┐
+//	│ Instruction    │ Source syntax        │ Kind                        │
+//	├────────────────┼──────────────────────┼─────────────────────────────┤
+//	│ *ssa.Send      │ ch <- db             │ KindChannelSend             │
+//	│ *ssa.Store     │ slice[i] = db        │ KindSliceStore              │
+//	│ *ssa.MapUpdate │ m[k] = db            │ KindMapStore                │
+//	└────────────────┴──────────────────────┴─────────────────────────────┘
+//
+// Values may be interface-boxed before storage (a []interface{} / map /
+// chan of interface{}); Leak unwraps a single MakeInterface box.
+//
+// # What is deliberately NOT a leak
+//
+//   - Packing into the varargs array of a known read-only stdlib function
+//     (fmt.Println(db), log.Printf("%v", db), t.Logf("%v", db)); these never
+//     retain or mutate their arguments. User-defined variadic functions stay
+//     conservatively polluting. See isReadOnlyVariadicArg.
+//   - A bare *ssa.MakeInterface with no downstream store/use. Interface
+//     conversion alone transfers no ownership; the value is only a leak once
+//     it is stored or passed somewhere, which the cases above already cover.
+//     This matches the main handler's MakeInterfaceHandler (a no-op).
+package pollutionsource
+
+import (
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/mpyw/gormreuse/internal/typeutil"
+)
+
+// Kind classifies a non-call pollution source.
+type Kind int
+
+const (
+	// KindNone means the instruction is not a leak.
+	KindNone Kind = iota
+	// KindChannelSend is `ch <- db`.
+	KindChannelSend
+	// KindSliceStore is `slice[i] = db` (store to a slice/array element).
+	KindSliceStore
+	// KindMapStore is `m[k] = db`.
+	KindMapStore
+)
+
+// UnwrapGormDB extracts the *gorm.DB value from an SSA value that may be
+// wrapped in a single MakeInterface. Returns the value and true if it is (or
+// wraps) a *gorm.DB, otherwise nil and false.
+//
+// This is needed because storing *gorm.DB into interface{} containers (slice,
+// map, channel) makes SSA box the value first, e.g. []interface{}{q} generates
+// MakeInterface(q) -> Store.
+func UnwrapGormDB(v ssa.Value) (ssa.Value, bool) {
+	if typeutil.IsGormDB(v.Type()) {
+		return v, true
+	}
+	if mi, ok := v.(*ssa.MakeInterface); ok && typeutil.IsGormDB(mi.X.Type()) {
+		return mi.X, true
+	}
+	return nil, false
+}
+
+// Leak reports whether instr lets a *gorm.DB escape and, if so, returns the
+// unwrapped *gorm.DB value and the kind of source. Returns (nil, KindNone)
+// otherwise. Read-only variadic stdlib packing is excluded (see the package
+// doc). Callers still decide what a leak means for them (the main handler
+// marks the value polluted; the purity validator reports a contract
+// violation).
+func Leak(instr ssa.Instruction) (ssa.Value, Kind) {
+	switch i := instr.(type) {
+	case *ssa.Send:
+		if v, ok := UnwrapGormDB(i.X); ok {
+			return v, KindChannelSend
+		}
+	case *ssa.Store:
+		// Only stores to a slice/array element (IndexAddr) count; stores to an
+		// Alloc are ordinary variable assignments handled elsewhere.
+		idx, ok := i.Addr.(*ssa.IndexAddr)
+		if !ok {
+			return nil, KindNone
+		}
+		v, ok := UnwrapGormDB(i.Val)
+		if !ok {
+			return nil, KindNone
+		}
+		if isReadOnlyVariadicArg(idx, i.Val) {
+			return nil, KindNone
+		}
+		return v, KindSliceStore
+	case *ssa.MapUpdate:
+		if v, ok := UnwrapGormDB(i.Value); ok {
+			return v, KindMapStore
+		}
+	}
+	return nil, KindNone
+}
+
+// readOnlyVariadicPkgs lists packages whose variadic ...interface{} functions
+// are known not to retain or mutate their arguments (formatting/output/logging
+// only). Passing a *gorm.DB into them must not be treated as a leak.
+var readOnlyVariadicPkgs = map[string]bool{
+	"fmt":     true,
+	"log":     true,
+	"testing": true,
+}
+
+// isReadOnlyVariadicArg reports whether the store packs an interface-boxed
+// *gorm.DB into the varargs array of a variadic call to a known read-only
+// stdlib function (see readOnlyVariadicPkgs). In SSA fmt.Println(q) is:
+//
+//	t2 = new [1]any (varargs)   // array alloc
+//	t3 = &t2[0]                 // idx (IndexAddr)
+//	t4 = make any <- *gorm.DB   // val (MakeInterface — interface-boxed)
+//	*t3 = t4                    // the Store
+//	t5 = slice t2[:]            // sliced ...
+//	t6 = fmt.Println(t5...)     // ... and handed to a variadic call
+//
+// It returns true only when the slot is interface-typed (val is a MakeInterface),
+// the array flows into the variadic argument of a call, AND that callee is an
+// allow-listed read-only stdlib function. This deliberately excludes:
+//   - concrete ...*gorm.DB packs (val is the *gorm.DB directly, not boxed),
+//   - user composite slices like []interface{}{q} (no variadic call), and
+//   - user-defined variadic ...interface{} functions (may branch the value),
+//
+// all of which stay conservatively polluting.
+func isReadOnlyVariadicArg(idx *ssa.IndexAddr, val ssa.Value) bool {
+	if _, ok := val.(*ssa.MakeInterface); !ok {
+		return false
+	}
+	alloc, ok := idx.X.(*ssa.Alloc)
+	if !ok || alloc.Referrers() == nil {
+		return false
+	}
+	for _, r := range *alloc.Referrers() {
+		slice, ok := r.(*ssa.Slice)
+		if !ok || slice.Referrers() == nil {
+			continue
+		}
+		for _, sr := range *slice.Referrers() {
+			call, ok := sr.(*ssa.Call)
+			if !ok {
+				continue
+			}
+			sig := call.Call.Signature()
+			args := call.Call.Args
+			if sig != nil && sig.Variadic() && len(args) > 0 && args[len(args)-1] == slice && isReadOnlyStdlibCallee(call) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isReadOnlyStdlibCallee reports whether call targets a function in an
+// allow-listed read-only package (see readOnlyVariadicPkgs).
+func isReadOnlyStdlibCallee(call *ssa.Call) bool {
+	callee := call.Call.StaticCallee()
+	if callee == nil || callee.Object() == nil || callee.Object().Pkg() == nil {
+		return false
+	}
+	return readOnlyVariadicPkgs[callee.Object().Pkg().Path()]
+}

--- a/internal/ssa/pollutionsource/pollutionsource_test.go
+++ b/internal/ssa/pollutionsource/pollutionsource_test.go
@@ -1,0 +1,150 @@
+package pollutionsource_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+
+	"github.com/mpyw/gormreuse/internal/ssa/pollutionsource"
+)
+
+// testdataDir returns the module-root testdata directory (GOPATH root for the
+// gorm stub and the gormreuse fixture package), computed relative to this file.
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// internal/ssa/pollutionsource -> module root is three levels up.
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..")
+	return filepath.Join(root, "testdata")
+}
+
+// loadFixtureFuncs builds SSA for the testdata/gormreuse fixture package and
+// returns its functions keyed by name.
+func loadFixtureFuncs(t *testing.T) map[string]*ssa.Function {
+	t.Helper()
+	td := testdataDir(t)
+	cfg := &packages.Config{
+		Mode: packages.LoadAllSyntax,
+		Dir:  td,
+		Env:  append(os.Environ(), "GOPATH="+td, "GO111MODULE=off", "GOFLAGS="),
+	}
+	pkgs, err := packages.Load(cfg, "gormreuse")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		t.Fatal("packages had errors")
+	}
+
+	prog, ssaPkgs := ssautil.Packages(pkgs, ssa.BuilderMode(0))
+	prog.Build()
+
+	funcs := make(map[string]*ssa.Function)
+	for _, p := range ssaPkgs {
+		if p == nil {
+			continue
+		}
+		for _, m := range p.Members {
+			if fn, ok := m.(*ssa.Function); ok {
+				funcs[fn.Name()] = fn
+			}
+		}
+	}
+	if len(funcs) == 0 {
+		t.Fatal("no SSA functions loaded from fixture package")
+	}
+	return funcs
+}
+
+// leakKindsIn returns the set of leak kinds pollutionsource.Leak reports across
+// all instructions of fn.
+func leakKindsIn(fn *ssa.Function) map[pollutionsource.Kind]bool {
+	kinds := make(map[pollutionsource.Kind]bool)
+	for _, b := range fn.Blocks {
+		for _, instr := range b.Instrs {
+			if v, k := pollutionsource.Leak(instr); k != pollutionsource.KindNone && v != nil {
+				kinds[k] = true
+			}
+		}
+	}
+	return kinds
+}
+
+// TestLeakEnumeratesSources is the single source of truth check: every non-call
+// pollution source the fixture package exercises is classified by Leak, and
+// non-leaking / read-only-exempt functions produce nothing (issue #66).
+func TestLeakEnumeratesSources(t *testing.T) {
+	t.Parallel()
+	funcs := loadFixtureFuncs(t)
+
+	tests := []struct {
+		fn   string
+		want pollutionsource.Kind // KindNone means "no leak of any kind"
+	}{
+		{"pureLeaksViaChanSend", pollutionsource.KindChannelSend},
+		{"pureLeaksViaSliceStore", pollutionsource.KindSliceStore},
+		{"pureLeaksViaMapStore", pollutionsource.KindMapStore},
+		// Read-only variadic stdlib packing (fmt.Println) must NOT be a leak.
+		{"pureLogsArgReadOnly", pollutionsource.KindNone},
+		// A function that never lets its argument escape.
+		{"pureDoesNothing", pollutionsource.KindNone},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.fn, func(t *testing.T) {
+			t.Parallel()
+			fn, ok := funcs[tc.fn]
+			if !ok {
+				t.Fatalf("fixture function %q not found", tc.fn)
+			}
+			got := leakKindsIn(fn)
+			if tc.want == pollutionsource.KindNone {
+				if len(got) != 0 {
+					t.Errorf("%s: expected no leak, got kinds %v", tc.fn, got)
+				}
+				return
+			}
+			if !got[tc.want] {
+				t.Errorf("%s: expected leak kind %v, got %v", tc.fn, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestUnwrapGormDB covers the interface-box unwrapping used by every source.
+func TestUnwrapGormDB(t *testing.T) {
+	t.Parallel()
+	funcs := loadFixtureFuncs(t)
+
+	// pureLeaksViaInterfaceArg boxes its *gorm.DB parameter into interface{}
+	// via a MakeInterface before the call, so the program contains at least one
+	// MakeInterface wrapping a *gorm.DB that UnwrapGormDB must see through.
+	fn, ok := funcs["pureLeaksViaInterfaceArg"]
+	if !ok {
+		t.Fatal("pureLeaksViaInterfaceArg not found")
+	}
+	var sawBoxedGormDB bool
+	for _, b := range fn.Blocks {
+		for _, instr := range b.Instrs {
+			mi, ok := instr.(*ssa.MakeInterface)
+			if !ok {
+				continue
+			}
+			if _, isGorm := pollutionsource.UnwrapGormDB(mi); isGorm {
+				sawBoxedGormDB = true
+			}
+		}
+	}
+	if !sawBoxedGormDB {
+		t.Error("UnwrapGormDB did not see through a MakeInterface-boxed *gorm.DB")
+	}
+}

--- a/internal/ssa/purity/validator.go
+++ b/internal/ssa/purity/validator.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/tools/go/ssa"
 
 	"github.com/mpyw/gormreuse/internal/directive"
+	"github.com/mpyw/gormreuse/internal/ssa/pollutionsource"
 	"github.com/mpyw/gormreuse/internal/typeutil"
 )
 
@@ -38,6 +39,14 @@ import (
 type Violation struct {
 	Pos     token.Pos
 	Message string
+
+	// Leak is true when the violation is a definitive escape of the argument
+	// (channel send, slice/array store, map store) rather than a conservative
+	// guess (passing to a not-yet-proven-pure function). Only definitive escapes
+	// revoke the function's pure-trust at its call sites — a conservative
+	// func-arg violation might still be pure in practice, and cascading it would
+	// produce false positives (see nestedClosureOuterPureViolation).
+	Leak bool
 }
 
 // =============================================================================
@@ -83,7 +92,13 @@ func ValidateFunction(fn *ssa.Function, pureFuncs *directive.DirectiveFuncSet) [
 
 			if call, ok := instr.(*ssa.Call); ok {
 				violations = append(violations, v.checkCallPollution(call)...)
+				continue
 			}
+
+			// Non-call leaks (channel send, slice/array store, map store).
+			// These share pollutionsource.Leak with the main handler so the
+			// two cannot disagree on what escapes a value (issue #66).
+			violations = append(violations, v.checkLeak(instr)...)
 		}
 	}
 
@@ -169,18 +184,46 @@ func (v *Validator) checkCallPollution(call *ssa.Call) []Violation {
 	// because IsGormDB only matches *gorm.DB (concrete pointer type).
 	// GORM's DB is a struct, so all method calls go through StaticCallee.
 
-	// Static call
 	callee := call.Call.StaticCallee()
-	if callee == nil {
+
+	// gorm chain method on a param-derived receiver pollutes the argument.
+	if callee != nil {
+		sig := callee.Signature
+		if sig != nil && sig.Recv() != nil && typeutil.IsGormDB(sig.Recv().Type()) {
+			return v.checkStaticMethodPollution(call, callee)
+		}
+	}
+
+	// Any other call — a static function, a builtin (e.g. append, which is how
+	// slice storage lowers), or an indirect call through a func value — leaks a
+	// param-derived *gorm.DB passed to it, unless the callee is itself pure.
+	// callee is nil for builtins and indirect calls; those are never pure, so
+	// they leak conservatively, matching the main handler.
+	return v.checkFunctionCallPollution(call, callee)
+}
+
+// checkLeak reports a contract violation when a param-derived *gorm.DB escapes
+// via a non-call pollution source (channel send, slice/array store, map store).
+func (v *Validator) checkLeak(instr ssa.Instruction) []Violation {
+	val, kind := pollutionsource.Leak(instr)
+	if kind == pollutionsource.KindNone || !v.paramDerived[val] {
 		return nil
 	}
 
-	sig := callee.Signature
-	if sig != nil && sig.Recv() != nil && typeutil.IsGormDB(sig.Recv().Type()) {
-		return v.checkStaticMethodPollution(call, callee)
+	var via string
+	switch kind {
+	case pollutionsource.KindChannelSend:
+		via = "channel send"
+	case pollutionsource.KindSliceStore:
+		via = "slice/array store"
+	case pollutionsource.KindMapStore:
+		via = "map store"
 	}
-
-	return v.checkFunctionCallPollution(call, callee)
+	return []Violation{{
+		Pos:     instr.Pos(),
+		Message: "pure function leaks *gorm.DB argument via " + via,
+		Leak:    true,
+	}}
 }
 
 func (v *Validator) checkStaticMethodPollution(call *ssa.Call, callee *ssa.Function) []Violation {
@@ -200,14 +243,36 @@ func (v *Validator) checkStaticMethodPollution(call *ssa.Call, callee *ssa.Funct
 }
 
 func (v *Validator) checkFunctionCallPollution(call *ssa.Call, callee *ssa.Function) []Violation {
+	// Pure callees don't pollute their arguments.
+	if callee != nil && v.pureFuncs.Contains(callee) {
+		return nil
+	}
+
 	var violations []Violation
 	for _, arg := range call.Call.Args {
-		if typeutil.IsGormDB(arg.Type()) && v.paramDerived[arg] && !v.pureFuncs.Contains(callee) {
-			violations = append(violations, Violation{
-				Pos:     call.Pos(),
-				Message: "pure function passes *gorm.DB argument to non-pure function " + callee.Name(),
-			})
+		// Unwrap interface-boxed args so a *gorm.DB passed as interface{}
+		// (e.g. to a variadic ...any function) is still caught.
+		gormArg, ok := pollutionsource.UnwrapGormDB(arg)
+		if !ok || !v.paramDerived[gormArg] {
+			continue
 		}
+		violations = append(violations, Violation{
+			Pos:     call.Pos(),
+			Message: "pure function passes *gorm.DB argument to non-pure function " + calleeName(call, callee),
+		})
 	}
 	return violations
+}
+
+// calleeName returns a human-readable name for a call's target: the function
+// name for static calls, the builtin name for builtins (append, etc.), or a
+// generic label for indirect calls through a func value.
+func calleeName(call *ssa.Call, callee *ssa.Function) string {
+	if callee != nil {
+		return callee.Name()
+	}
+	if b, ok := call.Call.Value.(*ssa.Builtin); ok {
+		return b.Name()
+	}
+	return "(closure)"
 }

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -94,13 +94,20 @@ import (
 type RootTracer struct {
 	pureFuncs            *directive.DirectiveFuncSet // User-defined pure functions
 	immutableReturnFuncs *directive.DirectiveFuncSet // Functions returning immutable *gorm.DB
+	failedPure           map[*ssa.Function]bool      // Pure functions that FAILED contract validation
 }
 
 // New creates a new RootTracer.
-func New(pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet) *RootTracer {
+//
+// failedPure lists functions marked //gormreuse:pure whose bodies definitively
+// leaked their *gorm.DB argument (channel send, slice/array store, map store;
+// validated earlier this pass). They must NOT be trusted as pure at call sites
+// — doing so would hide reuse of the value they leak (issue #66). It may be nil.
+func New(pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool) *RootTracer {
 	return &RootTracer{
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
+		failedPure:           failedPure,
 	}
 }
 
@@ -156,7 +163,15 @@ func (t *RootTracer) IsPureFunction(fn *ssa.Function) bool {
 	if fn == nil {
 		return false
 	}
-	return t.IsImmutableReturningBuiltin(fn) || t.pureFuncs.Contains(fn)
+	if t.IsImmutableReturningBuiltin(fn) {
+		return true
+	}
+	// A //gormreuse:pure function that failed its own contract validation is
+	// NOT trusted here: its callers must see the leak it hides.
+	if t.failedPure[fn] {
+		return false
+	}
+	return t.pureFuncs.Contains(fn)
 }
 
 // IsImmutableReturningBuiltin checks if a function is a builtin method that returns immutable *gorm.DB.

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -1,6 +1,10 @@
 package internal
 
-import "gorm.io/gorm"
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
 
 // =============================================================================
 // Directive Validation Test Cases
@@ -90,6 +94,49 @@ func pureOperatesOnSessionResult(db *gorm.DB) {
 	s.Where("x") // OK: s is immutable (result of Session), so this doesn't pollute db
 }
 
+// PV010: Pure function leaks argument via channel send.
+// A "pure" function must not let its argument escape — the receiver of the
+// channel could branch it concurrently (issue #66).
+//
+//gormreuse:pure
+func pureLeaksViaChanSend(db *gorm.DB, ch chan *gorm.DB) {
+	ch <- db // want `pure function leaks \*gorm\.DB argument via channel send`
+}
+
+// PV011: Pure function leaks argument via slice element store.
+//
+//gormreuse:pure
+func pureLeaksViaSliceStore(db *gorm.DB, dst []*gorm.DB) {
+	dst[0] = db // want `pure function leaks \*gorm\.DB argument via slice/array store`
+}
+
+// PV012: Pure function leaks argument via map store.
+//
+//gormreuse:pure
+func pureLeaksViaMapStore(db *gorm.DB, m map[string]*gorm.DB) {
+	m["k"] = db // want `pure function leaks \*gorm\.DB argument via map store`
+}
+
+// PV013: Pure function leaks argument by boxing it into interface{} and passing
+// it to a non-pure function. Interface conversion alone is not a leak, but the
+// non-pure call it flows into is.
+//
+//gormreuse:pure
+func pureLeaksViaInterfaceArg(db *gorm.DB) {
+	nonPureTakesAny(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureTakesAny`
+}
+
+// PV015: Reuse after a pure function that DEFINITIVELY leaks its argument is
+// reported at the call site — such a function loses its pure-trust (issue #66).
+func reuseAfterLeakingPure(db *gorm.DB, ch chan *gorm.DB) {
+	q := db.Where("x")
+	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
+	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+}
+
+// nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
+func nonPureTakesAny(v interface{}) {}
+
 // =============================================================================
 // SHOULD NOT REPORT - Valid pure functions
 // =============================================================================
@@ -99,6 +146,25 @@ func pureOperatesOnSessionResult(db *gorm.DB) {
 //gormreuse:pure
 func pureDoesNothing(db *gorm.DB) {
 	_ = db // Just reference, no method calls
+}
+
+// PV116: Pure function passing argument to a read-only variadic stdlib function
+// (fmt.Println) does NOT leak — these never retain or mutate their arguments.
+// The exemption is shared with the main handler via pollutionsource (issue #66).
+//
+//gormreuse:pure
+func pureLogsArgReadOnly(db *gorm.DB) {
+	fmt.Println("db:", db) // OK: read-only variadic stdlib, not a leak
+}
+
+// PV117: Reuse after a pure function whose ONLY violation is conservative
+// (passing to a not-proven-pure function) is NOT reported at the call site —
+// the pure annotation is still trusted, avoiding false positives. Contrast with
+// PV015, where the callee definitively leaks.
+func reuseAfterConservativePure(db *gorm.DB) {
+	q := db.Where("x")
+	purePollutesViaNonPureFunc(q) // conservative violation inside; still trusted here
+	q.Find(nil)                   // OK - no cascade to the caller
 }
 
 // PV102: Pure function only calls pure builtin methods

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,9 +1,13 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1061 +1,1061 @@
+@@ -1,1127 +1,1127 @@
  package internal
  
- import "gorm.io/gorm"
+ import (
+ 	"fmt"
+ 
+ 	"gorm.io/gorm"
+ )
  
  // =============================================================================
  // Directive Validation Test Cases
@@ -93,6 +97,50 @@
  	s.Where("x") // OK: s is immutable (result of Session), so this doesn't pollute db
  }
  
+ // PV010: Pure function leaks argument via channel send.
+ // A "pure" function must not let its argument escape — the receiver of the
+ // channel could branch it concurrently (issue #66).
+ //
+ //gormreuse:pure
+ func pureLeaksViaChanSend(db *gorm.DB, ch chan *gorm.DB) {
+ 	ch <- db // want `pure function leaks \*gorm\.DB argument via channel send`
+ }
+ 
+ // PV011: Pure function leaks argument via slice element store.
+ //
+ //gormreuse:pure
+ func pureLeaksViaSliceStore(db *gorm.DB, dst []*gorm.DB) {
+ 	dst[0] = db // want `pure function leaks \*gorm\.DB argument via slice/array store`
+ }
+ 
+ // PV012: Pure function leaks argument via map store.
+ //
+ //gormreuse:pure
+ func pureLeaksViaMapStore(db *gorm.DB, m map[string]*gorm.DB) {
+ 	m["k"] = db // want `pure function leaks \*gorm\.DB argument via map store`
+ }
+ 
+ // PV013: Pure function leaks argument by boxing it into interface{} and passing
+ // it to a non-pure function. Interface conversion alone is not a leak, but the
+ // non-pure call it flows into is.
+ //
+ //gormreuse:pure
+ func pureLeaksViaInterfaceArg(db *gorm.DB) {
+ 	nonPureTakesAny(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureTakesAny`
+ }
+ 
+ // PV015: Reuse after a pure function that DEFINITIVELY leaks its argument is
+ // reported at the call site — such a function loses its pure-trust (issue #66).
+ func reuseAfterLeakingPure(db *gorm.DB, ch chan *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
+ 	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
+ func nonPureTakesAny(v interface{}) {}
+ 
  // =============================================================================
  // SHOULD NOT REPORT - Valid pure functions
  // =============================================================================
@@ -102,6 +150,25 @@
  //gormreuse:pure
  func pureDoesNothing(db *gorm.DB) {
  	_ = db // Just reference, no method calls
+ }
+ 
+ // PV116: Pure function passing argument to a read-only variadic stdlib function
+ // (fmt.Println) does NOT leak — these never retain or mutate their arguments.
+ // The exemption is shared with the main handler via pollutionsource (issue #66).
+ //
+ //gormreuse:pure
+ func pureLogsArgReadOnly(db *gorm.DB) {
+ 	fmt.Println("db:", db) // OK: read-only variadic stdlib, not a leak
+ }
+ 
+ // PV117: Reuse after a pure function whose ONLY violation is conservative
+ // (passing to a not-proven-pure function) is NOT reported at the call site —
+ // the pure annotation is still trusted, avoiding false positives. Contrast with
+ // PV015, where the callee definitively leaks.
+ func reuseAfterConservativePure(db *gorm.DB) {
+ 	q := db.Where("x")
+ 	purePollutesViaNonPureFunc(q) // conservative violation inside; still trusted here
+ 	q.Find(nil)                   // OK - no cascade to the caller
  }
  
  // PV102: Pure function only calls pure builtin methods

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -1,6 +1,10 @@
 package internal
 
-import "gorm.io/gorm"
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
 
 // =============================================================================
 // Directive Validation Test Cases
@@ -90,6 +94,49 @@ func pureOperatesOnSessionResult(db *gorm.DB) {
 	s.Where("x") // OK: s is immutable (result of Session), so this doesn't pollute db
 }
 
+// PV010: Pure function leaks argument via channel send.
+// A "pure" function must not let its argument escape — the receiver of the
+// channel could branch it concurrently (issue #66).
+//
+//gormreuse:pure
+func pureLeaksViaChanSend(db *gorm.DB, ch chan *gorm.DB) {
+	ch <- db // want `pure function leaks \*gorm\.DB argument via channel send`
+}
+
+// PV011: Pure function leaks argument via slice element store.
+//
+//gormreuse:pure
+func pureLeaksViaSliceStore(db *gorm.DB, dst []*gorm.DB) {
+	dst[0] = db // want `pure function leaks \*gorm\.DB argument via slice/array store`
+}
+
+// PV012: Pure function leaks argument via map store.
+//
+//gormreuse:pure
+func pureLeaksViaMapStore(db *gorm.DB, m map[string]*gorm.DB) {
+	m["k"] = db // want `pure function leaks \*gorm\.DB argument via map store`
+}
+
+// PV013: Pure function leaks argument by boxing it into interface{} and passing
+// it to a non-pure function. Interface conversion alone is not a leak, but the
+// non-pure call it flows into is.
+//
+//gormreuse:pure
+func pureLeaksViaInterfaceArg(db *gorm.DB) {
+	nonPureTakesAny(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureTakesAny`
+}
+
+// PV015: Reuse after a pure function that DEFINITIVELY leaks its argument is
+// reported at the call site — such a function loses its pure-trust (issue #66).
+func reuseAfterLeakingPure(db *gorm.DB, ch chan *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
+	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+}
+
+// nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
+func nonPureTakesAny(v interface{}) {}
+
 // =============================================================================
 // SHOULD NOT REPORT - Valid pure functions
 // =============================================================================
@@ -99,6 +146,25 @@ func pureOperatesOnSessionResult(db *gorm.DB) {
 //gormreuse:pure
 func pureDoesNothing(db *gorm.DB) {
 	_ = db // Just reference, no method calls
+}
+
+// PV116: Pure function passing argument to a read-only variadic stdlib function
+// (fmt.Println) does NOT leak — these never retain or mutate their arguments.
+// The exemption is shared with the main handler via pollutionsource (issue #66).
+//
+//gormreuse:pure
+func pureLogsArgReadOnly(db *gorm.DB) {
+	fmt.Println("db:", db) // OK: read-only variadic stdlib, not a leak
+}
+
+// PV117: Reuse after a pure function whose ONLY violation is conservative
+// (passing to a not-proven-pure function) is NOT reported at the call site —
+// the pure annotation is still trusted, avoiding false positives. Contrast with
+// PV015, where the callee definitively leaks.
+func reuseAfterConservativePure(db *gorm.DB) {
+	q := db.Where("x")
+	purePollutesViaNonPureFunc(q) // conservative violation inside; still trusted here
+	q.Find(nil)                   // OK - no cascade to the caller
 }
 
 // PV102: Pure function only calls pure builtin methods


### PR DESCRIPTION
## Summary

Closes #66 (B3). `//gormreuse:pure` contract validation only inspected `*ssa.Call`, so a "pure" function that leaked its `*gorm.DB` argument via **channel send, slice/array store, or map store** passed validation silently — and callers then trusted it, hiding downstream reuse.

## What changed

- **New `internal/ssa/pollutionsource` package — the single source of truth** for the non-call instruction shapes that let a `*gorm.DB` escape (`Send` / slice-`Store` / `MapUpdate`), including the read-only variadic stdlib exemption (`fmt`/`log`/`testing`, from #65) and `MakeInterface` unwrapping. Both the main handler and the purity validator now consume it, so they can no longer disagree on what escapes a value (the asymmetry that caused this bug).
- **`purity.ValidateFunction` now flags those leaks**, and its function-call path unwraps interface-boxed args and covers builtins / indirect calls (it previously bailed on `callee == nil`, missing e.g. `append` and `interface{}` boxing).
- **Caller-trust revocation for definitive escapes.** A `//gormreuse:pure` function that *definitively* leaks its argument loses its pure-trust at call sites (`RunSSA` validates all pure funcs first, then threads the failed set into `RootTracer.IsPureFunction`), so the caller's later reuse is reported (acceptance criterion "`caller` warns"). **Conservative** func-arg violations (passing to a not-yet-proven-pure function) do **not** revoke trust — they may be pure in practice and cascading them would produce false positives (this is why the existing `nestedClosureOuterPure*` fixtures keep their behavior).

## Acceptance criteria (from #66)

- [x] `//gormreuse:pure` function leaking via chan/slice/map/interface is reported as a pure-contract violation.
- [x] `caller` reusing after a definitively-leaking pure function warns (PV015).
- [x] Pollution-source list defined once (validator and handler share `pollutionsource`), with a test enumerating the sources (`pollutionsource_test.go`).

## Design note for reviewers

The "definitive escape vs conservative guess" split is deliberate:

- **chan send / slice-store / map-store** move the value somewhere observable regardless of what the receiver does → sound to revoke caller trust, and consistent with how the main analyzer already treats these (unconditional pollution).
- **passing to a non-pure function** is a conservative guess (the callee might be pure-in-practice but unannotated); the pure annotation is an explicit "trust me", so we report the internal violation but don't cascade to callers. Reversing that would false-positive on patterns like `outer` calling an inner that does `_ = q`.

## Testing

- `go test ./...` green; `golangci-lint run ./...` 0 issues.
- `cd testdata/e2e && go test ./...` and `cd e2e/internal && go test ./...` green.
- New-code coverage: `pollutionsource.Leak`/`UnwrapGormDB` 100%, `checkLeak` 100%, `checkCallPollution` 100%.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv