### PR TITLE
fix: directive matching — package-level var closures and interface unused-detection (#72)

### DIFF
--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -519,14 +519,17 @@ func TestContainsGormDB(t *testing.T) {
 			expected: false,
 		},
 		{
+			// gap4 (#72): containsGormDB drives ONLY unused-directive detection,
+			// which requires a concrete *gorm.DB in the signature. A bare
+			// interface is no longer treated as potentially-gorm.
 			name:     "empty interface (interface{})",
 			typ:      types.NewInterfaceType(nil, nil),
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "non-empty interface",
 			typ:      types.NewInterfaceType([]*types.Func{types.NewFunc(0, nil, "Method", types.NewSignatureType(nil, nil, nil, nil, nil, false))}, nil),
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/internal/directive/pure.go
+++ b/internal/directive/pure.go
@@ -677,7 +677,11 @@ func (s *DirectiveFuncSet) isDirectValueInStatementAfterLine(file *ast.File, fun
 	}
 
 	if enclosingStmt == nil {
-		return false
+		// No enclosing statement: this is a package-level `var f = func(){}`
+		// declaration (a GenDecl/ValueSpec is a Decl, not a Stmt). Local-var
+		// closures reach here via a DeclStmt and are handled above; package-level
+		// ones need the ValueSpec handled directly (issue #72 gap2).
+		return s.isDirectValueInValueSpecAfterLine(path, funcLit, directiveLine)
 	}
 
 	stmtLine := s.fset.Position(enclosingStmt.Pos()).Line
@@ -701,6 +705,51 @@ func (s *DirectiveFuncSet) isDirectValueInStatementAfterLine(file *ast.File, fun
 
 	// Check if FuncLit is a direct value (not inside CompositeLit)
 	return s.isDirectRHSValue(enclosingStmt, funcLit)
+}
+
+// isDirectValueInValueSpecAfterLine handles the package-level counterpart of
+// isDirectValueInStatementAfterLine: a closure that is a direct RHS value of a
+// package-level `var` declaration whose directive sits on the preceding line.
+//
+//	//gormreuse:pure
+//	var pkgFn = func(q *gorm.DB) { ... }   ← pkgFn gets the directive
+//
+// As with the statement form, the closure must be a DIRECT value in the spec
+// (not nested inside a composite literal), and either the spec or the closure
+// must begin on directiveLine+1. All direct closures in a multi-value spec
+// (`var a, b = func(){}, func(){}`) get the directive.
+func (s *DirectiveFuncSet) isDirectValueInValueSpecAfterLine(path []ast.Node, funcLit *ast.FuncLit, directiveLine int) bool {
+	expectedLine := directiveLine + 1
+
+	var spec *ast.ValueSpec
+	for _, node := range path {
+		if vs, ok := node.(*ast.ValueSpec); ok {
+			spec = vs
+			break
+		}
+		// A composite literal between the FuncLit and the spec means the closure
+		// is not a direct value (e.g. `var x = &S{Fn: func(){}}`).
+		if _, ok := node.(*ast.CompositeLit); ok {
+			return false
+		}
+	}
+	if spec == nil {
+		return false
+	}
+
+	specLine := s.fset.Position(spec.Pos()).Line
+	funcLitLine := s.fset.Position(funcLit.Pos()).Line
+	if specLine != expectedLine && funcLitLine != expectedLine {
+		return false
+	}
+
+	// The closure must be a direct value of the spec.
+	for _, v := range spec.Values {
+		if v == funcLit {
+			return true
+		}
+	}
+	return false
 }
 
 // isFirstStatementOnLine checks if the given statement is the first (leftmost) one on its line.

--- a/internal/directive/signature.go
+++ b/internal/directive/signature.go
@@ -78,8 +78,16 @@ func containsGormDBWithCache(t types.Type, cache map[types.Type]*cacheEntry) boo
 	result := false
 	switch typ := underlying.(type) {
 	case *types.Interface:
-		// Any interface type could potentially hold *gorm.DB at runtime
-		result = true
+		// An interface could hold *gorm.DB at runtime, but this predicate only
+		// drives unused-directive detection, where we require the signature to
+		// name a CONCRETE *gorm.DB before treating the directive as satisfied.
+		// The pure/immutable-return analysis never tracks values through an
+		// interface-typed parameter/return anyway (it keys on the concrete
+		// *gorm.DB type), so a purely interface-typed signature genuinely does
+		// nothing — reporting it as unused is the correct, actionable signal
+		// (issue #72 gap4). NOTE: containsGormDB is used ONLY for unused
+		// detection; the SSA tracer uses its own containsGormDBThroughPointers.
+		result = false
 	case *types.Struct:
 		for i := 0; i < typ.NumFields(); i++ {
 			if containsGormDBWithCache(typ.Field(i).Type(), cache) {

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -25,6 +25,16 @@ import (
 // SHOULD REPORT - Pure function pollutes argument
 // =============================================================================
 
+// PV000: Directive on a package-level `var` closure is matched, not reported as
+// unused (issue #72 gap2). A package-level var is a Decl, not a Stmt, so the
+// directive-matching path must handle the ValueSpec directly. (The closure body
+// itself is not contract-validated — package-level var closures are not among
+// the analyzed source functions — but the directive is correctly associated, so
+// no spurious "unused" warning is emitted.)
+//
+//gormreuse:pure
+var pkgLevelPureClosure = func(q *gorm.DB) { _ = q }
+
 // PV001: Pure function calls non-pure method on argument
 //
 //gormreuse:pure
@@ -412,9 +422,13 @@ func pureReturningClosure(db *gorm.DB) func() {
 	}
 }
 
-// PV213: TypeAssert - extracting *gorm.DB from interface{}
+// PV213: TypeAssert - extracting *gorm.DB from interface{}.
+// The pure directive is vacuous here: the parameter is interface{}, not a
+// concrete *gorm.DB, so there is no argument for the pure contract to govern.
+// gap4 (#72) requires a concrete *gorm.DB in the signature, so this is reported
+// as unused.
 //
-//gormreuse:pure
+//gormreuse:pure // want `unused gormreuse:pure directive`
 func pureWithTypeAssert(v interface{}) *gorm.DB {
 	if db, ok := v.(*gorm.DB); ok {
 		return db.Session(&gorm.Session{})
@@ -466,13 +480,13 @@ func pureReturnsMapValue(m map[string]*gorm.DB) *gorm.DB {
 	return m["key"] // OK - no *gorm.DB argument pollution
 }
 
-// PV219: Return type assertion result directly (TypeAssert)
-// TypeAssert traces through to underlying value (interface{})
-// Since interface{} is not *gorm.DB, returns Clean
+// PV219: Return type assertion result directly (TypeAssert).
+// As with PV213, the parameter is interface{} (no concrete *gorm.DB), so the
+// pure directive governs nothing and is reported as unused (gap4, #72).
 //
-//gormreuse:pure
+//gormreuse:pure // want `unused gormreuse:pure directive`
 func pureReturnsTypeAssertDirect(v interface{}) *gorm.DB {
-	return v.(*gorm.DB) // OK: traces to v (Clean - interface{} not *gorm.DB)
+	return v.(*gorm.DB) // traces to v (interface{}, not *gorm.DB)
 }
 
 // PV220: Return type alias conversion (ChangeType)
@@ -787,6 +801,15 @@ func mixImmutableAndMutable(db *gorm.DB) {
 	imm.Find(nil)      // OK: imm is immutable
 	q.Find(nil)
 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// IR103: immutable-return on a function whose return type is a bare interface{}
+// (no concrete *gorm.DB anywhere in the signature) is vacuous — the directive
+// governs nothing, so it is reported as unused (gap4, #72).
+//
+//gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
+func immutableReturnInterface() interface{} {
+	return globalDB.Session(&gorm.Session{})
 }
 
 // #############################################################################

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1127 +1,1127 @@
+@@ -1,1150 +1,1150 @@
  package internal
  
  import (
@@ -27,6 +27,16 @@
  // =============================================================================
  // SHOULD REPORT - Pure function pollutes argument
  // =============================================================================
+ 
+ // PV000: Directive on a package-level `var` closure is matched, not reported as
+ // unused (issue #72 gap2). A package-level var is a Decl, not a Stmt, so the
+ // directive-matching path must handle the ValueSpec directly. (The closure body
+ // itself is not contract-validated — package-level var closures are not among
+ // the analyzed source functions — but the directive is correctly associated, so
+ // no spurious "unused" warning is emitted.)
+ //
+ //gormreuse:pure
+ var pkgLevelPureClosure = func(q *gorm.DB) { _ = q }
  
  // PV001: Pure function calls non-pure method on argument
  //
@@ -416,9 +426,13 @@
  	}
  }
  
- // PV213: TypeAssert - extracting *gorm.DB from interface{}
+ // PV213: TypeAssert - extracting *gorm.DB from interface{}.
+ // The pure directive is vacuous here: the parameter is interface{}, not a
+ // concrete *gorm.DB, so there is no argument for the pure contract to govern.
+ // gap4 (#72) requires a concrete *gorm.DB in the signature, so this is reported
+ // as unused.
  //
- //gormreuse:pure
+ //gormreuse:pure // want `unused gormreuse:pure directive`
  func pureWithTypeAssert(v interface{}) *gorm.DB {
  	if db, ok := v.(*gorm.DB); ok {
  		return db.Session(&gorm.Session{})
@@ -470,13 +484,13 @@
  	return m["key"] // OK - no *gorm.DB argument pollution
  }
  
- // PV219: Return type assertion result directly (TypeAssert)
- // TypeAssert traces through to underlying value (interface{})
- // Since interface{} is not *gorm.DB, returns Clean
+ // PV219: Return type assertion result directly (TypeAssert).
+ // As with PV213, the parameter is interface{} (no concrete *gorm.DB), so the
+ // pure directive governs nothing and is reported as unused (gap4, #72).
  //
- //gormreuse:pure
+ //gormreuse:pure // want `unused gormreuse:pure directive`
  func pureReturnsTypeAssertDirect(v interface{}) *gorm.DB {
- 	return v.(*gorm.DB) // OK: traces to v (Clean - interface{} not *gorm.DB)
+ 	return v.(*gorm.DB) // traces to v (interface{}, not *gorm.DB)
  }
  
  // PV220: Return type alias conversion (ChangeType)
@@ -793,6 +807,15 @@
  	imm.Find(nil)      // OK: imm is immutable
  	q.Find(nil)
  	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ }
+ 
+ // IR103: immutable-return on a function whose return type is a bare interface{}
+ // (no concrete *gorm.DB anywhere in the signature) is vacuous — the directive
+ // governs nothing, so it is reported as unused (gap4, #72).
+ //
+ //gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
+ func immutableReturnInterface() interface{} {
+ 	return globalDB.Session(&gorm.Session{})
  }
  
  // #############################################################################

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -25,6 +25,16 @@ import (
 // SHOULD REPORT - Pure function pollutes argument
 // =============================================================================
 
+// PV000: Directive on a package-level `var` closure is matched, not reported as
+// unused (issue #72 gap2). A package-level var is a Decl, not a Stmt, so the
+// directive-matching path must handle the ValueSpec directly. (The closure body
+// itself is not contract-validated — package-level var closures are not among
+// the analyzed source functions — but the directive is correctly associated, so
+// no spurious "unused" warning is emitted.)
+//
+//gormreuse:pure
+var pkgLevelPureClosure = func(q *gorm.DB) { _ = q }
+
 // PV001: Pure function calls non-pure method on argument
 //
 //gormreuse:pure
@@ -412,9 +422,13 @@ func pureReturningClosure(db *gorm.DB) func() {
 	}
 }
 
-// PV213: TypeAssert - extracting *gorm.DB from interface{}
+// PV213: TypeAssert - extracting *gorm.DB from interface{}.
+// The pure directive is vacuous here: the parameter is interface{}, not a
+// concrete *gorm.DB, so there is no argument for the pure contract to govern.
+// gap4 (#72) requires a concrete *gorm.DB in the signature, so this is reported
+// as unused.
 //
-//gormreuse:pure
+//gormreuse:pure // want `unused gormreuse:pure directive`
 func pureWithTypeAssert(v interface{}) *gorm.DB {
 	if db, ok := v.(*gorm.DB); ok {
 		return db.Session(&gorm.Session{})
@@ -466,13 +480,13 @@ func pureReturnsMapValue(m map[string]*gorm.DB) *gorm.DB {
 	return m["key"] // OK - no *gorm.DB argument pollution
 }
 
-// PV219: Return type assertion result directly (TypeAssert)
-// TypeAssert traces through to underlying value (interface{})
-// Since interface{} is not *gorm.DB, returns Clean
+// PV219: Return type assertion result directly (TypeAssert).
+// As with PV213, the parameter is interface{} (no concrete *gorm.DB), so the
+// pure directive governs nothing and is reported as unused (gap4, #72).
 //
-//gormreuse:pure
+//gormreuse:pure // want `unused gormreuse:pure directive`
 func pureReturnsTypeAssertDirect(v interface{}) *gorm.DB {
-	return v.(*gorm.DB) // OK: traces to v (Clean - interface{} not *gorm.DB)
+	return v.(*gorm.DB) // traces to v (interface{}, not *gorm.DB)
 }
 
 // PV220: Return type alias conversion (ChangeType)
@@ -787,6 +801,15 @@ func mixImmutableAndMutable(db *gorm.DB) {
 	imm.Find(nil)      // OK: imm is immutable
 	q.Find(nil)
 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+}
+
+// IR103: immutable-return on a function whose return type is a bare interface{}
+// (no concrete *gorm.DB anywhere in the signature) is vacuous — the directive
+// governs nothing, so it is reported as unused (gap4, #72).
+//
+//gormreuse:immutable-return // want `unused gormreuse:immutable-return directive`
+func immutableReturnInterface() interface{} {
+	return globalDB.Session(&gorm.Session{})
 }
 
 // #############################################################################


### PR DESCRIPTION
## Summary

Completes #72 — gaps **2** and **4** (gaps 1 and 3 landed in #83).

### gap2 — package-level `var` closures could not be marked pure / immutable-return

```go
//gormreuse:pure
var pkgFn = func(q *gorm.DB) { ... } // was reported "unused gormreuse:pure directive"
```

`isDirectValueInStatementAfterLine` only searched for an enclosing `ast.Stmt`, but a package-level `var f = func(){}` is a `Decl`/`ValueSpec`, not a `Stmt`, so the directive was neither applied nor matched → false "unused". Added `isDirectValueInValueSpecAfterLine` to handle the `ValueSpec` directly. Because `findDirectiveForFuncLit` is the shared choke point for both unused-detection and call-site matching, the single fix covers both.

(The closure *body* is still not contract-validated — package-level var closures aren't among the analyzed source functions, and calls through a func-typed var are indirect and treated conservatively anyway — but the spurious "unused" warning is gone, which was the reported symptom.)

### gap4 — interface-only signatures were never flagged unused

```go
//gormreuse:immutable-return
func F() interface{} { ... } // was silently accepted as "used"
```

`containsGormDB` treated *any* interface as potentially-gorm. That predicate drives **only** unused-directive detection (the SSA tracer uses its own `containsGormDBThroughPointers`), and the pure / immutable-return analysis never tracks values through an interface-typed parameter/return — so a purely interface-typed signature is genuinely vacuous. Now requires a concrete `*gorm.DB` somewhere in the signature.

## Fixtures

- **PV000** — package-level var closure is matched, not reported unused (verified regression guard: reverting the fix re-introduces the "unused" warning).
- **IR103** — `immutable-return` on `func() interface{}` is now reported unused.
- **PV213 / PV219** — updated to expect the now-correct unused warning (their `pure` directive on an `interface{}`-only-param function was always vacuous).
- `TestContainsGormDB` updated for the new interface semantics.

## Note on gap4's scope (for reviewer)

This reclassifies `pure`/`immutable-return` on interface-only signatures as **unused** — a small user-facing behavior change the issue recommends ("require at least one concrete `*gorm.DB`"). It's correct because the analysis can't act on interface-typed args/returns anyway. Flagging me if you'd rather keep the conservative accept.

## Testing

`go test ./...`, both e2e modules, and `golangci-lint run ./...` all green.

Closes #72. Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv