### PR TITLE
chore: panic guard, cmd smoke test, *_test.go trap doc (#77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,13 @@ go run ./testdata/cmd/gengolden/main.go
   - `===== SHOULD REPORT =====` - Cases that should trigger warnings
   - `===== SHOULD NOT REPORT =====` - Negative cases
 
+> **Trap: never name a fixture `*_test.go` unless you mean to.** `analysistest`
+> loads a package's `*_test.go` files as part of both the normal package and the
+> test variant, so every diagnostic in such a fixture is collected **twice**
+> (this produced 343 duplicated diagnostics in PR #57). Use a plain `.go` name.
+> The one intentional exception is `testdata/src/filefilter/code_test.go`, which
+> exists specifically to test the analyzer's `-test` flag handling.
+
 ### Testdata Organization
 
 ```

--- a/cmd/gormreuse/main_test.go
+++ b/cmd/gormreuse/main_test.go
@@ -1,0 +1,45 @@
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSmoke builds the vettool and runs it against the known-bad gormreuse
+// fixture package, asserting it exits non-zero and prints the expected
+// diagnostic (issue #77 item 4). This is the only coverage of main.go's wiring
+// of singlechecker; the analysis itself is covered by the analysistest suite.
+func TestSmoke(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+
+	bin := filepath.Join(t.TempDir(), "gormreuse")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+
+	// The fixtures live under the module's testdata GOPATH root.
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	testdata := filepath.Join(filepath.Dir(file), "..", "..", "testdata")
+
+	cmd := exec.Command(bin, "gormreuse")
+	cmd.Dir = testdata
+	cmd.Env = append(os.Environ(), "GOPATH="+testdata, "GO111MODULE=off")
+	out, err := cmd.CombinedOutput()
+
+	// The vettool exits non-zero when it reports diagnostics.
+	if err == nil {
+		t.Errorf("expected non-zero exit (diagnostics reported), got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "reused after chain method") {
+		t.Errorf("expected 'reused after chain method' diagnostic, got:\n%s", out)
+	}
+}

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -35,7 +35,9 @@
 package internal
 
 import (
+	"fmt"
 	"go/token"
+	"os"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
@@ -124,14 +126,16 @@ func RunSSA(
 			continue
 		}
 		if pureFuncs != nil && pureFuncs.Contains(fn) {
-			for _, v := range purity.ValidateFunction(fn, pureFuncs) {
-				pass.Reportf(v.Pos, "%s", v.Message)
-				// Only a definitive escape revokes pure-trust at call sites;
-				// conservative func-arg violations do not (avoids FP cascades).
-				if v.Leak {
-					failedPure[fn] = true
+			recoverPerFunction(fn, func() {
+				for _, v := range purity.ValidateFunction(fn, pureFuncs) {
+					pass.Reportf(v.Pos, "%s", v.Message)
+					// Only a definitive escape revokes pure-trust at call sites;
+					// conservative func-arg violations do not (avoids FP cascades).
+					if v.Leak {
+						failedPure[fn] = true
+					}
 				}
-			}
+			})
 		}
 	}
 
@@ -146,7 +150,7 @@ func RunSSA(
 		}
 
 		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, globalReported, globalSuggestedEdits, fixGen)
-		chk.checkFunction(fn)
+		recoverPerFunction(fn, func() { chk.checkFunction(fn) })
 	}
 
 	// Report unused ignore directives
@@ -182,6 +186,23 @@ func RunSSA(
 			pass.Reportf(pos, "unused gormreuse:immutable-return directive")
 		}
 	}
+}
+
+// recoverPerFunction runs work, recovering from any panic so that a single
+// pathological function (exotic SSA the tracer mishandles) cannot abort the
+// entire `go vet` run for the package. Aborting would be worse than any false
+// positive and contrary to the conservative-bias design, so the offending
+// function is simply skipped.
+//
+// Set GORMREUSE_DEBUG_PANIC to a non-empty value to re-panic instead, surfacing
+// the stack trace for debugging.
+func recoverPerFunction(fn *ssa.Function, work func()) {
+	defer func() {
+		if r := recover(); r != nil && os.Getenv("GORMREUSE_DEBUG_PANIC") != "" {
+			panic(fmt.Sprintf("gormreuse: panic analyzing %s: %v", fn, r))
+		}
+	}()
+	work()
 }
 
 // =============================================================================

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -10,6 +10,30 @@ import (
 	ssautil "github.com/mpyw/gormreuse/internal/ssa"
 )
 
+// TestRecoverPerFunction verifies that a panic in per-function analysis is
+// contained (issue #77 item 3) so one pathological function cannot abort the
+// whole vet run, and that GORMREUSE_DEBUG_PANIC re-surfaces it.
+func TestRecoverPerFunction(t *testing.T) {
+	// Default: panic is swallowed, execution continues.
+	ran := false
+	recoverPerFunction(nil, func() { panic("boom") })
+	recoverPerFunction(nil, func() { ran = true })
+	if !ran {
+		t.Fatal("recoverPerFunction did not run work after a prior panic")
+	}
+
+	// With GORMREUSE_DEBUG_PANIC set, the panic is re-surfaced.
+	t.Setenv("GORMREUSE_DEBUG_PANIC", "1")
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected re-panic under GORMREUSE_DEBUG_PANIC, got none")
+			}
+		}()
+		recoverPerFunction(nil, func() { panic("boom") })
+	}()
+}
+
 // =============================================================================
 // Analyzer Tests
 // =============================================================================

--- a/testdata/src/filefilter/code_test.go
+++ b/testdata/src/filefilter/code_test.go
@@ -1,3 +1,12 @@
+// This fixture is intentionally named *_test.go to exercise the analyzer's
+// -test flag behavior (test files are analyzed when -test=true, the default).
+//
+// TRAP: analysistest loads a package's *_test.go files as part of BOTH the
+// normal package and the test variant, so every diagnostic in a *_test.go
+// fixture is collected twice. This once produced 343 duplicated diagnostics in
+// PR #57. Only name a fixture *_test.go when you are deliberately testing
+// test-file handling (as here); otherwise use a plain .go name. See CLAUDE.md
+// "Testing Strategy".
 package filefilter
 
 import "gorm.io/gorm"


### PR DESCRIPTION
## Summary

Three independent, mechanical dev-infra items from #77 (none changes analysis behavior). Items 1 (lint-config decision), 2 (golden/diff dedup refactor), and 6 (tracer doc cleanup) remain for follow-up.

### Item 3 — panic guard (the notable one)
The analyzer had zero `recover`, so a tracer panic on exotic SSA aborted the **entire** `go vet` run for the package — worse than any false positive and contrary to the conservative-bias design. Per-function analysis (both pure validation and the reuse checker) is now wrapped in `recoverPerFunction`: the offending function is skipped, and `GORMREUSE_DEBUG_PANIC=1` re-surfaces the panic (with the function name) for debugging. Unit-tested both paths.

### Item 4 — cmd smoke test
`cmd/gormreuse` had 0% coverage. `TestSmoke` builds the vettool and runs it against the known-bad fixture package, asserting non-zero exit and the expected diagnostic substring. This is the only coverage of `main.go`'s `singlechecker` wiring.

### Item 5 — `*_test.go` fixture double-load trap
Documented at `testdata/src/filefilter/code_test.go` and in CLAUDE.md's Testing Strategy: `analysistest` double-loads `*_test.go` fixtures, collecting every diagnostic twice (this produced 343 duplicated diagnostics in PR #57). `filefilter/code_test.go` is the one intentional use.

## Testing

`go test ./...` (incl. new `cmd` + panic-guard tests), both e2e modules, and `golangci-lint run ./...` all green.

Part of #59 / #77 (items 3, 4, 5 — leaving 1, 2, 6 checked-off individually on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv