### PR TITLE
chore: enable complexity linters, fix stale tracer docs (#77)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,12 @@ run:
 
 linters:
   default: standard
+  # Complexity linters whose thresholds are configured below. Without this
+  # enable list they never run under golangci-lint v2's default: standard (#77).
+  enable:
+    - cyclop
+    - funlen
+    - gocognit
   settings:
     cyclop:
       max-complexity: 30

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -47,9 +47,12 @@
 //	│  *ssa.Alloc             │  Find Store instructions to this alloc     │
 //	│  *ssa.FreeVar           │  Find binding in parent's MakeClosure      │
 //	│  *ssa.FieldAddr         │  Find Store to this field                  │
-//	│  *ssa.Parameter         │  STOP - parameter is immutable source      │
+//	│  *ssa.Parameter         │  STOP - immutable source (caller's concern)│
+//	│  *ssa.Parameter (Scopes)│  ROOT - Scopes/Preload callback param is   │
+//	│                         │  mutable (receives clone==0 db, #60)       │
 //	│  *ssa.Const (nil)       │  STOP - nil is ignored                     │
 //	│  Builtin pure call      │  STOP - returns immutable (nil root)       │
+//	│  immutable-return call  │  STOP - returns immutable (nil root)       │
 //	│  User-defined pure call │  Returns call as root (may be mutable)     │
 //	└───────────────────────────────────────────────────────────────────────┘
 package tracer
@@ -1458,21 +1461,6 @@ func isNilConst(v ssa.Value) bool {
 	return ok && c.Value == nil
 }
 
-// isClosureResultStored checks if a closure call's result is stored in a variable.
-// This happens when the closure returns multiple values and the result is extracted.
-// Example: `publishedQuery, err := closureFunc()` - result goes through Extract.
-// In contrast, IIFE chains like `closure().Find()` use the result directly.
-// isClosureResultStored checks if a closure call's result is stored rather than
-// directly chained to a method call.
-//
-// Returns true (stored) for patterns like:
-//   - `q, err := closureFunc()` (multi-return with Extract)
-//   - `q := closureFunc()` (single-return assigned to variable)
-//   - Result flows into Phi node
-//
-// Returns false (chained) for IIFE patterns like:
-//   - `closureFunc().Find(nil)` (result directly used as method receiver)
-//
 // isClosureResultStored checks if a closure call's result is stored (assigned to
 // a variable) rather than directly chained in an IIFE pattern.
 //


### PR DESCRIPTION
## Summary

Two more #77 items (item 2, the golden/diff pipeline dedup, remains).

### Item 1 — enable the configured complexity linters
`.golangci.yaml` defined `settings` for `cyclop`/`funlen`/`gocognit` but golangci-lint v2's `default: standard` never runs them without an explicit `enable:` list — the config was inert. Enabled them; with the thresholds already set (cyclop 30, funlen 200, gocognit 60) **nothing fires today** (`tracePhi` at 160 lines is under `funlen`'s 200), so this just makes the config honest rather than an illusion.

### Item 6 — stale tracer docs
- `isClosureResultStored` carried three stacked doc blocks, the first contradicting the implementation — collapsed to one accurate block.
- The package-header tracing table omitted `//gormreuse:immutable-return` calls and the Scopes/Preload mutable-parameter case (#60); both added.

## Testing

`go test ./...` and `golangci-lint run ./...` (now with the three complexity linters active) green.

Part of #59 / #77 (items 1, 6). Item 2 remains checked-off individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv