### PR TITLE
feat: Phase 1a — Scopes/Preload callback params as mutable roots (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,26 @@ q.Session(&gorm.Session{}).Count(&c) // VIOLATION: second branch from q
 > db.Where("base").Where("a").Where("b").Find(&users)  // OK - single chain
 > ```
 
+#### Scopes / Preload callbacks
+
+The [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) passed to a [`Scopes`](https://pkg.go.dev/gorm.io/gorm#DB.Scopes) / [`Preload`](https://pkg.go.dev/gorm.io/gorm#DB.Preload) callback is a **mid-chain (mutable) value**, so reusing it inside the callback is a violation — just like any other mutable value:
+
+```go
+db.Scopes(func(tx *gorm.DB) *gorm.DB {
+    tx.Where("a").Find(&users) // first branch from tx - OK
+    return tx.Where("b")       // VIOLATION: second branch from tx
+})
+```
+
+This applies **only** to callbacks actually handed to `Scopes`/`Preload`. An ordinary parameter of a plain helper is still treated as immutable (the caller's responsibility) and needs no migration:
+
+```go
+func helper(tx *gorm.DB) *gorm.DB {
+    tx.Where("a").Find(&users) // OK - ordinary parameter is treated as immutable
+    return tx.Where("b")
+}
+```
+
 #### Safe: Variable reassignment
 
 Variable reassignment creates a **new mutable root**, so the variable can be used fresh:

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -46,6 +46,7 @@ import (
 	ssautil "github.com/mpyw/gormreuse/internal/ssa"
 	"github.com/mpyw/gormreuse/internal/ssa/pollution"
 	"github.com/mpyw/gormreuse/internal/ssa/purity"
+	"github.com/mpyw/gormreuse/internal/ssa/tracer"
 )
 
 // =============================================================================
@@ -134,13 +135,17 @@ func RunSSA(
 		}
 	}
 
+	// Collect Scopes/Preload callbacks once: their *gorm.DB parameter receives a
+	// mid-chain (clone==0) value, so reuse inside them must be detected (#60).
+	scopesCallbacks := tracer.CollectScopesCallbacks(ssaInfo.SrcFuncs)
+
 	// PASS 2: run SSA reuse analysis.
 	for _, fn := range ssaInfo.SrcFuncs {
 		if skip(fn, true) {
 			continue
 		}
 
-		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, failedPure, globalReported, globalSuggestedEdits, fixGen)
+		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, globalReported, globalSuggestedEdits, fixGen)
 		chk.checkFunction(fn)
 	}
 
@@ -195,6 +200,7 @@ type checker struct {
 	pureFuncs            *directive.DirectiveFuncSet // Pure functions for analysis
 	immutableReturnFuncs *directive.DirectiveFuncSet // Immutable-return functions
 	failedPure           map[*ssa.Function]bool      // Pure functions that failed contract validation
+	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
 	reported             map[token.Pos]bool          // Deduplication of reports
 	suggestedEdits       map[editKey]bool            // Global deduplication of suggested fixes
 	fixGen               *fix.Generator              // Cached fix generator for all violations
@@ -212,13 +218,14 @@ type editKey struct {
 // across parent functions and their closures.
 // The suggestedEdits map is shared to avoid duplicate fix edits.
 // The fixGen is shared to avoid recreating the generator for each violation.
-func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
+func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
 	return &checker{
 		pass:                 pass,
 		ignoreMap:            ignoreMap,
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
 		failedPure:           failedPure,
+		scopesCallbacks:      scopesCallbacks,
 		reported:             reported,
 		suggestedEdits:       suggestedEdits,
 		fixGen:               fixGen,
@@ -227,7 +234,7 @@ func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, i
 
 // checkFunction runs SSA analysis on a single function and reports violations.
 func (c *checker) checkFunction(fn *ssa.Function) {
-	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.failedPure)
+	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.failedPure, c.scopesCallbacks)
 	violations := analyzer.Analyze()
 
 	// Deduplicate violations by root to avoid generating duplicate fixes.

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -20,7 +20,7 @@ func TestNewAnalyzer(t *testing.T) {
 	pureFuncs := directive.NewPureFuncSet(nil, nil)
 	pureFuncs.Add(directive.FuncKey{PkgPath: "test", FuncName: "Pure"})
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(nil, nil)
-	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs, nil)
+	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs, nil, nil)
 
 	if analyzer == nil {
 		t.Error("Expected analyzer to be initialized")
@@ -36,7 +36,7 @@ func TestNewChecker(t *testing.T) {
 	reported := make(map[token.Pos]bool)
 	suggestedEdits := make(map[editKey]bool)
 
-	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil, reported, suggestedEdits, nil)
+	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil, nil, reported, suggestedEdits, nil)
 
 	if chk == nil {
 		t.Error("Expected checker to be initialized")
@@ -46,7 +46,7 @@ func TestNewChecker(t *testing.T) {
 func TestAnalyzer_Analyze_NilFunction(t *testing.T) {
 	t.Parallel()
 
-	analyzer := ssautil.NewAnalyzer(nil, nil, nil, nil)
+	analyzer := ssautil.NewAnalyzer(nil, nil, nil, nil, nil)
 
 	// Should not panic with nil function
 	violations := analyzer.Analyze()
@@ -59,7 +59,7 @@ func TestAnalyzer_Analyze_EmptyFunction(t *testing.T) {
 	t.Parallel()
 
 	fn := &ssa.Function{}
-	analyzer := ssautil.NewAnalyzer(fn, nil, nil, nil)
+	analyzer := ssautil.NewAnalyzer(fn, nil, nil, nil, nil)
 
 	violations := analyzer.Analyze()
 	if len(violations) != 0 {

--- a/internal/fix/generator.go
+++ b/internal/fix/generator.go
@@ -94,6 +94,16 @@ func (g *Generator) Generate(v pollution.Violation) []analysis.SuggestedFix {
 		return nil // Cannot fix without root information
 	}
 
+	// A parameter root (e.g. a Scopes/Preload callback's *gorm.DB, issue #60)
+	// has no definition site to make immutable — the generator's "insert
+	// Session() at the root" model does not apply, and forcing an edit produces
+	// a misleading fix on an unrelated expression. Report the violation without
+	// an auto-fix instead. (Isolating a reused parameter requires a manual
+	// Session() at the branch, which the user must place.)
+	if _, ok := root.(*ssa.Parameter); ok {
+		return nil
+	}
+
 	allUses := v.AllUses
 	if len(allUses) == 0 {
 		return nil // No uses to fix

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -74,10 +74,11 @@ type Analyzer struct {
 //   - pureFuncs: Set of functions marked with //gormreuse:pure directive
 //   - immutableReturnFuncs: Set of functions marked with //gormreuse:immutable-return directive
 //   - failedPure: Pure functions that failed contract validation (not trusted as pure)
-func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool) *Analyzer {
+//   - scopesCallbacks: Scopes/Preload callbacks whose *gorm.DB param is a mutable root
+func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool) *Analyzer {
 	return &Analyzer{
 		fn:          fn,
-		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs, failedPure),
+		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks),
 		cfgAnalyzer: cfg.New(),
 	}
 }
@@ -155,7 +156,10 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 			// Recursively process closures that capture *gorm.DB
 			if mc, ok := instr.(*ssa.MakeClosure); ok {
 				if closureFn, ok := mc.Fn.(*ssa.Function); ok {
-					if tracer.ClosureCapturesGormDB(mc) {
+					// Recurse into closures that capture *gorm.DB, and into
+					// Scopes/Preload callbacks (which operate on their mutable
+					// parameter rather than a captured variable — see #60).
+					if tracer.ClosureCapturesGormDB(mc) || a.rootTracer.IsScopesCallbackFunc(closureFn) {
 						a.processFunction(closureFn, tracker, visited)
 					}
 				}

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -95,6 +95,7 @@ type RootTracer struct {
 	pureFuncs            *directive.DirectiveFuncSet // User-defined pure functions
 	immutableReturnFuncs *directive.DirectiveFuncSet // Functions returning immutable *gorm.DB
 	failedPure           map[*ssa.Function]bool      // Pure functions that FAILED contract validation
+	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
 }
 
 // New creates a new RootTracer.
@@ -103,11 +104,17 @@ type RootTracer struct {
 // leaked their *gorm.DB argument (channel send, slice/array store, map store;
 // validated earlier this pass). They must NOT be trusted as pure at call sites
 // — doing so would hide reuse of the value they leak (issue #66). It may be nil.
-func New(pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure map[*ssa.Function]bool) *RootTracer {
+//
+// scopesCallbacks lists function literals passed to gorm's Scopes/Preload, whose
+// *gorm.DB parameter receives a mid-chain (clone==0) value at runtime and is
+// therefore itself a mutable root — reuse inside the callback interferes (#60).
+// It may be nil.
+func New(pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool) *RootTracer {
 	return &RootTracer{
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
 		failedPure:           failedPure,
+		scopesCallbacks:      scopesCallbacks,
 	}
 }
 
@@ -242,6 +249,15 @@ func (t *RootTracer) trace(v ssa.Value, visited map[ssa.Value]bool, loopInfo *cf
 		return nil
 	}
 	visited[v] = true
+
+	// A *gorm.DB parameter of a Scopes/Preload callback receives a mid-chain
+	// (clone==0) value at runtime, so it is itself a mutable root — unlike an
+	// ordinary parameter, which is treated as immutable (caller's concern).
+	// This must be checked BEFORE isImmutableSource, which reports parameters as
+	// immutable (issue #60).
+	if p, ok := v.(*ssa.Parameter); ok && t.isScopesCallbackParam(p) {
+		return p
+	}
 
 	// Check if this is an immutable source
 	if t.isImmutableSource(v) {
@@ -1107,6 +1123,13 @@ func (t *RootTracer) traceAll(v ssa.Value, visited map[ssa.Value]bool, loopInfo 
 	}
 	visited[v] = true
 
+	// A Scopes/Preload callback's *gorm.DB parameter is itself a mutable root
+	// (issue #60); keep this consistent with trace()/FindMutableRoot so Phi-based
+	// pollution checks see it too.
+	if p, ok := v.(*ssa.Parameter); ok && t.isScopesCallbackParam(p) {
+		return []ssa.Value{p}
+	}
+
 	switch val := v.(type) {
 	case *ssa.Phi:
 		// =====================================================================
@@ -1373,6 +1396,23 @@ func (t *RootTracer) traceAllFreeVar(fv *ssa.FreeVar, visited map[ssa.Value]bool
 	return nil
 }
 
+// isScopesCallbackParam reports whether p is the *gorm.DB parameter of a
+// function literal passed to gorm's Scopes/Preload (see CollectScopesCallbacks).
+func (t *RootTracer) isScopesCallbackParam(p *ssa.Parameter) bool {
+	if t.scopesCallbacks == nil || !typeutil.IsGormDB(p.Type()) {
+		return false
+	}
+	return t.scopesCallbacks[p.Parent()]
+}
+
+// IsScopesCallbackFunc reports whether fn is a Scopes/Preload callback. The
+// analyzer uses this to recurse into such callbacks even when they capture no
+// *gorm.DB (they operate on their parameter, not a captured variable), so reuse
+// of the mutable parameter inside them is still detected (#60).
+func (t *RootTracer) IsScopesCallbackFunc(fn *ssa.Function) bool {
+	return t.scopesCallbacks[fn]
+}
+
 // isImmutableSource checks if a value is an immutable source (no mutable root).
 //
 // Immutable sources:
@@ -1530,6 +1570,113 @@ func ClosureCapturesGormDB(mc *ssa.MakeClosure) bool {
 		}
 	}
 	return false
+}
+
+// CollectScopesCallbacks returns the set of functions passed as callbacks to
+// gorm's Scopes / Preload across all given functions and their nested closures.
+//
+// Such callbacks receive a mid-chain (clone==0) *gorm.DB at runtime, so their
+// *gorm.DB parameter is a mutable root and reuse inside them interferes (#60).
+// This is deliberately narrow — only functions actually handed to Scopes/Preload
+// qualify, NOT every func(*gorm.DB) *gorm.DB (that broader treatment is Phase
+// 1b, not 1a).
+//
+// Scopes(funcs ...func(*DB) *DB) and Preload(query, args ...interface{}) are
+// variadic, so the callbacks are packed into a varargs array (the last call
+// argument is a slice of it); Preload additionally boxes them in interface{}.
+func CollectScopesCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
+	set := make(map[*ssa.Function]bool)
+	visited := make(map[*ssa.Function]bool)
+	for _, fn := range funcs {
+		collectScopesCallbacks(fn, set, visited)
+	}
+	return set
+}
+
+func collectScopesCallbacks(fn *ssa.Function, set, visited map[*ssa.Function]bool) {
+	if fn == nil || visited[fn] {
+		return
+	}
+	visited[fn] = true
+
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if call, ok := instr.(*ssa.Call); ok {
+				collectScopesCallbacksFromCall(call, set)
+			}
+		}
+	}
+	for _, af := range fn.AnonFuncs {
+		collectScopesCallbacks(af, set, visited)
+	}
+}
+
+// collectScopesCallbacksFromCall adds any callback function passed to a
+// Scopes/Preload call to set.
+func collectScopesCallbacksFromCall(call *ssa.Call, set map[*ssa.Function]bool) {
+	callee := call.Call.StaticCallee()
+	if callee == nil || !isScopesOrPreloadMethod(callee) {
+		return
+	}
+
+	// The variadic callbacks are packed into an array whose slice is the last
+	// argument. Walk the array's element stores back to the callback functions.
+	args := call.Call.Args
+	if len(args) == 0 {
+		return
+	}
+	slice, ok := args[len(args)-1].(*ssa.Slice)
+	if !ok {
+		return
+	}
+	alloc, ok := slice.X.(*ssa.Alloc)
+	if !ok || alloc.Referrers() == nil {
+		return
+	}
+	for _, r := range *alloc.Referrers() {
+		idx, ok := r.(*ssa.IndexAddr)
+		if !ok || idx.Referrers() == nil {
+			continue
+		}
+		for _, ir := range *idx.Referrers() {
+			store, ok := ir.(*ssa.Store)
+			if !ok {
+				continue
+			}
+			if cb := callbackFuncValue(store.Val); cb != nil {
+				set[cb] = true
+			}
+		}
+	}
+}
+
+// isScopesOrPreloadMethod reports whether callee is gorm's Scopes or Preload
+// method (gated on a gorm.DB receiver so a same-named user method is excluded).
+func isScopesOrPreloadMethod(callee *ssa.Function) bool {
+	name := callee.Name()
+	if name != "Scopes" && name != "Preload" {
+		return false
+	}
+	sig := callee.Signature
+	return sig != nil && sig.Recv() != nil && typeutil.IsGormDB(sig.Recv().Type())
+}
+
+// callbackFuncValue extracts the concrete function from a value stored into a
+// Scopes/Preload varargs slot: a MakeClosure (capturing closure), a bare
+// *ssa.Function (named function reference), or either boxed in an interface
+// (Preload's args are ...interface{}).
+func callbackFuncValue(v ssa.Value) *ssa.Function {
+	switch x := v.(type) {
+	case *ssa.MakeClosure:
+		if fn, ok := x.Fn.(*ssa.Function); ok {
+			return fn
+		}
+	case *ssa.Function:
+		return x
+	case *ssa.MakeInterface:
+		return callbackFuncValue(x.X)
+	}
+	return nil
 }
 
 // containsGormDBThroughPointers checks if a type contains *gorm.DB through pointer chain.

--- a/testdata/src/gormreuse/scopes_callback.go
+++ b/testdata/src/gormreuse/scopes_callback.go
@@ -1,0 +1,83 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// Scopes/Preload callback parameters are MUTABLE roots (#60, Phase 1a)
+//
+// GORM passes the mid-chain (clone==0) *gorm.DB into Scopes/Preload callbacks,
+// so reusing that parameter inside the callback interferes at runtime — exactly
+// like reusing any other mutable *gorm.DB. This is the narrow, uncontroversial
+// half of #56 Phase 1: only callbacks actually handed to Scopes/Preload are
+// affected, not every func(*gorm.DB) *gorm.DB (that is Phase 1b).
+// =============================================================================
+
+// =============================================================================
+// SHOULD REPORT
+// =============================================================================
+
+// SC001: Reuse of the Scopes callback parameter (two branches from tx).
+func scopesCallbackReuse(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		tx.Where("a").Find(nil) // first branch from tx
+		return tx.Where("b")    // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// SC002: Reuse of a Preload scope callback parameter (a scope func rides in
+// Preload's variadic args and receives the same mid-chain value).
+func preloadCallbackReuse(db *gorm.DB) {
+	db.Preload("Orders", func(tx *gorm.DB) *gorm.DB {
+		tx.Where("a").Find(nil)
+		return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// SC003: A named function passed to Scopes is analyzed as an ordinary source
+// function; its *gorm.DB parameter is a mutable root too.
+func namedScope(tx *gorm.DB) *gorm.DB {
+	tx.Where("a").Find(nil)
+	return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+}
+
+func useNamedScope(db *gorm.DB) {
+	db.Scopes(namedScope)
+}
+
+// =============================================================================
+// SHOULD NOT REPORT
+// =============================================================================
+
+// SC101: Single use of the Scopes callback parameter is fine (one branch).
+func scopesCallbackSingleUse(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("a") // OK: single branch from tx
+	})
+}
+
+// SC102: Session() inside the callback isolates before branching.
+func scopesCallbackSessionIsolated(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		s := tx.Session(&gorm.Session{})
+		s.Where("a").Find(nil)
+		return s.Where("b") // OK: s is immutable (Session isolates)
+	})
+}
+
+// SC103: A Transaction callback receives a FRESH (forkable, clone>0) tx, not a
+// mid-chain value, so reuse inside it is safe and must NOT be reported. Only
+// Scopes/Preload callbacks get the mutable-root treatment.
+func transactionCallbackNoReport(db *gorm.DB) {
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh session, not a Scopes callback
+		return nil
+	})
+}
+
+// SC104: An ordinary (non-Scopes) func(*gorm.DB) *gorm.DB helper still treats
+// its parameter as immutable — Phase 1a does NOT broaden to all parameters.
+func ordinaryHelperParamStillImmutable(tx *gorm.DB) *gorm.DB {
+	tx.Where("a").Find(nil)
+	return tx.Where("b") // OK: ordinary parameter is immutable (caller's concern)
+}

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -1,0 +1,83 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// Scopes/Preload callback parameters are MUTABLE roots (#60, Phase 1a)
+//
+// GORM passes the mid-chain (clone==0) *gorm.DB into Scopes/Preload callbacks,
+// so reusing that parameter inside the callback interferes at runtime — exactly
+// like reusing any other mutable *gorm.DB. This is the narrow, uncontroversial
+// half of #56 Phase 1: only callbacks actually handed to Scopes/Preload are
+// affected, not every func(*gorm.DB) *gorm.DB (that is Phase 1b).
+// =============================================================================
+
+// =============================================================================
+// SHOULD REPORT
+// =============================================================================
+
+// SC001: Reuse of the Scopes callback parameter (two branches from tx).
+func scopesCallbackReuse(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		tx.Where("a").Find(nil) // first branch from tx
+		return tx.Where("b")    // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// SC002: Reuse of a Preload scope callback parameter (a scope func rides in
+// Preload's variadic args and receives the same mid-chain value).
+func preloadCallbackReuse(db *gorm.DB) {
+	db.Preload("Orders", func(tx *gorm.DB) *gorm.DB {
+		tx.Where("a").Find(nil)
+		return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	})
+}
+
+// SC003: A named function passed to Scopes is analyzed as an ordinary source
+// function; its *gorm.DB parameter is a mutable root too.
+func namedScope(tx *gorm.DB) *gorm.DB {
+	tx.Where("a").Find(nil)
+	return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+}
+
+func useNamedScope(db *gorm.DB) {
+	db.Scopes(namedScope)
+}
+
+// =============================================================================
+// SHOULD NOT REPORT
+// =============================================================================
+
+// SC101: Single use of the Scopes callback parameter is fine (one branch).
+func scopesCallbackSingleUse(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("a") // OK: single branch from tx
+	})
+}
+
+// SC102: Session() inside the callback isolates before branching.
+func scopesCallbackSessionIsolated(db *gorm.DB) {
+	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+		s := tx.Session(&gorm.Session{})
+		s.Where("a").Find(nil)
+		return s.Where("b") // OK: s is immutable (Session isolates)
+	})
+}
+
+// SC103: A Transaction callback receives a FRESH (forkable, clone>0) tx, not a
+// mid-chain value, so reuse inside it is safe and must NOT be reported. Only
+// Scopes/Preload callbacks get the mutable-root treatment.
+func transactionCallbackNoReport(db *gorm.DB) {
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh session, not a Scopes callback
+		return nil
+	})
+}
+
+// SC104: An ordinary (non-Scopes) func(*gorm.DB) *gorm.DB helper still treats
+// its parameter as immutable — Phase 1a does NOT broaden to all parameters.
+func ordinaryHelperParamStillImmutable(tx *gorm.DB) *gorm.DB {
+	tx.Where("a").Find(nil)
+	return tx.Where("b") // OK: ordinary parameter is immutable (caller's concern)
+}


### PR DESCRIPTION
## Summary

Phase 1a of #56 — the narrow, "ship first" half. GORM passes the **mid-chain (`clone==0`, mutable)** `*gorm.DB` into `Scopes`/`Preload` callbacks, so reusing that parameter inside the callback interferes at runtime. This was previously undetected because the tracer treats all parameters as immutable.

```go
db.Scopes(func(tx *gorm.DB) *gorm.DB {
    tx.Where("a").Find(&users) // first branch from tx - OK
    return tx.Where("b")       // VIOLATION: second branch from tx
})
```

### Scope

- **Narrow by design**: only functions *actually handed to* `Scopes`/`Preload` get the mutable-root treatment. An ordinary `func(*gorm.DB) *gorm.DB` helper's parameter stays immutable (that broader treatment is Phase 1b, #61). SC003 vs SC104 lock this precision (identical bodies; only the Scopes-passed one flags).
- **Part 1 of #60 (pure validation on parameters) is already covered** by the existing purity validator — PV001–008 flag `*gorm.DB` argument pollution in `//gormreuse:pure` functions today. This PR delivers the remaining part 2.

## Changes

- `tracer.CollectScopesCallbacks` — scans all functions + nested closures for `Scopes`/`Preload` calls and collects the callback functions. Both are variadic (callbacks packed into a varargs array; `Preload` boxes them in `interface{}`), so it walks the varargs-array element stores back to the `MakeClosure` / `*ssa.Function` / interface-boxed callback.
- `RootTracer.trace` / `traceAll` — a callback's `*gorm.DB` parameter is returned as its own mutable root (before `isImmutableSource`).
- `Analyzer.processFunction` — recurse into Scopes/Preload callbacks even when they capture no `*gorm.DB` (they operate on their parameter).
- `RunSSA` computes the callback set once and threads it through `NewAnalyzer`.
- `fix.Generate` — **suppress the auto-fix for a `Parameter` root**. There's no definition site to make immutable, and forcing an edit produced a misleading fix appended to the outer `Scopes(...)` chain (a #71-class wrong-variable fix). The violation is still reported; the user places the `Session()` manually.

## Fixtures (`scopes_callback.go`)

| | case | result |
|---|---|---|
| SC001 | reuse Scopes callback param | ✅ reported |
| SC002 | reuse Preload scope-func param | ✅ reported |
| SC003 | named func passed to Scopes | ✅ reported |
| SC101 | single use in callback | clean |
| SC102 | `Session()` isolates inside callback | clean |
| SC103 | `Transaction` callback (fresh forkable tx) | clean — NOT flagged |
| SC104 | ordinary `func(*gorm.DB)` helper param | clean — still immutable |

README updated to document the new detection.

## Testing

`go test ./...`, both e2e modules, and `golangci-lint run ./...` all green. No existing fixtures use Scopes/Preload, so zero churn on prior behavior.

Closes #60. Part of #59 (Track A). Next in the train: #61 (Phase 1b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv