### PR TITLE
feat: actionable reuse diagnostics with root + first-branch positions (#76)

### DIFF
--- a/cmd/gormreuse/main_test.go
+++ b/cmd/gormreuse/main_test.go
@@ -39,7 +39,7 @@ func TestSmoke(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected non-zero exit (diagnostics reported), got success\n%s", out)
 	}
-	if !strings.Contains(string(out), "reused after chain method") {
-		t.Errorf("expected 'reused after chain method' diagnostic, got:\n%s", out)
+	if !strings.Contains(string(out), "reused: second branch from mutable root") {
+		t.Errorf("expected reuse diagnostic, got:\n%s", out)
 	}
 }

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -34,6 +34,8 @@
 package ssa
 
 import (
+	"go/token"
+
 	"golang.org/x/tools/go/ssa"
 
 	"github.com/mpyw/gormreuse/internal/directive"
@@ -99,7 +101,11 @@ func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.Di
 // Closures that capture *gorm.DB are processed recursively to detect
 // violations across closure boundaries.
 func (a *Analyzer) Analyze() []Violation {
-	tracker := pollution.New(a.cfgAnalyzer)
+	var fset *token.FileSet
+	if a.fn != nil && a.fn.Prog != nil {
+		fset = a.fn.Prog.Fset
+	}
+	tracker := pollution.New(a.cfgAnalyzer, fset)
 
 	// PHASE 1: TRACKING
 	// Process all instructions and record usages

--- a/internal/ssa/pollution/tracker.go
+++ b/internal/ssa/pollution/tracker.go
@@ -35,6 +35,9 @@ package pollution
 
 import (
 	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	"golang.org/x/tools/go/ssa"
 )
@@ -88,6 +91,10 @@ type Tracker struct {
 
 	// cfgAnalyzer for reachability checks.
 	cfgAnalyzer CFGAnalyzer
+
+	// fset renders root/first-branch positions in diagnostic messages. May be
+	// nil (positions are then omitted).
+	fset *token.FileSet
 }
 
 // CFGAnalyzer interface for control flow analysis.
@@ -95,14 +102,16 @@ type CFGAnalyzer interface {
 	CanReach(src, dst *ssa.BasicBlock) bool
 }
 
-// New creates a new Tracker.
-func New(cfgAnalyzer CFGAnalyzer) *Tracker {
+// New creates a new Tracker. fset is used to render source positions in reuse
+// diagnostics and may be nil (positions are then omitted).
+func New(cfgAnalyzer CFGAnalyzer, fset *token.FileSet) *Tracker {
 	return &Tracker{
 		pollutingUses:  make(map[ssa.Value][]UsageInfo),
 		pureUses:       make(map[ssa.Value][]UsageInfo),
 		assignmentUses: make(map[ssa.Value][]UsageInfo),
 		branchUses:     make(map[ssa.Value][]UsageInfo),
 		cfgAnalyzer:    cfgAnalyzer,
+		fset:           fset,
 	}
 }
 
@@ -155,10 +164,53 @@ func (t *Tracker) isReachable(pollutedBlock, targetBlock *ssa.BasicBlock) bool {
 func (t *Tracker) addViolationWithContext(pos token.Pos, root ssa.Value, allUses []UsageInfo) {
 	t.violations = append(t.violations, Violation{
 		Pos:     pos,
-		Message: "*gorm.DB instance reused after chain method (use .Session(&gorm.Session{}) to make it safe)",
+		Message: t.reuseMessage(root),
 		Root:    root,
 		AllUses: allUses,
 	})
+}
+
+// reuseMessage builds the reuse diagnostic. It names the mutable root and its
+// first branch (when their positions are known) so the report points the user
+// at all three sites — root, first branch, and the offending second branch (the
+// diagnostic's own position) — not just the last one (#76).
+func (t *Tracker) reuseMessage(root ssa.Value) string {
+	msg := "*gorm.DB reused: second branch from mutable root"
+
+	var locs []string
+	if root != nil && root.Pos().IsValid() {
+		locs = append(locs, "root at "+t.loc(root.Pos()))
+	}
+	if fb := t.firstBranchPos(root); fb.IsValid() {
+		locs = append(locs, "first branch at "+t.loc(fb))
+	}
+	if len(locs) > 0 {
+		msg += " (" + strings.Join(locs, ", ") + ")"
+	}
+
+	return msg + "; make the root immutable with .Session(&gorm.Session{})"
+}
+
+// loc renders pos as "file.go:line" (base name only — the file is almost always
+// the one being reported on, and absolute paths would be noise).
+func (t *Tracker) loc(pos token.Pos) string {
+	if t.fset == nil {
+		return ""
+	}
+	p := t.fset.Position(pos)
+	return filepath.Base(p.Filename) + ":" + strconv.Itoa(p.Line)
+}
+
+// firstBranchPos returns the earliest polluting use of root (its first branch),
+// which precedes the second branch that triggered the violation.
+func (t *Tracker) firstBranchPos(root ssa.Value) token.Pos {
+	best := token.NoPos
+	for _, u := range t.pollutingUses[root] {
+		if u.Pos.IsValid() && (!best.IsValid() || u.Pos < best) {
+			best = u.Pos
+		}
+	}
+	return best
 }
 
 // IsPolluted checks if a root has been polluted (for defer).

--- a/testdata/src/external_pure_test/external.go
+++ b/testdata/src/external_pure_test/external.go
@@ -51,5 +51,5 @@ func externalChainReuse() {
 	db := new(purelib.Orm).GetDB()
 	q := db.Where("x = ?", 1) // Chain method creates mutable
 	q.Find(nil)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/filefilter/code_test.go
+++ b/testdata/src/filefilter/code_test.go
@@ -15,5 +15,5 @@ import "gorm.io/gorm"
 func badReuseInTest(db *gorm.DB) {
 	q := db.Model(&User{}).Where("test = ?", true)
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/filefilter/main.go
+++ b/testdata/src/filefilter/main.go
@@ -16,7 +16,7 @@ type User struct {
 func badReuse(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goodReuse properly uses Session.

--- a/testdata/src/gormreuse/advanced.go
+++ b/testdata/src/gormreuse/advanced.go
@@ -15,21 +15,21 @@ func derivedVariables(db *gorm.DB) {
 	queryDB := db.Model(&User{}).Where("name = ?", "jinzhu").Session(&gorm.Session{})
 	q := queryDB.Where("age > ?", 10) // Derived without Session - mutable
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedChainResultReuse demonstrates reuse of stored chain result.
 func storedChainResultReuse(db *gorm.DB) {
 	q := db.Where("active = ?", true)
 	q.Find(nil)
-	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedChainResultMultipleDerivations demonstrates multiple derivations from same base.
 func storedChainResultMultipleDerivations(db *gorm.DB) {
 	base := db.Where("tenant_id = ?", 1)
 	base.Where("type = ?", "A").Find(nil)
-	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // derivedFromSessionUnsafe demonstrates that chain after Session is still mutable.
@@ -39,7 +39,7 @@ func derivedFromSessionUnsafe(db *gorm.DB) {
 	derived := safe.Where("active = ?", true) // Mutable!
 
 	derived.Find(nil)
-	derived.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	derived.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiLevelUnsafeDerivation demonstrates chained derivation.
@@ -49,7 +49,7 @@ func multiLevelUnsafeDerivation(db *gorm.DB) {
 	level3 := level2.Where("c")
 
 	level3.Find(nil)
-	level3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	level3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -103,7 +103,7 @@ func helperWhere(db *gorm.DB, name string) *gorm.DB {
 func functionReturnValue(db *gorm.DB) {
 	q := helperWhere(db, "jinzhu")
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -125,22 +125,22 @@ func functionReturnWithSession(db *gorm.DB) {
 func sessionAfterPolluted(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Count(new(int64))                        // q is polluted
-	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // sessionOnPollutedValue demonstrates Session on already-polluted value.
 func sessionOnPollutedValue(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil)
-	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
 func multipleDirectUsesWithoutSession(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil)
-	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
-	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)                          // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -186,10 +186,10 @@ func conditionalExtendPartialWithPollution(db *gorm.DB, flag bool) {
 	q.Find(nil) // Pollutes q
 
 	if flag {
-		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendBothWithPollution demonstrates conditional extension in both branches with initial pollution.
@@ -200,9 +200,9 @@ func conditionalExtendBothWithPollution(db *gorm.DB, flag bool) {
 	q.Find(nil) // Pollutes q
 
 	if flag {
-		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		q = q.Where("z = ?", 3) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("z = ?", 3) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Count(nil) // OK: both branches created new q via assignment
@@ -218,7 +218,7 @@ func conditionalExtendPartialNoPollution(db *gorm.DB, flag bool) {
 	}
 
 	q.Find(nil)                 // OK: first actual use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendBothNoPollution demonstrates conditional extension in both branches without initial pollution.
@@ -233,7 +233,7 @@ func conditionalExtendBothNoPollution(db *gorm.DB, flag bool) {
 	}
 
 	q.Find(nil)                 // OK: first actual use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendThreeBranches demonstrates three-way branch with partial assignment.
@@ -249,7 +249,7 @@ func conditionalExtendThreeBranches(db *gorm.DB, n int) {
 	// else: q remains unchanged (original mutable root)
 
 	q.Find(nil)  // OK: Phi(q_1, q_2, q_3) - all first use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -265,7 +265,7 @@ func conditionalExtendThreeBranches(db *gorm.DB, n int) {
 func nonFinisherOnlyGeneratesFix(db *gorm.DB) {
 	q := db.Where("base")
 	q.Where("filter1") // Non-finisher expr stmt - should get "q = q.Where("filter1")" fix
-	q.Find(nil)        // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)        // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // finisherDoesNotGenerateReassignmentFix demonstrates that finisher calls
@@ -273,7 +273,7 @@ func nonFinisherOnlyGeneratesFix(db *gorm.DB) {
 func finisherDoesNotGenerateReassignmentFix(db *gorm.DB) {
 	q := db.Where("base")
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -288,7 +288,7 @@ func parentScopeVariable(db *gorm.DB) {
 	q := db.Where("outer")
 	func() {
 		q.Where("inner")
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 }
 
@@ -299,7 +299,7 @@ func nestedClosureFixDedup(db *gorm.DB) {
 	func() {
 		func() {
 			q.Where("deep")
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}()
 	}()
 }
@@ -312,7 +312,7 @@ func tripleNestedClosureDedup(db *gorm.DB) {
 		func() {
 			func() {
 				q.Where("level3")
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}()
 		}()
 	}()
@@ -327,8 +327,8 @@ func tripleNestedClosureDedup(db *gorm.DB) {
 func nestedArgsFromMutableParent(db *gorm.DB) {
 	q := db.Where("base") // q is mutable
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
-		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
 }
 
@@ -346,10 +346,10 @@ func nestedArgsFromImmutableParent(db *gorm.DB) {
 func nestedArgsFromMutableThenReuse(db *gorm.DB) {
 	q := db.Where("base") // q is mutable
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
-		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedArgsSingleUse demonstrates that even single nested arg is a violation
@@ -357,9 +357,9 @@ func nestedArgsFromMutableThenReuse(db *gorm.DB) {
 func nestedArgsSingleUse(db *gorm.DB) {
 	q := db.Where("base")
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -433,7 +433,7 @@ func pureImmutableReturnReturnsDB(db *gorm.DB) *gorm.DB {
 func passToVoidFunc(db *gorm.DB) {
 	q := db.Where("base")
 	voidFunc(q.Where("a"))
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to function returning *gorm.DB ---
@@ -443,9 +443,9 @@ func passToVoidFunc(db *gorm.DB) {
 func passToReturnsDB(db *gorm.DB) {
 	q := db.Where("base")
 	result := returnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: first use of result
-	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to pure function ---
@@ -457,9 +457,9 @@ func passToReturnsDB(db *gorm.DB) {
 func passToPureReturnsDB(db *gorm.DB) {
 	q := db.Where("base")
 	result := pureReturnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: first use of result
-	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to immutable-return function ---
@@ -469,7 +469,7 @@ func passToPureReturnsDB(db *gorm.DB) {
 func passToImmutableReturnReturnsDB(db *gorm.DB) {
 	q := db.Where("base")
 	result := immutableReturnReturnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: result is immutable
 	result.Find(nil) // OK: result is immutable, can reuse freely
 }
@@ -482,7 +482,7 @@ func passToImmutableReturnReturnsDB(db *gorm.DB) {
 func passToPureImmutableReturnReturnsDB(db *gorm.DB) {
 	q := db.Where("base")
 	result := pureImmutableReturnReturnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: result is immutable
 	result.Find(nil) // OK: result is immutable, can reuse freely
 }
@@ -493,7 +493,7 @@ func passToPureImmutableReturnReturnsDB(db *gorm.DB) {
 func multipleCallsToVoidFunc(db *gorm.DB) {
 	q := db.Where("base")
 	voidFunc(q.Where("a"))
-	voidFunc(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
+	voidFunc(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multipleCallsToPureFunc demonstrates multiple calls passing q.Where() to pure function.
@@ -501,8 +501,8 @@ func multipleCallsToVoidFunc(db *gorm.DB) {
 func multipleCallsToPureFunc(db *gorm.DB) {
 	q := db.Where("base")
 	pureReturnsDB(q.Where("a"))
-	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
-	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -514,7 +514,7 @@ func multipleCallsToPureFunc(db *gorm.DB) {
 func passQDirectlyToNonPure(db *gorm.DB) {
 	q := db.Where("base")
 	voidFunc(q)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToPure demonstrates passing q directly to pure function.
@@ -523,7 +523,7 @@ func passQDirectlyToPure(db *gorm.DB) {
 	q := db.Where("base")
 	pureReturnsDB(q)
 	q.Find(nil) // OK: pure function doesn't pollute q
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToPureMultiple demonstrates multiple calls passing q to pure function.
@@ -534,7 +534,7 @@ func passQDirectlyToPureMultiple(db *gorm.DB) {
 	pureReturnsDB(q) // OK: pure function doesn't pollute q
 	pureReturnsDB(q) // OK: still not polluted
 	q.Find(nil)      // OK: first actual use of q
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToMixedFunctions demonstrates passing q to both pure and non-pure functions.
@@ -542,7 +542,7 @@ func passQDirectlyToMixedFunctions(db *gorm.DB) {
 	q := db.Where("base")
 	pureReturnsDB(q) // OK: pure doesn't pollute
 	voidFunc(q)      // Pollutes q
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -566,7 +566,7 @@ func consecutiveIfReassignment(db *gorm.DB, a, b bool) {
 	q = q.Order("c") // Assignment - no diagnostic here (fix added for Count violation below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveIfSwitchReassignment demonstrates consecutive if and switch with reassignment.
@@ -590,7 +590,7 @@ func consecutiveIfSwitchReassignment(db *gorm.DB, keyword string, status *int) {
 	q = q.Order("created_at") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // helperFunctionReassignment tests reassignment with helper function return value.
@@ -611,7 +611,7 @@ func helperFunctionReassignment(db *gorm.DB, a, b bool) {
 	q = q.Order("c") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 type repo struct {
@@ -638,7 +638,7 @@ func methodReceiverReassignment(r *repo, a, b bool) {
 	q = q.Order("c") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 type repoImmutable struct {
@@ -667,7 +667,7 @@ func immutableReturnMethodReassignment(r *repoImmutable, a, b bool) {
 	q = q.Order("c") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchMultipleCasesReassignment tests switch with multiple cases reassigning q.
@@ -695,7 +695,7 @@ func switchMultipleCasesReassignment(db *gorm.DB, keyword string, status *int) {
 	q = q.Order("c") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchMultipleCasesChainedReassignment tests switch with chained Where calls.
@@ -716,7 +716,7 @@ func switchMultipleCasesChainedReassignment(db *gorm.DB, status *int) {
 	q = q.Order("e") // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // exactUserPatternImmutableReturn reproduces the exact user pattern:
@@ -819,10 +819,10 @@ func consecutiveHelperCallsNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+		buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveHelperCallsWithFind tests when Find breaks the chain.
@@ -837,10 +837,10 @@ func consecutiveHelperCallsWithFind(db *gorm.DB, a, b bool) {
 	q.Find(nil) // First use - OK, but now q is polluted
 
 	if b {
-		q = buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+		q = buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveHelperCallsWithFindReassign tests when Find result is used in reassignment pattern.
@@ -858,7 +858,7 @@ func consecutiveHelperCallsWithFindReassign(db *gorm.DB, a, b bool) {
 		q = db.Where("new") // NEW mutable root - q is now fresh
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ===== USER-DEFINED HELPER FUNCTION DIRECTIVE PATTERNS =====
@@ -917,10 +917,10 @@ func testNoPureHelperNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		noPureHelper(q) // want `\*gorm\.DB instance reused after chain method`
+		noPureHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureOnlyHelperReassign tests helper with pure directive, result reassigned.
@@ -970,7 +970,7 @@ func testImmutableReturnOnlyHelperReassign(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableReturnOnlyHelperReassignGuaranteed tests helper with immutable-return directive.
@@ -999,10 +999,10 @@ func testImmutableReturnOnlyHelperNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		immutableReturnOnlyHelper(q) // want `\*gorm\.DB instance reused after chain method`
+		immutableReturnOnlyHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureAndImmutableReturnHelperReassign tests helper with both directives.
@@ -1019,7 +1019,7 @@ func testPureAndImmutableReturnHelperReassign(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureAndImmutableReturnHelperReassignGuaranteed tests helper with both directives.
@@ -1070,7 +1070,7 @@ func testImmutableInitialWithNoPureHelper(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableInitialWithNoPureHelperGuaranteed tests immutable initial q, guaranteed reassign.
@@ -1085,7 +1085,7 @@ func testImmutableInitialWithNoPureHelperGuaranteed(db *gorm.DB, a bool) {
 
 	// q is now mutable (from noPureHelper), but it's first use
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableInitialWithImmutableReturnHelper tests immutable initial q with immutable-return helper.
@@ -1143,7 +1143,7 @@ func testMixedHelperTypes(db *gorm.DB, a, b, c bool) {
 
 	// Path-insensitive: q could be original mutable, or any of the helper results
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testMixedHelperTypesAllImmutablePaths tests mixing helpers where all paths lead to immutable.
@@ -1173,7 +1173,7 @@ func testMixedHelperTypesMutableAndImmutable(db *gorm.DB, a bool) {
 
 	// Phi(mutable, immutable) - need to be conservative
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ===== NO DIRECTIVE GUARANTEED PATTERN =====
@@ -1190,7 +1190,7 @@ func testNoPureHelperReassignGuaranteed(db *gorm.DB, a bool) {
 
 	// Both paths create new mutable root, so first use is OK
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureOnlyHelperReassignGuaranteed tests pure helper with guaranteed reassignment.
@@ -1205,5 +1205,5 @@ func testPureOnlyHelperReassignGuaranteed(db *gorm.DB, a bool) {
 
 	// Both paths create new mutable root
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/advanced.go.diff
+++ b/testdata/src/gormreuse/advanced.go.diff
@@ -19,7 +19,7 @@
 -	q := queryDB.Where("age > ?", 10) // Derived without Session - mutable
 +	q := queryDB.Where("age > ?", 10).Session(&gorm.Session{}) // Derived without Session - mutable
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // storedChainResultReuse demonstrates reuse of stored chain result.
@@ -27,7 +27,7 @@
 -	q := db.Where("active = ?", true)
 +	q := db.Where("active = ?", true).Session(&gorm.Session{})
  	q.Find(nil)
- 	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // storedChainResultMultipleDerivations demonstrates multiple derivations from same base.
@@ -35,7 +35,7 @@
 -	base := db.Where("tenant_id = ?", 1)
 +	base := db.Where("tenant_id = ?", 1).Session(&gorm.Session{})
  	base.Where("type = ?", "A").Find(nil)
- 	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // derivedFromSessionUnsafe demonstrates that chain after Session is still mutable.
@@ -46,7 +46,7 @@
 +	derived := safe.Where("active = ?", true).Session(&gorm.Session{}) // Mutable!
  
  	derived.Find(nil)
- 	derived.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	derived.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multiLevelUnsafeDerivation demonstrates chained derivation.
@@ -57,7 +57,7 @@
 +	level3 := level2.Where("c").Session(&gorm.Session{})
  
  	level3.Find(nil)
- 	level3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	level3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -112,7 +112,7 @@
 -	q := helperWhere(db, "jinzhu")
 +	q := helperWhere(db, "jinzhu").Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -135,7 +135,7 @@
 -	q := db.Model(&User{}).Where("active = ?", true)
 +	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
  	q.Count(new(int64))                        // q is polluted
- 	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // sessionOnPollutedValue demonstrates Session on already-polluted value.
@@ -143,7 +143,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil)
- 	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
@@ -151,8 +151,8 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil)
- 	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
- 	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)                          // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -198,10 +198,10 @@
  	q.Find(nil) // Pollutes q
  
  	if flag {
- 		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalExtendBothWithPollution demonstrates conditional extension in both branches with initial pollution.
@@ -213,9 +213,9 @@
  	q.Find(nil) // Pollutes q
  
  	if flag {
- 		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
  	} else {
- 		q = q.Where("z = ?", 3) // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("z = ?", 3) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Count(nil) // OK: both branches created new q via assignment
@@ -233,7 +233,7 @@
  	}
  
  	q.Find(nil)                 // OK: first actual use
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalExtendBothNoPollution demonstrates conditional extension in both branches without initial pollution.
@@ -250,7 +250,7 @@
  	}
  
  	q.Find(nil)                 // OK: first actual use
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalExtendThreeBranches demonstrates three-way branch with partial assignment.
@@ -269,7 +269,7 @@
  	// else: q remains unchanged (original mutable root)
  
  	q.Find(nil)  // OK: Phi(q_1, q_2, q_3) - all first use
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -286,7 +286,7 @@
  	q := db.Where("base")
 -	q.Where("filter1") // Non-finisher expr stmt - should get "q = q.Where("filter1")" fix
 +	q = q.Where("filter1") // Non-finisher expr stmt - should get "q = q.Where("filter1")" fix
- 	q.Find(nil)        // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)        // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // finisherDoesNotGenerateReassignmentFix demonstrates that finisher calls
@@ -295,7 +295,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -311,7 +311,7 @@
  	func() {
 -		q.Where("inner")
 +		q = q.Where("inner")
- 		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}()
  }
  
@@ -323,7 +323,7 @@
  		func() {
 -			q.Where("deep")
 +			q = q.Where("deep")
- 			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}()
  	}()
  }
@@ -337,7 +337,7 @@
  			func() {
 -				q.Where("level3")
 +				q = q.Where("level3")
- 				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}()
  		}()
  	}()
@@ -353,8 +353,8 @@
 -	q := db.Where("base") // q is mutable
 +	q := db.Where("base").Session(&gorm.Session{}) // q is mutable
  	q.Or(
- 		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
- 		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
  	).Find(nil)
  }
  
@@ -373,10 +373,10 @@
 -	q := db.Where("base") // q is mutable
 +	q := db.Where("base").Session(&gorm.Session{}) // q is mutable
  	q.Or(
- 		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
- 		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
  	).Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedArgsSingleUse demonstrates that even single nested arg is a violation
@@ -385,9 +385,9 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	q.Or(
- 		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
  	).Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -462,7 +462,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	voidFunc(q.Where("a"))
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // --- Test cases for passing q.Where() to function returning *gorm.DB ---
@@ -474,9 +474,9 @@
 -	result := returnsDB(q.Where("a"))
 +	q := db.Where("base").Session(&gorm.Session{})
 +	result := returnsDB(q.Where("a")).Session(&gorm.Session{})
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  	result.Find(nil) // OK: first use of result
- 	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // --- Test cases for passing q.Where() to pure function ---
@@ -490,9 +490,9 @@
 -	result := pureReturnsDB(q.Where("a"))
 +	q := db.Where("base").Session(&gorm.Session{})
 +	result := pureReturnsDB(q.Where("a")).Session(&gorm.Session{})
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  	result.Find(nil) // OK: first use of result
- 	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // --- Test cases for passing q.Where() to immutable-return function ---
@@ -503,7 +503,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	result := immutableReturnReturnsDB(q.Where("a"))
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  	result.Find(nil) // OK: result is immutable
  	result.Find(nil) // OK: result is immutable, can reuse freely
  }
@@ -517,7 +517,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	result := pureImmutableReturnReturnsDB(q.Where("a"))
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  	result.Find(nil) // OK: result is immutable
  	result.Find(nil) // OK: result is immutable, can reuse freely
  }
@@ -529,7 +529,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	voidFunc(q.Where("a"))
- 	voidFunc(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
+ 	voidFunc(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multipleCallsToPureFunc demonstrates multiple calls passing q.Where() to pure function.
@@ -538,8 +538,8 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	pureReturnsDB(q.Where("a"))
- 	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
- 	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+ 	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -552,7 +552,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	voidFunc(q)
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // passQDirectlyToPure demonstrates passing q directly to pure function.
@@ -562,7 +562,7 @@
 +	q := db.Where("base").Session(&gorm.Session{})
  	pureReturnsDB(q)
  	q.Find(nil) // OK: pure function doesn't pollute q
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // passQDirectlyToPureMultiple demonstrates multiple calls passing q to pure function.
@@ -574,7 +574,7 @@
  	pureReturnsDB(q) // OK: pure function doesn't pollute q
  	pureReturnsDB(q) // OK: still not polluted
  	q.Find(nil)      // OK: first actual use of q
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // passQDirectlyToMixedFunctions demonstrates passing q to both pure and non-pure functions.
@@ -583,7 +583,7 @@
 +	q := db.Where("base").Session(&gorm.Session{})
  	pureReturnsDB(q) // OK: pure doesn't pollute
  	voidFunc(q)      // Pollutes q
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -608,7 +608,7 @@
 +	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic here (fix added for Count violation below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // consecutiveIfSwitchReassignment demonstrates consecutive if and switch with reassignment.
@@ -633,7 +633,7 @@
 +	q = q.Order("created_at").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // helperFunctionReassignment tests reassignment with helper function return value.
@@ -655,7 +655,7 @@
 +	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  type repo struct {
@@ -683,7 +683,7 @@
 +	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  type repoImmutable struct {
@@ -713,7 +713,7 @@
 +	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // switchMultipleCasesReassignment tests switch with multiple cases reassigning q.
@@ -742,7 +742,7 @@
 +	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // switchMultipleCasesChainedReassignment tests switch with chained Where calls.
@@ -764,7 +764,7 @@
 +	q = q.Order("e").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
  
  	q.Find(nil)      // First actual use - OK
- 	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // exactUserPatternImmutableReturn reproduces the exact user pattern:
@@ -868,10 +868,10 @@
  	}
  
  	if b {
- 		buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+ 		buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // consecutiveHelperCallsWithFind tests when Find breaks the chain.
@@ -888,10 +888,10 @@
  	q.Find(nil) // First use - OK, but now q is polluted
  
  	if b {
- 		q = buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+ 		q = buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // consecutiveHelperCallsWithFindReassign tests when Find result is used in reassignment pattern.
@@ -911,7 +911,7 @@
  		q = db.Where("new") // NEW mutable root - q is now fresh
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // ===== USER-DEFINED HELPER FUNCTION DIRECTIVE PATTERNS =====
@@ -971,10 +971,10 @@
  	}
  
  	if b {
- 		noPureHelper(q) // want `\*gorm\.DB instance reused after chain method`
+ 		noPureHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testPureOnlyHelperReassign tests helper with pure directive, result reassigned.
@@ -1026,7 +1026,7 @@
  	}
  
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testImmutableReturnOnlyHelperReassignGuaranteed tests helper with immutable-return directive.
@@ -1056,10 +1056,10 @@
  	}
  
  	if b {
- 		immutableReturnOnlyHelper(q) // want `\*gorm\.DB instance reused after chain method`
+ 		immutableReturnOnlyHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testPureAndImmutableReturnHelperReassign tests helper with both directives.
@@ -1078,7 +1078,7 @@
  	}
  
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testPureAndImmutableReturnHelperReassignGuaranteed tests helper with both directives.
@@ -1129,7 +1129,7 @@
  	}
  
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testImmutableInitialWithNoPureHelperGuaranteed tests immutable initial q, guaranteed reassign.
@@ -1144,7 +1144,7 @@
  
  	// q is now mutable (from noPureHelper), but it's first use
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testImmutableInitialWithImmutableReturnHelper tests immutable initial q with immutable-return helper.
@@ -1204,7 +1204,7 @@
  
  	// Path-insensitive: q could be original mutable, or any of the helper results
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testMixedHelperTypesAllImmutablePaths tests mixing helpers where all paths lead to immutable.
@@ -1236,7 +1236,7 @@
  
  	// Phi(mutable, immutable) - need to be conservative
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // ===== NO DIRECTIVE GUARANTEED PATTERN =====
@@ -1255,7 +1255,7 @@
  
  	// Both paths create new mutable root, so first use is OK
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // testPureOnlyHelperReassignGuaranteed tests pure helper with guaranteed reassignment.
@@ -1272,5 +1272,5 @@
  
  	// Both paths create new mutable root
  	q.Find(nil)  // First use - OK
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/advanced.go.golden
+++ b/testdata/src/gormreuse/advanced.go.golden
@@ -15,21 +15,21 @@ func derivedVariables(db *gorm.DB) {
 	queryDB := db.Model(&User{}).Where("name = ?", "jinzhu").Session(&gorm.Session{})
 	q := queryDB.Where("age > ?", 10).Session(&gorm.Session{}) // Derived without Session - mutable
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedChainResultReuse demonstrates reuse of stored chain result.
 func storedChainResultReuse(db *gorm.DB) {
 	q := db.Where("active = ?", true).Session(&gorm.Session{})
 	q.Find(nil)
-	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("name = ?", "x").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedChainResultMultipleDerivations demonstrates multiple derivations from same base.
 func storedChainResultMultipleDerivations(db *gorm.DB) {
 	base := db.Where("tenant_id = ?", 1).Session(&gorm.Session{})
 	base.Where("type = ?", "A").Find(nil)
-	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	base.Where("type = ?", "B").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // derivedFromSessionUnsafe demonstrates that chain after Session is still mutable.
@@ -39,7 +39,7 @@ func derivedFromSessionUnsafe(db *gorm.DB) {
 	derived := safe.Where("active = ?", true).Session(&gorm.Session{}) // Mutable!
 
 	derived.Find(nil)
-	derived.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	derived.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiLevelUnsafeDerivation demonstrates chained derivation.
@@ -49,7 +49,7 @@ func multiLevelUnsafeDerivation(db *gorm.DB) {
 	level3 := level2.Where("c").Session(&gorm.Session{})
 
 	level3.Find(nil)
-	level3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	level3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -103,7 +103,7 @@ func helperWhere(db *gorm.DB, name string) *gorm.DB {
 func functionReturnValue(db *gorm.DB) {
 	q := helperWhere(db, "jinzhu").Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -125,22 +125,22 @@ func functionReturnWithSession(db *gorm.DB) {
 func sessionAfterPolluted(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
 	q.Count(new(int64))                        // q is polluted
-	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // sessionOnPollutedValue demonstrates Session on already-polluted value.
 func sessionOnPollutedValue(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil)
-	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Session(&gorm.Session{}).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multipleDirectUsesWithoutSession demonstrates multiple uses without Session.
 func multipleDirectUsesWithoutSession(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil)
-	q.Count(nil)                          // want `\*gorm\.DB instance reused after chain method`
-	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)                          // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Session(&gorm.Session{}).First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -186,10 +186,10 @@ func conditionalExtendPartialWithPollution(db *gorm.DB, flag bool) {
 	q.Find(nil) // Pollutes q
 
 	if flag {
-		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendBothWithPollution demonstrates conditional extension in both branches with initial pollution.
@@ -200,9 +200,9 @@ func conditionalExtendBothWithPollution(db *gorm.DB, flag bool) {
 	q.Find(nil) // Pollutes q
 
 	if flag {
-		q = q.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		q = q.Where("z = ?", 3) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("z = ?", 3) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Count(nil) // OK: both branches created new q via assignment
@@ -218,7 +218,7 @@ func conditionalExtendPartialNoPollution(db *gorm.DB, flag bool) {
 	}
 
 	q.Find(nil)                 // OK: first actual use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendBothNoPollution demonstrates conditional extension in both branches without initial pollution.
@@ -233,7 +233,7 @@ func conditionalExtendBothNoPollution(db *gorm.DB, flag bool) {
 	}
 
 	q.Find(nil)                 // OK: first actual use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalExtendThreeBranches demonstrates three-way branch with partial assignment.
@@ -249,7 +249,7 @@ func conditionalExtendThreeBranches(db *gorm.DB, n int) {
 	// else: q remains unchanged (original mutable root)
 
 	q.Find(nil)  // OK: Phi(q_1, q_2, q_3) - all first use
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -265,7 +265,7 @@ func conditionalExtendThreeBranches(db *gorm.DB, n int) {
 func nonFinisherOnlyGeneratesFix(db *gorm.DB) {
 	q := db.Where("base")
 	q = q.Where("filter1") // Non-finisher expr stmt - should get "q = q.Where("filter1")" fix
-	q.Find(nil)        // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)        // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // finisherDoesNotGenerateReassignmentFix demonstrates that finisher calls
@@ -273,7 +273,7 @@ func nonFinisherOnlyGeneratesFix(db *gorm.DB) {
 func finisherDoesNotGenerateReassignmentFix(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -288,7 +288,7 @@ func parentScopeVariable(db *gorm.DB) {
 	q := db.Where("outer")
 	func() {
 		q = q.Where("inner")
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 }
 
@@ -299,7 +299,7 @@ func nestedClosureFixDedup(db *gorm.DB) {
 	func() {
 		func() {
 			q = q.Where("deep")
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}()
 	}()
 }
@@ -312,7 +312,7 @@ func tripleNestedClosureDedup(db *gorm.DB) {
 		func() {
 			func() {
 				q = q.Where("level3")
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}()
 		}()
 	}()
@@ -327,8 +327,8 @@ func tripleNestedClosureDedup(db *gorm.DB) {
 func nestedArgsFromMutableParent(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{}) // q is mutable
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
-		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
 }
 
@@ -346,10 +346,10 @@ func nestedArgsFromImmutableParent(db *gorm.DB) {
 func nestedArgsFromMutableThenReuse(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{}) // q is mutable
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
-		q.Where("b"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Where("b"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedArgsSingleUse demonstrates that even single nested arg is a violation
@@ -357,9 +357,9 @@ func nestedArgsFromMutableThenReuse(db *gorm.DB) {
 func nestedArgsSingleUse(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	q.Or(
-		q.Where("a"), // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a"), // want `\*gorm\.DB reused: second branch from mutable root`
 	).Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -433,7 +433,7 @@ func pureImmutableReturnReturnsDB(db *gorm.DB) *gorm.DB {
 func passToVoidFunc(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	voidFunc(q.Where("a"))
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to function returning *gorm.DB ---
@@ -443,9 +443,9 @@ func passToVoidFunc(db *gorm.DB) {
 func passToReturnsDB(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	result := returnsDB(q.Where("a")).Session(&gorm.Session{})
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: first use of result
-	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to pure function ---
@@ -457,9 +457,9 @@ func passToReturnsDB(db *gorm.DB) {
 func passToPureReturnsDB(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	result := pureReturnsDB(q.Where("a")).Session(&gorm.Session{})
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: first use of result
-	result.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // --- Test cases for passing q.Where() to immutable-return function ---
@@ -469,7 +469,7 @@ func passToPureReturnsDB(db *gorm.DB) {
 func passToImmutableReturnReturnsDB(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	result := immutableReturnReturnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: result is immutable
 	result.Find(nil) // OK: result is immutable, can reuse freely
 }
@@ -482,7 +482,7 @@ func passToImmutableReturnReturnsDB(db *gorm.DB) {
 func passToPureImmutableReturnReturnsDB(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	result := pureImmutableReturnReturnsDB(q.Where("a"))
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil) // OK: result is immutable
 	result.Find(nil) // OK: result is immutable, can reuse freely
 }
@@ -493,7 +493,7 @@ func passToPureImmutableReturnReturnsDB(db *gorm.DB) {
 func multipleCallsToVoidFunc(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	voidFunc(q.Where("a"))
-	voidFunc(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
+	voidFunc(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multipleCallsToPureFunc demonstrates multiple calls passing q.Where() to pure function.
@@ -501,8 +501,8 @@ func multipleCallsToVoidFunc(db *gorm.DB) {
 func multipleCallsToPureFunc(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	pureReturnsDB(q.Where("a"))
-	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB instance reused after chain method`
-	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+	pureReturnsDB(q.Where("b")) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -514,7 +514,7 @@ func multipleCallsToPureFunc(db *gorm.DB) {
 func passQDirectlyToNonPure(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	voidFunc(q)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToPure demonstrates passing q directly to pure function.
@@ -523,7 +523,7 @@ func passQDirectlyToPure(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	pureReturnsDB(q)
 	q.Find(nil) // OK: pure function doesn't pollute q
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToPureMultiple demonstrates multiple calls passing q to pure function.
@@ -534,7 +534,7 @@ func passQDirectlyToPureMultiple(db *gorm.DB) {
 	pureReturnsDB(q) // OK: pure function doesn't pollute q
 	pureReturnsDB(q) // OK: still not polluted
 	q.Find(nil)      // OK: first actual use of q
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // passQDirectlyToMixedFunctions demonstrates passing q to both pure and non-pure functions.
@@ -542,7 +542,7 @@ func passQDirectlyToMixedFunctions(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	pureReturnsDB(q) // OK: pure doesn't pollute
 	voidFunc(q)      // Pollutes q
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -566,7 +566,7 @@ func consecutiveIfReassignment(db *gorm.DB, a, b bool) {
 	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic here (fix added for Count violation below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveIfSwitchReassignment demonstrates consecutive if and switch with reassignment.
@@ -590,7 +590,7 @@ func consecutiveIfSwitchReassignment(db *gorm.DB, keyword string, status *int) {
 	q = q.Order("created_at").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // helperFunctionReassignment tests reassignment with helper function return value.
@@ -611,7 +611,7 @@ func helperFunctionReassignment(db *gorm.DB, a, b bool) {
 	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 type repo struct {
@@ -638,7 +638,7 @@ func methodReceiverReassignment(r *repo, a, b bool) {
 	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 type repoImmutable struct {
@@ -667,7 +667,7 @@ func immutableReturnMethodReassignment(r *repoImmutable, a, b bool) {
 	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchMultipleCasesReassignment tests switch with multiple cases reassigning q.
@@ -695,7 +695,7 @@ func switchMultipleCasesReassignment(db *gorm.DB, keyword string, status *int) {
 	q = q.Order("c").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchMultipleCasesChainedReassignment tests switch with chained Where calls.
@@ -716,7 +716,7 @@ func switchMultipleCasesChainedReassignment(db *gorm.DB, status *int) {
 	q = q.Order("e").Session(&gorm.Session{}) // Assignment - no diagnostic (fix for Count below)
 
 	q.Find(nil)      // First actual use - OK
-	q.Count(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // exactUserPatternImmutableReturn reproduces the exact user pattern:
@@ -819,10 +819,10 @@ func consecutiveHelperCallsNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+		buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveHelperCallsWithFind tests when Find breaks the chain.
@@ -837,10 +837,10 @@ func consecutiveHelperCallsWithFind(db *gorm.DB, a, b bool) {
 	q.Find(nil) // First use - OK, but now q is polluted
 
 	if b {
-		q = buildQuery(q, "b") // want `\*gorm\.DB instance reused after chain method`
+		q = buildQuery(q, "b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // consecutiveHelperCallsWithFindReassign tests when Find result is used in reassignment pattern.
@@ -858,7 +858,7 @@ func consecutiveHelperCallsWithFindReassign(db *gorm.DB, a, b bool) {
 		q = db.Where("new") // NEW mutable root - q is now fresh
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ===== USER-DEFINED HELPER FUNCTION DIRECTIVE PATTERNS =====
@@ -917,10 +917,10 @@ func testNoPureHelperNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		noPureHelper(q) // want `\*gorm\.DB instance reused after chain method`
+		noPureHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureOnlyHelperReassign tests helper with pure directive, result reassigned.
@@ -970,7 +970,7 @@ func testImmutableReturnOnlyHelperReassign(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableReturnOnlyHelperReassignGuaranteed tests helper with immutable-return directive.
@@ -999,10 +999,10 @@ func testImmutableReturnOnlyHelperNoReassign(db *gorm.DB, a, b bool) {
 	}
 
 	if b {
-		immutableReturnOnlyHelper(q) // want `\*gorm\.DB instance reused after chain method`
+		immutableReturnOnlyHelper(q) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureAndImmutableReturnHelperReassign tests helper with both directives.
@@ -1019,7 +1019,7 @@ func testPureAndImmutableReturnHelperReassign(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureAndImmutableReturnHelperReassignGuaranteed tests helper with both directives.
@@ -1070,7 +1070,7 @@ func testImmutableInitialWithNoPureHelper(db *gorm.DB, a, b bool) {
 	}
 
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableInitialWithNoPureHelperGuaranteed tests immutable initial q, guaranteed reassign.
@@ -1085,7 +1085,7 @@ func testImmutableInitialWithNoPureHelperGuaranteed(db *gorm.DB, a bool) {
 
 	// q is now mutable (from noPureHelper), but it's first use
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testImmutableInitialWithImmutableReturnHelper tests immutable initial q with immutable-return helper.
@@ -1143,7 +1143,7 @@ func testMixedHelperTypes(db *gorm.DB, a, b, c bool) {
 
 	// Path-insensitive: q could be original mutable, or any of the helper results
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testMixedHelperTypesAllImmutablePaths tests mixing helpers where all paths lead to immutable.
@@ -1173,7 +1173,7 @@ func testMixedHelperTypesMutableAndImmutable(db *gorm.DB, a bool) {
 
 	// Phi(mutable, immutable) - need to be conservative
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ===== NO DIRECTIVE GUARANTEED PATTERN =====
@@ -1190,7 +1190,7 @@ func testNoPureHelperReassignGuaranteed(db *gorm.DB, a bool) {
 
 	// Both paths create new mutable root, so first use is OK
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // testPureOnlyHelperReassignGuaranteed tests pure helper with guaranteed reassignment.
@@ -1205,5 +1205,5 @@ func testPureOnlyHelperReassignGuaranteed(db *gorm.DB, a bool) {
 
 	// Both paths create new mutable root
 	q.Find(nil)  // First use - OK
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/basic.go
+++ b/testdata/src/gormreuse/basic.go
@@ -16,32 +16,35 @@ type User struct {
 // =============================================================================
 
 // basicReuse demonstrates unsafe reuse of a *gorm.DB after chain method.
+// This case also locks the enriched diagnostic format (#76): the message names
+// the mutable root and the first branch (line numbers matched loosely with \d+
+// so edits above don't churn the want).
 func basicReuse(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root \(root at basic\.go:\d+, first branch at basic\.go:\d+\); make the root immutable with \.Session`
 }
 
 // reuseAfterChain demonstrates reuse after multiple chain methods.
 func reuseAfterChain(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Order("id")
 	q.Find(&[]User{})
-	q.First(&User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.First(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleUse demonstrates multiple violations from triple reuse.
 func tripleUse(db *gorm.DB) {
 	q := db.Model(&User{}).Where("a = ?", 1)
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
-	q.First(&User{})    // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.First(&User{})    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // sessionInMiddle demonstrates that Session in the middle doesn't make reuse safe.
 func sessionInMiddle(db *gorm.DB) {
 	q := db.Model(&User{}).Session(&gorm.Session{}).Where("x = ?", 1)
 	q.Find(&[]User{})
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/basic.go.diff
+++ b/testdata/src/gormreuse/basic.go.diff
@@ -1,6 +1,6 @@
 --- basic.go	1970-01-01 00:00:00
 +++ basic.go.golden	1970-01-01 00:00:00
-@@ -1,96 +1,96 @@
+@@ -1,99 +1,99 @@
  // Package internal contains test functions for gormreuse linter.
  package internal
  
@@ -19,11 +19,14 @@
  // =============================================================================
  
  // basicReuse demonstrates unsafe reuse of a *gorm.DB after chain method.
+ // This case also locks the enriched diagnostic format (#76): the message names
+ // the mutable root and the first branch (line numbers matched loosely with \d+
+ // so edits above don't churn the want).
  func basicReuse(db *gorm.DB) {
 -	q := db.Model(&User{}).Where("active = ?", true)
 +	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root \(root at basic\.go:\d+, first branch at basic\.go:\d+\); make the root immutable with \.Session`
  }
  
  // reuseAfterChain demonstrates reuse after multiple chain methods.
@@ -31,7 +34,7 @@
 -	q := db.Where("x = ?", 1).Order("id")
 +	q := db.Where("x = ?", 1).Order("id").Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.First(&User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleUse demonstrates multiple violations from triple reuse.
@@ -39,8 +42,8 @@
 -	q := db.Model(&User{}).Where("a = ?", 1)
 +	q := db.Model(&User{}).Where("a = ?", 1).Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
- 	q.First(&User{})    // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.First(&User{})    // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // sessionInMiddle demonstrates that Session in the middle doesn't make reuse safe.
@@ -48,7 +51,7 @@
 -	q := db.Model(&User{}).Session(&gorm.Session{}).Where("x = ?", 1)
 +	q := db.Model(&User{}).Session(&gorm.Session{}).Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/basic.go.golden
+++ b/testdata/src/gormreuse/basic.go.golden
@@ -16,32 +16,35 @@ type User struct {
 // =============================================================================
 
 // basicReuse demonstrates unsafe reuse of a *gorm.DB after chain method.
+// This case also locks the enriched diagnostic format (#76): the message names
+// the mutable root and the first branch (line numbers matched loosely with \d+
+// so edits above don't churn the want).
 func basicReuse(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true).Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root \(root at basic\.go:\d+, first branch at basic\.go:\d+\); make the root immutable with \.Session`
 }
 
 // reuseAfterChain demonstrates reuse after multiple chain methods.
 func reuseAfterChain(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Order("id").Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.First(&User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.First(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleUse demonstrates multiple violations from triple reuse.
 func tripleUse(db *gorm.DB) {
 	q := db.Model(&User{}).Where("a = ?", 1).Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
-	q.First(&User{})    // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.First(&User{})    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // sessionInMiddle demonstrates that Session in the middle doesn't make reuse safe.
 func sessionInMiddle(db *gorm.DB) {
 	q := db.Model(&User{}).Session(&gorm.Session{}).Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/closure_directive.go
+++ b/testdata/src/gormreuse/closure_directive.go
@@ -73,7 +73,7 @@ func closureNoPure(db *gorm.DB) {
 
 	q := db.Where("base")
 	impureHelper(q)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureNoImmutableReturn: No directive - closure result is mutable
@@ -84,7 +84,7 @@ func closureNoImmutableReturn(db *gorm.DB) {
 
 	q := getDB()
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -193,7 +193,7 @@ func nestedClosureInnerImmutableReturn(db *gorm.DB) {
 	result := outer(q)
 	q.Find(nil)      // OK - outer is pure
 	result.Find(nil) // outer's return is NOT immutable-return
-	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosurePureImmutableReturnBoth: Outer has both directives
@@ -233,7 +233,7 @@ func nestedClosureSameLineInnerPure(db *gorm.DB) {
 
 	q := db.Where("base")
 	outer(q)    // outer is NOT pure (directive is for inner)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosureSameLineOuterPure: Same line, directive AFTER outer's { but BEFORE inner's {
@@ -320,7 +320,7 @@ func complexDirective05(db *gorm.DB) {
 	result := helper(base)
 	base.Find(nil) // OK - helper is pure
 	result.Find(nil)
-	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // complexDirective06: immutable-return only - argument should be polluted
@@ -332,7 +332,7 @@ func complexDirective06(db *gorm.DB) {
 
 	base := db.Where("x")
 	result := helper(base)
-	base.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	base.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil)
 	result.Count(nil) // OK - result is immutable
 }
@@ -417,7 +417,7 @@ func multiAssign03(db *gorm.DB) {
 
 	q2 := db.Where("base2")
 	b.Fn(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign04: Three closures - first two direct, third in composite literal
@@ -435,7 +435,7 @@ func multiAssign04(db *gorm.DB) {
 
 	q3 := db.Where("base3")
 	c(q3)
-	q3.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q3.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign05: Separated statements - only first gets directive
@@ -450,7 +450,7 @@ func multiAssign05(db *gorm.DB) {
 
 	q2 := db.Where("base2")
 	b(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign06: Semicolon-separated on same line - only first statement gets directive
@@ -464,7 +464,7 @@ func multiAssign06(db *gorm.DB) {
 
 	q2 := db.Where("base2")
 	b(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign07: Multi-line assignment - all closures in same statement get directive

--- a/testdata/src/gormreuse/closure_directive.go.diff
+++ b/testdata/src/gormreuse/closure_directive.go.diff
@@ -77,7 +77,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	impureHelper(q)
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // closureNoImmutableReturn: No directive - closure result is mutable
@@ -89,7 +89,7 @@
  
  	q := getDB()
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -199,7 +199,7 @@
 +	result := outer(q).Session(&gorm.Session{})
  	q.Find(nil)      // OK - outer is pure
  	result.Find(nil) // outer's return is NOT immutable-return
- 	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedClosurePureImmutableReturnBoth: Outer has both directives
@@ -240,7 +240,7 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	outer(q)    // outer is NOT pure (directive is for inner)
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedClosureSameLineOuterPure: Same line, directive AFTER outer's { but BEFORE inner's {
@@ -328,7 +328,7 @@
 +	result := helper(base).Session(&gorm.Session{})
  	base.Find(nil) // OK - helper is pure
  	result.Find(nil)
- 	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // complexDirective06: immutable-return only - argument should be polluted
@@ -341,7 +341,7 @@
 -	base := db.Where("x")
 +	base := db.Where("x").Session(&gorm.Session{})
  	result := helper(base)
- 	base.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	base.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	result.Find(nil)
  	result.Count(nil) // OK - result is immutable
  }
@@ -427,7 +427,7 @@
 -	q2 := db.Where("base2")
 +	q2 := db.Where("base2").Session(&gorm.Session{})
  	b.Fn(q2)
- 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multiAssign04: Three closures - first two direct, third in composite literal
@@ -446,7 +446,7 @@
 -	q3 := db.Where("base3")
 +	q3 := db.Where("base3").Session(&gorm.Session{})
  	c(q3)
- 	q3.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q3.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multiAssign05: Separated statements - only first gets directive
@@ -462,7 +462,7 @@
 -	q2 := db.Where("base2")
 +	q2 := db.Where("base2").Session(&gorm.Session{})
  	b(q2)
- 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multiAssign06: Semicolon-separated on same line - only first statement gets directive
@@ -477,7 +477,7 @@
 -	q2 := db.Where("base2")
 +	q2 := db.Where("base2").Session(&gorm.Session{})
  	b(q2)
- 	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // multiAssign07: Multi-line assignment - all closures in same statement get directive

--- a/testdata/src/gormreuse/closure_directive.go.golden
+++ b/testdata/src/gormreuse/closure_directive.go.golden
@@ -73,7 +73,7 @@ func closureNoPure(db *gorm.DB) {
 
 	q := db.Where("base").Session(&gorm.Session{})
 	impureHelper(q)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureNoImmutableReturn: No directive - closure result is mutable
@@ -84,7 +84,7 @@ func closureNoImmutableReturn(db *gorm.DB) {
 
 	q := getDB()
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -193,7 +193,7 @@ func nestedClosureInnerImmutableReturn(db *gorm.DB) {
 	result := outer(q).Session(&gorm.Session{})
 	q.Find(nil)      // OK - outer is pure
 	result.Find(nil) // outer's return is NOT immutable-return
-	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosurePureImmutableReturnBoth: Outer has both directives
@@ -233,7 +233,7 @@ func nestedClosureSameLineInnerPure(db *gorm.DB) {
 
 	q := db.Where("base").Session(&gorm.Session{})
 	outer(q)    // outer is NOT pure (directive is for inner)
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosureSameLineOuterPure: Same line, directive AFTER outer's { but BEFORE inner's {
@@ -320,7 +320,7 @@ func complexDirective05(db *gorm.DB) {
 	result := helper(base).Session(&gorm.Session{})
 	base.Find(nil) // OK - helper is pure
 	result.Find(nil)
-	result.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	result.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // complexDirective06: immutable-return only - argument should be polluted
@@ -332,7 +332,7 @@ func complexDirective06(db *gorm.DB) {
 
 	base := db.Where("x").Session(&gorm.Session{})
 	result := helper(base)
-	base.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	base.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	result.Find(nil)
 	result.Count(nil) // OK - result is immutable
 }
@@ -417,7 +417,7 @@ func multiAssign03(db *gorm.DB) {
 
 	q2 := db.Where("base2").Session(&gorm.Session{})
 	b.Fn(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign04: Three closures - first two direct, third in composite literal
@@ -435,7 +435,7 @@ func multiAssign04(db *gorm.DB) {
 
 	q3 := db.Where("base3").Session(&gorm.Session{})
 	c(q3)
-	q3.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q3.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign05: Separated statements - only first gets directive
@@ -450,7 +450,7 @@ func multiAssign05(db *gorm.DB) {
 
 	q2 := db.Where("base2").Session(&gorm.Session{})
 	b(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign06: Semicolon-separated on same line - only first statement gets directive
@@ -464,7 +464,7 @@ func multiAssign06(db *gorm.DB) {
 
 	q2 := db.Where("base2").Session(&gorm.Session{})
 	b(q2)
-	q2.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // multiAssign07: Multi-line assignment - all closures in same statement get directive

--- a/testdata/src/gormreuse/closure_loop.go
+++ b/testdata/src/gormreuse/closure_loop.go
@@ -71,7 +71,7 @@ func iifeConditionalReturnSameRoot(db *gorm.DB) {
 		return q.Where("b")
 	}().Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
@@ -84,7 +84,7 @@ func iifeConditionalReturnDifferentRoots(db *gorm.DB) {
 	// Returns from different roots - should detect if any root is polluted
 	_ = func() *gorm.DB {
 		if true {
-			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+			return q1.Where("a") // want "\\*gorm\\.DB reused: second branch from mutable root"
 		}
 		return q2.Where("b") // q2 is clean
 	}().Find(nil)
@@ -102,7 +102,7 @@ func storedClosureSingleReturn(db *gorm.DB) {
 	result := getQuery()
 	result.Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // storedClosureMultiReturn: Stored closure with multi return value
@@ -117,7 +117,7 @@ func storedClosureMultiReturn(db *gorm.DB) {
 	result, _ := getQuery()
 	result.Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/closure_loop.go.diff
+++ b/testdata/src/gormreuse/closure_loop.go.diff
@@ -75,7 +75,7 @@
  		return q.Where("b")
  	}().Find(nil)
  
- 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
@@ -89,7 +89,7 @@
  	// Returns from different roots - should detect if any root is polluted
  	_ = func() *gorm.DB {
  		if true {
- 			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+ 			return q1.Where("a") // want "\\*gorm\\.DB reused: second branch from mutable root"
  		}
  		return q2.Where("b") // q2 is clean
  	}().Find(nil)
@@ -108,7 +108,7 @@
  	result := getQuery()
  	result.Find(nil)
  
- 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // storedClosureMultiReturn: Stored closure with multi return value
@@ -124,7 +124,7 @@
  	result, _ := getQuery()
  	result.Find(nil)
  
- 	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/closure_loop.go.golden
+++ b/testdata/src/gormreuse/closure_loop.go.golden
@@ -71,7 +71,7 @@ func iifeConditionalReturnSameRoot(db *gorm.DB) {
 		return q.Where("b")
 	}().Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // iifeConditionalReturnDifferentRoots: IIFE with conditional returns from different roots
@@ -84,7 +84,7 @@ func iifeConditionalReturnDifferentRoots(db *gorm.DB) {
 	// Returns from different roots - should detect if any root is polluted
 	_ = func() *gorm.DB {
 		if true {
-			return q1.Where("a") // want "\\*gorm\\.DB instance reused"
+			return q1.Where("a") // want "\\*gorm\\.DB reused: second branch from mutable root"
 		}
 		return q2.Where("b") // q2 is clean
 	}().Find(nil)
@@ -102,7 +102,7 @@ func storedClosureSingleReturn(db *gorm.DB) {
 	result := getQuery()
 	result.Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // storedClosureMultiReturn: Stored closure with multi return value
@@ -117,7 +117,7 @@ func storedClosureMultiReturn(db *gorm.DB) {
 	result, _ := getQuery()
 	result.Find(nil)
 
-	q.Count(nil) // want "\\*gorm\\.DB instance reused"
+	q.Count(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -141,7 +141,7 @@ func pureLeaksViaInterfaceArg(db *gorm.DB) {
 func reuseAfterLeakingPure(db *gorm.DB, ch chan *gorm.DB) {
 	q := db.Where("x")
 	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
-	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
@@ -791,7 +791,7 @@ func deriveMutableFromImmutable() {
 	db := getImmutableDB() // immutable
 	q := db.Where("x")     // q is mutable (derived from chain method)
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // IR102: Mixing immutable-return with regular chain methods
@@ -800,7 +800,7 @@ func mixImmutableAndMutable(db *gorm.DB) {
 	q := db.Where("x") // q is mutable
 	imm.Find(nil)      // OK: imm is immutable
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // IR103: immutable-return on a function whose return type is a bare interface{}

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -145,7 +145,7 @@
 -	q := db.Where("x")
 +	q := db.Where("x").Session(&gorm.Session{})
  	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
- 	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
@@ -796,7 +796,7 @@
 -	q := db.Where("x")     // q is mutable (derived from chain method)
 +	q := db.Where("x").Session(&gorm.Session{})     // q is mutable (derived from chain method)
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // IR102: Mixing immutable-return with regular chain methods
@@ -806,7 +806,7 @@
 +	q := db.Where("x").Session(&gorm.Session{}) // q is mutable
  	imm.Find(nil)      // OK: imm is immutable
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // IR103: immutable-return on a function whose return type is a bare interface{}

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -141,7 +141,7 @@ func pureLeaksViaInterfaceArg(db *gorm.DB) {
 func reuseAfterLeakingPure(db *gorm.DB, ch chan *gorm.DB) {
 	q := db.Where("x").Session(&gorm.Session{})
 	pureLeaksViaChanSend(q, ch) // leaks q → not trusted as pure here
-	q.Find(nil)                 // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)                 // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nonPureTakesAny is a non-pure helper taking interface{} (used by PV014).
@@ -791,7 +791,7 @@ func deriveMutableFromImmutable() {
 	db := getImmutableDB() // immutable
 	q := db.Where("x").Session(&gorm.Session{})     // q is mutable (derived from chain method)
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // IR102: Mixing immutable-return with regular chain methods
@@ -800,7 +800,7 @@ func mixImmutableAndMutable(db *gorm.DB) {
 	q := db.Where("x").Session(&gorm.Session{}) // q is mutable
 	imm.Find(nil)      // OK: imm is immutable
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // IR103: immutable-return on a function whose return type is a bare interface{}

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -18,7 +18,7 @@ func conditionalUsageBothMayExecute(db *gorm.DB, flag1, flag2 bool) {
 	}
 
 	if flag2 {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -42,7 +42,7 @@ func conditionalUsageOneConditionalOneUnconditional(db *gorm.DB, flag bool) {
 		q.Find(nil)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalUsageNestedConditions demonstrates nested conditionals with usage.
@@ -52,7 +52,7 @@ func conditionalUsageNestedConditions(db *gorm.DB, a, b bool) {
 	if a {
 		q.Find(nil)
 		if b {
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		q.First(nil) // OK: mutually exclusive with Find branch
@@ -72,7 +72,7 @@ func loopAssignmentOnly(db *gorm.DB, items []int) {
 	}
 
 	q.Find(nil)   // OK: first actual use (loop only had assignments)
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // loopConditionalAssignment demonstrates loop with conditional assignment.
@@ -88,7 +88,7 @@ func loopConditionalAssignment(db *gorm.DB, flags []bool) {
 	}
 
 	q.Find(nil)   // OK: first use after loop with conditional assignments only
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -107,7 +107,7 @@ func closureReuse(db *gorm.DB) {
 	fn()
 
 	// Detected: q was polluted inside the closure
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closurePollutesOutside demonstrates closure polluting, then using outside.
@@ -118,7 +118,7 @@ func closurePollutesOutside(db *gorm.DB) {
 		q.Find(nil) // Pollutes q inside closure
 	}()
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosure demonstrates nested closure detection.
@@ -133,7 +133,7 @@ func nestedClosure(db *gorm.DB) {
 	}
 	outer()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -179,7 +179,7 @@ func conditionalReuse(db *gorm.DB, flag bool) {
 		q.Where("b = ?", 2).Find(nil) // First use in else-branch (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalBothBranches demonstrates that if/else branches are mutually exclusive.
@@ -194,7 +194,7 @@ func conditionalBothBranches(db *gorm.DB, flag bool) {
 	}
 
 	// After either branch, q is polluted - this IS a reuse
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchReuse demonstrates that switch cases are mutually exclusive.
@@ -224,7 +224,7 @@ func loopReuse(db *gorm.DB, items []string) {
 
 	for _, item := range items {
 		// Second iteration reuses polluted q
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -234,7 +234,7 @@ func forLoopReuse(db *gorm.DB) {
 
 	for i := 0; i < 3; i++ {
 		// Second iteration reuses polluted q
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -269,7 +269,7 @@ func deferReuse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
 	// Defer is processed in second pass, after q.Find pollutes q
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil) // LIMITATION: Not detected (defer executes after, but q.Find is first in code order)
 }
@@ -280,7 +280,7 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // First use - pollutes q
 
-	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+	defer helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // twoDefersNoDirectUse: two deferred branches from the same root with NO direct
@@ -288,7 +288,7 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 func twoDefersNoDirectUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	defer q.Find(nil)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -320,7 +320,7 @@ func interProceduralPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	helperPollute(q) // Marks q as polluted (function assumed to pollute)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -373,7 +373,7 @@ func pureFactoryFunction() *gorm.DB {
 func pureFactoryUsage() {
 	db := pureFactoryFunction()
 	db.Find(nil)
-	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -391,7 +391,7 @@ func interfaceMethodPollution(db *gorm.DB, repo Repository) {
 	q := db.Where("x = ?", 1)
 	repo.Query(q) // Interface method assumed to pollute q
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -404,7 +404,7 @@ func channelPollution(db *gorm.DB, ch chan *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	ch <- q // Sending to channel marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -420,7 +420,7 @@ func goroutineClosureReuse(db *gorm.DB) {
 		q.Find(nil) // Pollutes q in goroutine closure
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineDirectMethodCall demonstrates direct method call in goroutine.
@@ -429,7 +429,7 @@ func goroutineDirectMethodCall(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // First use - pollutes q
 
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineFunctionCallWithDB demonstrates passing *gorm.DB to function in goroutine.
@@ -438,7 +438,7 @@ func goroutineFunctionCallWithDB(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // First use - pollutes q
 
-	go helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+	go helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineCrossFunctionPollution demonstrates cross-function pollution with goroutine.
@@ -454,7 +454,7 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 
 	// Start goroutine that uses the already-polluted q
 	// isPollutedAt should detect pollution from different function (closure)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
@@ -462,7 +462,7 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 func twoGoroutinesNoDirectUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	go q.Find(nil)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -511,7 +511,7 @@ func tripleNestedClosure(db *gorm.DB) {
 	}
 	level1()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadrupleNestedClosure demonstrates 4-level nested closure detection.
@@ -528,7 +528,7 @@ func quadrupleNestedClosure(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedClosureSafe demonstrates 3-level nested closure with Session.
@@ -555,7 +555,7 @@ func parentPollutesNestedClosureUses(db *gorm.DB) {
 
 	func() {
 		func() {
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}()
 	}()
 }
@@ -569,7 +569,7 @@ func parentPollutesTripleNestedUses(db *gorm.DB) {
 	func() {
 		func() {
 			func() {
-				q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}()
 		}()
 	}()
@@ -592,7 +592,7 @@ func higherOrderGoroutine(db *gorm.DB) {
 
 	go makeWorker(q)() // Pollutes q through higher-order function
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // makeWorkerMaker returns a function that returns a function.
@@ -610,7 +610,7 @@ func doubleHigherOrderGoroutine(db *gorm.DB) {
 
 	go makeWorkerMaker(q)()() // Pollutes q through double higher-order
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleHigherOrder demonstrates go fn()()()() pattern.
@@ -629,7 +629,7 @@ func tripleHigherOrder(db *gorm.DB) {
 
 	go maker(q)()()() // Pollutes q through triple higher-order
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -659,7 +659,7 @@ func goroutineInsideDefer(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedDeferGoroutineDefer demonstrates defer->goroutine->defer chain.
@@ -681,8 +681,8 @@ func nestedDeferGoroutineDefer(db *gorm.DB) {
 func multipleDefers(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil) // LIMITATION: Not detected (defers execute after, but q.Find is first in code order)
 }
@@ -713,7 +713,7 @@ func freeVarFrom4To2(db *gorm.DB) {
 	}
 	level1()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // freeVarMixedLevels demonstrates FreeVar with mixed usage levels.
@@ -736,7 +736,7 @@ func freeVarMixedLevels(db *gorm.DB) {
 	}
 	outer()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -751,7 +751,7 @@ func iifeReuse(db *gorm.DB) {
 		q.Find(nil)
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIIFE demonstrates nested IIFE pattern.
@@ -764,7 +764,7 @@ func nestedIIFE(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeWithArgument demonstrates IIFE with argument passing.
@@ -775,7 +775,7 @@ func iifeWithArgument(db *gorm.DB) {
 		d.Find(nil)
 	}(q)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeReturnChain demonstrates IIFE returning chain result.
@@ -789,7 +789,7 @@ func iifeReturnChain(db *gorm.DB) {
 	}().Find(nil) // First branch (IIFE chain counts as single branch)
 
 	// Second branch from q - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -821,7 +821,7 @@ func multiStructField(db *gorm.DB) {
 	h := multiHolder{q1: q, q2: q}
 	h.q1.Find(nil) // First use - pollutes underlying q
 
-	h.q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -834,7 +834,7 @@ func pointerIndirection(db *gorm.DB) {
 	ptr := &q
 	(*ptr).Find(nil) // Pollutes q through pointer
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // doublePointer demonstrates double pointer indirection.
@@ -844,7 +844,7 @@ func doublePointer(db *gorm.DB) {
 	ptr2 := &ptr
 	(**ptr2).Find(nil) // Pollutes q through double pointer
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -872,7 +872,7 @@ func slicePollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	_ = []*gorm.DB{q} // Storing in slice marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // mapPollution demonstrates pollution through map storage.
@@ -881,7 +881,7 @@ func mapPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	_ = map[string]*gorm.DB{"main": q} // Storing in map marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -898,7 +898,7 @@ func panicRecover(db *gorm.DB) {
 		}
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -917,7 +917,7 @@ func selectStatement(db *gorm.DB, ch chan int) {
 		q.First(nil) // First use in default (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -932,7 +932,7 @@ func methodValue(db *gorm.DB) {
 	find := q.Find
 	find(nil) // Pollutes q through method value
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // methodValueSameBlock demonstrates same-block pollution with method value.
@@ -941,7 +941,7 @@ func methodValueSameBlock(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	find := q.Find
 	find(nil)  // First use - pollutes q
-	find(nil)  // want `\*gorm\.DB instance reused after chain method`
+	find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // methodValueInLoop demonstrates method value in loop.
@@ -951,7 +951,7 @@ func methodValueInLoop(db *gorm.DB, items []string) {
 	find := q.Find
 
 	for range items {
-		find(nil) // want `\*gorm\.DB instance reused after chain method`
+		find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1031,7 +1031,7 @@ func helperWithNamedReturn(db *gorm.DB) (result *gorm.DB) {
 func namedReturn(db *gorm.DB) {
 	q := helperWithNamedReturn(db)
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1050,7 +1050,7 @@ func variadicPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	processQueries(q) // Function call assumed to pollute q
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1070,7 +1070,7 @@ func gotoStatement(db *gorm.DB, flag bool) {
 	q.First(nil)
 
 cleanup:
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1087,7 +1087,7 @@ func switchFallthrough(db *gorm.DB, level int) {
 		q.Find(nil) // First use in case 0
 		fallthrough
 	case 1:
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1104,10 +1104,10 @@ func multipleGoroutines(db *gorm.DB) {
 	}()
 
 	go func() {
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1124,7 +1124,7 @@ func interleavedCalls(db *gorm.DB) {
 		}(d)
 	}(q)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1144,7 +1144,7 @@ func combinedChaos(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ultimateChaos demonstrates the ultimate evil pattern.
@@ -1167,7 +1167,7 @@ func ultimateChaos(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1191,7 +1191,7 @@ func nestedIf(db *gorm.DB, a, b, c bool) {
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deepNestedIf demonstrates 4-level nested if.
@@ -1209,7 +1209,7 @@ func deepNestedIf(db *gorm.DB, a, b, c, d bool) {
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ifElseChain demonstrates if-else-if chain with mutually exclusive branches.
@@ -1227,7 +1227,7 @@ func ifElseChain(db *gorm.DB, level int) {
 		q.Take(nil) // First use in else (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1240,7 +1240,7 @@ func ifInsideFor(db *gorm.DB, items []string) {
 
 	for _, item := range items {
 		if item != "" {
-			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1251,9 +1251,9 @@ func ifElseInsideFor(db *gorm.DB, items []int) {
 
 	for _, item := range items {
 		if item > 0 {
-			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
-			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1265,7 +1265,7 @@ func nestedIfInsideFor(db *gorm.DB, items []int, flag bool) {
 	for _, item := range items {
 		if item > 0 {
 			if flag {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1281,11 +1281,11 @@ func forInsideIf(db *gorm.DB, items []string, flag bool) {
 
 	if flag {
 		for _, item := range items {
-			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // forInsideIfElse demonstrates for inside if-else branches.
@@ -1294,15 +1294,15 @@ func forInsideIfElse(db *gorm.DB, items []string, flag bool) {
 
 	if flag {
 		for _, item := range items {
-			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		for _, item := range items {
-			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1315,7 +1315,7 @@ func nestedFor(db *gorm.DB, outer, inner []string) {
 
 	for _, o := range outer {
 		for _, i := range inner {
-			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1327,7 +1327,7 @@ func tripleNestedFor(db *gorm.DB) {
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			for k := 0; k < 3; k++ {
-				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1344,10 +1344,10 @@ func forWithBreakContinue(db *gorm.DB, items []int) {
 		if item > 100 {
 			break
 		}
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1359,7 +1359,7 @@ func deferInsideIf(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1371,9 +1371,9 @@ func deferInsideIfElse(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1386,7 +1386,7 @@ func deferInsideNestedIf(db *gorm.DB, a, b bool) {
 
 	if a {
 		if b {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
@@ -1398,8 +1398,8 @@ func multipleDeferInsideIf(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1415,7 +1415,7 @@ func deferInsideFor(db *gorm.DB, items []string) {
 	q := db.Where("x = ?", 1)
 
 	for range items {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (defer inside loop)
@@ -1432,7 +1432,7 @@ func deferInsideForWithCondition(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferInsideNestedFor demonstrates defer inside nested for.
@@ -1446,7 +1446,7 @@ func deferInsideNestedFor(db *gorm.DB) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1464,7 +1464,7 @@ func forInsideDefer(db *gorm.DB, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedForInsideDefer demonstrates nested for inside defer.
@@ -1480,7 +1480,7 @@ func nestedForInsideDefer(db *gorm.DB) {
 		}
 	}()
 
-	q.Where("setup").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("setup").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1497,7 +1497,7 @@ func ifInsideDefer(db *gorm.DB, flag bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ifElseInsideDefer demonstrates if-else inside defer closure.
@@ -1512,7 +1512,7 @@ func ifElseInsideDefer(db *gorm.DB, flag bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfInsideDefer demonstrates nested if inside defer.
@@ -1529,7 +1529,7 @@ func nestedIfInsideDefer(db *gorm.DB, a, b bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1542,7 +1542,7 @@ func ifForDefer(db *gorm.DB, flag bool, items []string) {
 
 	if flag {
 		for range items {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
@@ -1560,7 +1560,7 @@ func forIfDefer(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferIfFor demonstrates defer closure containing if containing for.
@@ -1576,7 +1576,7 @@ func deferIfFor(db *gorm.DB, flag bool, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferForIf demonstrates defer closure containing for containing if.
@@ -1592,7 +1592,7 @@ func deferForIf(db *gorm.DB, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingIfForDefer demonstrates 3-level nesting: if -> for -> defer.
@@ -1610,7 +1610,7 @@ func tripleNestingIfForDefer(db *gorm.DB, flag bool, items []string) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingForIfDefer demonstrates 3-level nesting: for -> if -> defer.
@@ -1626,7 +1626,7 @@ func tripleNestingForIfDefer(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingDeferIfFor demonstrates 3-level nesting: defer -> if -> for.
@@ -1642,7 +1642,7 @@ func tripleNestingDeferIfFor(db *gorm.DB, flag bool, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingDeferForIf demonstrates 3-level nesting: defer -> for -> if.
@@ -1658,7 +1658,7 @@ func tripleNestingDeferForIf(db *gorm.DB, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1672,7 +1672,7 @@ func quadNestingIfForIfDefer(db *gorm.DB, a bool, items []int) {
 	if a {
 		for _, item := range items {
 			if item > 0 {
-				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1687,12 +1687,12 @@ func quadNestingForIfForDefer(db *gorm.DB, outer []bool, inner []int) {
 	for _, flag := range outer {
 		if flag {
 			for range inner {
-				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadNestingDeferIfForIf demonstrates 4-level: defer -> if -> for -> if.
@@ -1710,7 +1710,7 @@ func quadNestingDeferIfForIf(db *gorm.DB, a bool, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadNestingDeferForIfFor demonstrates 4-level: defer -> for -> if -> for.
@@ -1728,7 +1728,7 @@ func quadNestingDeferForIfFor(db *gorm.DB, outer []bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1740,11 +1740,11 @@ func multipleDefersInDifferentBranches(db *gorm.DB, level int) {
 	q := db.Where("x = ?", 1)
 
 	if level == 0 {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else if level == 1 {
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		defer q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1756,13 +1756,13 @@ func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
 
 	for _, item := range items {
 		if item > 0 {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
-			defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1774,7 +1774,7 @@ func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
 func earlyReturnWithDefer(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if flag {
 		q.Find(nil) // Pollutes q
@@ -1789,14 +1789,14 @@ func earlyReturnWithDefer(db *gorm.DB, flag bool) {
 func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	for _, item := range items {
 		if item < 0 {
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			return
 		}
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1808,16 +1808,16 @@ func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
 func labeledBreakWithDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 outer:
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			if i == 1 && j == 1 {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				break outer
 			}
-			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1826,16 +1826,16 @@ outer:
 func labeledContinueWithDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 outer:
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			if j == 1 {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				continue outer
 			}
-			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1861,7 +1861,7 @@ func foreverLoopWithBreak(db *gorm.DB, ch chan bool) {
 		break // Prevent actual infinite loop in test
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1896,7 +1896,7 @@ func deferCapturingLoopVar(db *gorm.DB, items []string) {
 		}()
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1913,7 +1913,7 @@ func nestedDeferClosures(db *gorm.DB) {
 		}()
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedDeferClosures demonstrates 3-level nested defer closures.
@@ -1928,7 +1928,7 @@ func tripleNestedDeferClosures(db *gorm.DB) {
 		}()
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedDeferWithFor demonstrates nested defer with for.
@@ -1943,7 +1943,7 @@ func nestedDeferWithFor(db *gorm.DB) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1954,10 +1954,10 @@ func nestedDeferWithFor(db *gorm.DB) {
 func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	for item := range ch {
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1970,7 +1970,7 @@ func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
 func typeSwitchWithDefer(db *gorm.DB, v interface{}) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	switch v.(type) {
 	case int:
@@ -1989,9 +1989,9 @@ func typeSwitchInsideFor(db *gorm.DB, items []interface{}) {
 	for _, item := range items {
 		switch item.(type) {
 		case int:
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		case string:
-			q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -2020,7 +2020,7 @@ func ultimateIfForDeferChaos(db *gorm.DB, a, b bool, outer []int, inner []string
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2041,7 +2041,7 @@ func tripleNestedIIFE(db *gorm.DB) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedIIFEWithBranch demonstrates IIFE with conditional branches.
@@ -2057,7 +2057,7 @@ func tripleNestedIIFEWithBranch(db *gorm.DB, cond bool) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2081,7 +2081,7 @@ func iifeMultipleReturns(db *gorm.DB, flag int) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2123,7 +2123,7 @@ func structFieldIIFE(db *gorm.DB) {
 	h.query.Find(nil) // [LIMITATION] Does not trace through struct field
 
 	// Second use of q - violation (q was polluted by IIFE's internal call)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2140,7 +2140,7 @@ func chainedIIFE(db *gorm.DB) {
 	}().Where("second", 2).Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2157,7 +2157,7 @@ func iifeCaptureAndModify(db *gorm.DB) {
 	}()
 
 	result.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2179,7 +2179,7 @@ func iifeWithPhiNode(db *gorm.DB, cond bool) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2197,7 +2197,7 @@ func iifeArgumentReturnsChain(db *gorm.DB) {
 	}(q).Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
@@ -2211,8 +2211,8 @@ func iifeArgumentAndFreeVarMixed(db *gorm.DB) {
 		return inner.Where("arg", 1)
 	}(q1).Find(nil)
 
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2247,9 +2247,9 @@ func deepNestedMixedCapture(db *gorm.DB) {
 	}().Find(nil)
 
 	// All second branches - violations
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2267,7 +2267,7 @@ func storedClosureChain(db *gorm.DB) {
 	}
 	q2 := fn()         // q2 holds first branch from q1
 	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedClosureReordered demonstrates order of calls with stored closure.
@@ -2282,7 +2282,7 @@ func storedClosureReordered(db *gorm.DB) {
 		return q1.Where("from closure", 1) // Pollutes q1 (closure body processed first in SSA)
 	}
 	q2 := fn()
-	q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
+	q1.Where("z", 3) // want `\*gorm\.DB reused: second branch from mutable root`
 	q2.Where("y", 2) // OK: q2 is fresh root
 }
 
@@ -2295,7 +2295,7 @@ func iifeStoredResult(db *gorm.DB) {
 		return q1.Where("from iife", 1)
 	}()
 	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2314,7 +2314,7 @@ func beginReturnsImmutable(db *gorm.DB) {
 func beginChainedBecomesMutable(db *gorm.DB) {
 	tx := db.Begin().Where("x = ?", 1)
 	tx.Find(nil)
-	tx.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	tx.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2328,7 +2328,7 @@ func reassignInLoop(db *gorm.DB, items []string) {
 	for _, item := range items {
 		q = db.Where("name = ?", item)
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -2353,7 +2353,7 @@ func reassignConditionalPartial(db *gorm.DB, flag bool) {
 		q = db.Where("y = ?", 2) // Reassigns q in this branch only
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignConditionalBoth demonstrates reassignment in both branches.
@@ -2377,7 +2377,7 @@ func reassignAfterPollutionSameValue(db *gorm.DB) {
 	base := db.Where("x = ?", 1)
 	base.Find(nil) // Pollutes base
 
-	q := base.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+	q := base.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	q.Count(nil)                // OK: q is a fresh root
 }
 
@@ -2390,10 +2390,10 @@ func reassignShadowing(db *gorm.DB) {
 	{
 		q := db.Where("y = ?", 2) // New variable (shadows)
 		q.Find(nil)               // Pollutes inner q
-		q.Count(nil)              // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil)              // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignInClosure demonstrates reassignment inside closure.
@@ -2405,7 +2405,7 @@ func reassignInClosure(db *gorm.DB) {
 		q = db.Where("y = ?", 2) // Reassign in closure
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignFromHelper demonstrates reassignment from helper function.
@@ -2415,7 +2415,7 @@ func reassignFromHelper(db *gorm.DB) {
 
 	q = helperReturnsDB(db) // Reassign from helper
 	q.Find(nil)             // Pollutes new q
-	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func helperReturnsDB(db *gorm.DB) *gorm.DB {
@@ -2441,7 +2441,7 @@ func reassignChainExtension(db *gorm.DB) {
 	q = db.Where("y = ?", 2)
 	q = q.Where("z = ?", 3) // Extend the new chain
 	q.Find(nil)             // Pollutes new q
-	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignMultipleTimes demonstrates multiple reassignments.
@@ -2474,7 +2474,7 @@ func reassignInSwitch(db *gorm.DB, mode int) {
 		// No reassignment in default - q is still polluted
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignInSwitchAll demonstrates reassignment in all switch branches.
@@ -2502,7 +2502,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 	where := db.Where
 	q = where("y = ?", 2) // Reassign from method value
 	q.Find(nil)           // Pollutes new q
-	q.Count(nil)          // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)          // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignDeferredUse demonstrates reassignment with deferred use.
@@ -2510,7 +2510,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 func reassignDeferredUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Count(nil) // Pollutes q, defer will use this polluted q
 
@@ -2528,8 +2528,8 @@ func reassignPointerDeref(db *gorm.DB) {
 	*p = db.Where("y = ?", 2) // Reassign through pointer
 
 	// [LIMITATION] FALSE POSITIVE: Pointer reassignment creates new root tracking
-	q.Find(nil)  // want `\*gorm\.DB instance reused after chain method`
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2557,7 +2557,7 @@ func pointerPhiCase(db *gorm.DB, flag bool) {
 	(*pp).Find(nil) // Pollutes through pointer
 
 	// q1 is detected because traceAllAllocStores finds the store
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	// q2 detection depends on SSA structure - may or may not be detected
 	q2.Count(nil)
 }
@@ -2582,7 +2582,7 @@ func pureMethodUsage() {
 	wrapper := &OrmWrapper{}
 	db := wrapper.GetDB()
 	db.Find(nil)
-	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2598,7 +2598,7 @@ func whereOnlyBasic(db *gorm.DB) {
 
 	q.Where("a").Find(nil) // First branch - pollutes q
 
-	q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyChain demonstrates chained Where without finisher.
@@ -2607,7 +2607,7 @@ func whereOnlyChain(db *gorm.DB) {
 
 	q.Find(nil) // First branch - pollutes q
 
-	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyClosure demonstrates closure pollution then Where-only outside.
@@ -2618,7 +2618,7 @@ func whereOnlyClosure(db *gorm.DB) {
 		q.Find(nil) // Pollutes q inside closure
 	}()
 
-	q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFE demonstrates IIFE pollution then Where-only outside.
@@ -2629,7 +2629,7 @@ func whereOnlyIIFE(db *gorm.DB) {
 		return q.Where("from iife")
 	}().Find(nil) // First branch (IIFE chain)
 
-	q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyLoop demonstrates loop pollution with Where-only.
@@ -2637,7 +2637,7 @@ func whereOnlyLoop(db *gorm.DB, items []int) {
 	q := db.Where("x = ?", 1)
 
 	for range items {
-		q.Where("in loop") // want `\*gorm\.DB instance reused after chain method`
+		q.Where("in loop") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -2651,14 +2651,14 @@ func whereOnlyConditional(db *gorm.DB, flag bool) {
 		q.Count(nil) // First branch (mutually exclusive)
 	}
 
-	q.Where("after conditional") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after conditional") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyDefer demonstrates defer with Where-only.
 func whereOnlyDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
-	defer q.Where("deferred") // want `\*gorm\.DB instance reused after chain method`
+	defer q.Where("deferred") // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil)
 }
@@ -2672,7 +2672,7 @@ func whereOnlyGoroutine(db *gorm.DB) {
 		q.Where("in goroutine")
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyStoredClosure demonstrates stored closure with Where-only violation.
@@ -2684,7 +2684,7 @@ func whereOnlyStoredClosure(db *gorm.DB) {
 	}
 	fn()
 
-	q.Where("after stored closure") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after stored closure") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyStoredClosureReturn demonstrates stored closure returning chain.
@@ -2696,7 +2696,7 @@ func whereOnlyStoredClosureReturn(db *gorm.DB) {
 	}
 	_ = fn().Find(nil) // First branch
 
-	q.Where("after") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFEStored demonstrates stored IIFE result with Where-only.
@@ -2709,7 +2709,7 @@ func whereOnlyIIFEStored(db *gorm.DB) {
 	}()
 
 	q2.Where("use stored") // Continues q2's chain (OK)
-	q.Where("original")    // want `\*gorm\.DB instance reused after chain method`
+	q.Where("original")    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyBoundMethod demonstrates bound method with Where-only.
@@ -2719,7 +2719,7 @@ func whereOnlyBoundMethod(db *gorm.DB) {
 	where := q.Where
 	where("bound method call") // First use - pollutes q
 
-	q.Where("after bound") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after bound") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyNestedIIFE demonstrates nested IIFE with Where-only.
@@ -2732,7 +2732,7 @@ func whereOnlyNestedIIFE(db *gorm.DB) {
 		}()
 	}().Find(nil) // First branch (entire nested IIFE chain)
 
-	q.Where("after nested") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after nested") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFEChainContinued demonstrates IIFE chain with Where continuation.
@@ -2743,7 +2743,7 @@ func whereOnlyIIFEChainContinued(db *gorm.DB) {
 		return q.Where("iife inner")
 	}().Where("chained after iife").Find(nil) // First branch
 
-	q.Where("second branch") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("second branch") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyDoubleIIFE demonstrates two IIFEs with Where-only.
@@ -2755,7 +2755,7 @@ func whereOnlyDoubleIIFE(db *gorm.DB) {
 	}().Find(nil) // First branch
 
 	_ = func() *gorm.DB {
-		return q.Where("second iife") // want `\*gorm\.DB instance reused after chain method`
+		return q.Where("second iife") // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 }
 
@@ -2773,7 +2773,7 @@ func whereOnlyStructFieldClosure(db *gorm.DB) {
 	}
 	h.fn()
 
-	q.Where("after struct field closure") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after struct field closure") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyMultipleBranches demonstrates multiple Where-only branches.
@@ -2782,9 +2782,9 @@ func whereOnlyMultipleBranches(db *gorm.DB) {
 
 	q.Where("branch1").Find(nil) // First branch
 
-	q.Where("branch2") // want `\*gorm\.DB instance reused after chain method`
-	q.Where("branch3") // want `\*gorm\.DB instance reused after chain method`
-	q.Where("branch4") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("branch2") // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("branch3") // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("branch4") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2796,8 +2796,8 @@ func whereOnlyMultipleBranches(db *gorm.DB) {
 func chainingWithoutReassignmentViolation(db *gorm.DB) {
 	q := db.Where("base")
 	q.Where("a")     // first branch - OK
-	q.Where("b")     // want `\*gorm\.DB instance reused after chain method`
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q.Where("b")     // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chainingWithReassignmentSafe demonstrates the solution: reassign each step.
@@ -2830,7 +2830,7 @@ func phiOneHasSession(db *gorm.DB, cond bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSessionInMiddle demonstrates Session in the middle of a chain.
@@ -2844,7 +2844,7 @@ func phiSessionInMiddle(db *gorm.DB, cond bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiThreeBranchesMiddleImmutable demonstrates if/else if/else with middle branch immutable.
@@ -2860,7 +2860,7 @@ func phiThreeBranchesMiddleImmutable(db *gorm.DB, mode int) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSwitchMixedSession demonstrates switch with mixed Session.
@@ -2879,7 +2879,7 @@ func phiSwitchMixedSession(db *gorm.DB, mode int) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSwitchAllImmutable demonstrates switch where all cases are immutable.
@@ -2916,7 +2916,7 @@ func callbackViolationInWrapper(db *gorm.DB) {
 	wrapperFunc(func() {
 		q := db.Where("x")
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -2925,8 +2925,8 @@ func callbackMultipleViolationsInWrapper(db *gorm.DB) {
 	wrapperFunc(func() {
 		q := db.Where("base")
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -2936,7 +2936,7 @@ func callbackNestedWrappers(db *gorm.DB) {
 		wrapperFunc(func() {
 			q := db.Where("nested")
 			q.Find(nil)
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		})
 	})
 }
@@ -2969,7 +2969,7 @@ func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 	}
 	// h.db may be q1 (polluted) or q2 (clean)
 	// Should detect pollution from q1
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignOnePollutedReverse demonstrates the same pattern
@@ -2990,7 +2990,7 @@ func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 	}
 	// h.db may be q1 (clean) or q2 (polluted)
 	// Should detect pollution from q2
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
@@ -3008,7 +3008,7 @@ func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
 		h.db = q2 // Branch 2: also polluted
 	}
 	// h.db may be q1 or q2, both are polluted
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignThenUseInBothBranches demonstrates field assignment
@@ -3021,7 +3021,7 @@ func conditionalFieldAssignThenUseInBothBranches(db *gorm.DB, cond bool) {
 		h.db = db.Where("b")
 	}
 	h.db.Find(nil) // First use - OK
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -3043,7 +3043,7 @@ func closureCapturesPhi(db *gorm.DB, cond bool) {
 	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
 
 	fn := func() {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3066,7 +3066,7 @@ func closureCaputresPhiOnePolluted(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q1
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3088,7 +3088,7 @@ func closureCaputresPhiOnePollutedReverse(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q2
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3109,7 +3109,7 @@ func boundMethodWithPhiOnePolluted(db *gorm.DB, flag bool) {
 	}
 	// q is Phi(q_polluted, q_clean)
 	find := q.Find // Bound method
-	find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // [LIMITATION] boundMethodWithPhiOnePollutedReverse tests bound method with reversed branch order.
@@ -3139,7 +3139,7 @@ func goStatementWithPhiOnePolluted(db *gorm.DB, flag bool) {
 		q = db.Where("b")
 	}
 	// q is Phi(q_polluted, q_clean)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goStatementWithPhiOnePollutedReverse tests go with reversed branch order.
@@ -3152,7 +3152,7 @@ func goStatementWithPhiOnePollutedReverse(db *gorm.DB, flag bool) {
 		q.Find(nil) // pollutes q from this branch
 	}
 	// q is Phi(q_clean, q_polluted)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferStatementWithPhiOnePolluted tests defer where one branch of Phi is polluted.
@@ -3165,7 +3165,7 @@ func deferStatementWithPhiOnePolluted(db *gorm.DB, flag bool) {
 		q = db.Where("b")
 	}
 	// q is Phi(q_polluted, q_clean)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferStatementWithPhiOnePollutedReverse tests defer with reversed branch order.
@@ -3178,5 +3178,5 @@ func deferStatementWithPhiOnePollutedReverse(db *gorm.DB, flag bool) {
 		q.Find(nil) // pollutes q from this branch
 	}
 	// q is Phi(q_clean, q_polluted)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -22,7 +22,7 @@
  	}
  
  	if flag2 {
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -47,7 +47,7 @@
  		q.Find(nil)
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalUsageNestedConditions demonstrates nested conditionals with usage.
@@ -58,7 +58,7 @@
  	if a {
  		q.Find(nil)
  		if b {
- 			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	} else {
  		q.First(nil) // OK: mutually exclusive with Find branch
@@ -80,7 +80,7 @@
  	}
  
  	q.Find(nil)   // OK: first actual use (loop only had assignments)
- 	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // loopConditionalAssignment demonstrates loop with conditional assignment.
@@ -98,7 +98,7 @@
  	}
  
  	q.Find(nil)   // OK: first use after loop with conditional assignments only
- 	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -118,7 +118,7 @@
  	fn()
  
  	// Detected: q was polluted inside the closure
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // closurePollutesOutside demonstrates closure polluting, then using outside.
@@ -130,7 +130,7 @@
  		q.Find(nil) // Pollutes q inside closure
  	}()
  
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedClosure demonstrates nested closure detection.
@@ -146,7 +146,7 @@
  	}
  	outer()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -193,7 +193,7 @@
  		q.Where("b = ?", 2).Find(nil) // First use in else-branch (mutually exclusive)
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalBothBranches demonstrates that if/else branches are mutually exclusive.
@@ -209,7 +209,7 @@
  	}
  
  	// After either branch, q is polluted - this IS a reuse
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // switchReuse demonstrates that switch cases are mutually exclusive.
@@ -240,7 +240,7 @@
  
  	for _, item := range items {
  		// Second iteration reuses polluted q
- 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -251,7 +251,7 @@
  
  	for i := 0; i < 3; i++ {
  		// Second iteration reuses polluted q
- 		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -287,7 +287,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	// Defer is processed in second pass, after q.Find pollutes q
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q.Find(nil) // LIMITATION: Not detected (defer executes after, but q.Find is first in code order)
  }
@@ -299,7 +299,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
- 	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+ 	defer helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // twoDefersNoDirectUse: two deferred branches from the same root with NO direct
@@ -307,7 +307,7 @@
  func twoDefersNoDirectUse(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	defer q.Find(nil)
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -340,7 +340,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	helperPollute(q) // Marks q as polluted (function assumed to pollute)
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -394,7 +394,7 @@
 -	db := pureFactoryFunction()
 +	db := pureFactoryFunction().Session(&gorm.Session{})
  	db.Find(nil)
- 	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -413,7 +413,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	repo.Query(q) // Interface method assumed to pollute q
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -427,7 +427,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	ch <- q // Sending to channel marks q as polluted
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -444,7 +444,7 @@
  		q.Find(nil) // Pollutes q in goroutine closure
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // goroutineDirectMethodCall demonstrates direct method call in goroutine.
@@ -454,7 +454,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
- 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // goroutineFunctionCallWithDB demonstrates passing *gorm.DB to function in goroutine.
@@ -464,7 +464,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	q.Find(nil) // First use - pollutes q
  
- 	go helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+ 	go helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // goroutineCrossFunctionPollution demonstrates cross-function pollution with goroutine.
@@ -481,7 +481,7 @@
  
  	// Start goroutine that uses the already-polluted q
  	// isPollutedAt should detect pollution from different function (closure)
- 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
@@ -489,7 +489,7 @@
  func twoGoroutinesNoDirectUse(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	go q.Find(nil)
- 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -539,7 +539,7 @@
  	}
  	level1()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // quadrupleNestedClosure demonstrates 4-level nested closure detection.
@@ -557,7 +557,7 @@
  		}()
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestedClosureSafe demonstrates 3-level nested closure with Session.
@@ -585,7 +585,7 @@
  
  	func() {
  		func() {
- 			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}()
  	}()
  }
@@ -600,7 +600,7 @@
  	func() {
  		func() {
  			func() {
- 				q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}()
  		}()
  	}()
@@ -624,7 +624,7 @@
  
  	go makeWorker(q)() // Pollutes q through higher-order function
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // makeWorkerMaker returns a function that returns a function.
@@ -643,7 +643,7 @@
  
  	go makeWorkerMaker(q)()() // Pollutes q through double higher-order
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleHigherOrder demonstrates go fn()()()() pattern.
@@ -663,7 +663,7 @@
  
  	go maker(q)()()() // Pollutes q through triple higher-order
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -694,7 +694,7 @@
  		}()
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedDeferGoroutineDefer demonstrates defer->goroutine->defer chain.
@@ -717,8 +717,8 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q.Find(nil) // LIMITATION: Not detected (defers execute after, but q.Find is first in code order)
  }
@@ -750,7 +750,7 @@
  	}
  	level1()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // freeVarMixedLevels demonstrates FreeVar with mixed usage levels.
@@ -774,7 +774,7 @@
  	}
  	outer()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -790,7 +790,7 @@
  		q.Find(nil)
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIIFE demonstrates nested IIFE pattern.
@@ -804,7 +804,7 @@
  		}()
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // iifeWithArgument demonstrates IIFE with argument passing.
@@ -816,7 +816,7 @@
  		d.Find(nil)
  	}(q)
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // iifeReturnChain demonstrates IIFE returning chain result.
@@ -831,7 +831,7 @@
  	}().Find(nil) // First branch (IIFE chain counts as single branch)
  
  	// Second branch from q - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -864,7 +864,7 @@
  	h := multiHolder{q1: q, q2: q}
  	h.q1.Find(nil) // First use - pollutes underlying q
  
- 	h.q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	h.q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -878,7 +878,7 @@
  	ptr := &q
  	(*ptr).Find(nil) // Pollutes q through pointer
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // doublePointer demonstrates double pointer indirection.
@@ -889,7 +889,7 @@
  	ptr2 := &ptr
  	(**ptr2).Find(nil) // Pollutes q through double pointer
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -918,7 +918,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	_ = []*gorm.DB{q} // Storing in slice marks q as polluted
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // mapPollution demonstrates pollution through map storage.
@@ -928,7 +928,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	_ = map[string]*gorm.DB{"main": q} // Storing in map marks q as polluted
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -946,7 +946,7 @@
  		}
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -966,7 +966,7 @@
  		q.First(nil) // First use in default (mutually exclusive)
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -982,7 +982,7 @@
  	find := q.Find
  	find(nil) // Pollutes q through method value
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // methodValueSameBlock demonstrates same-block pollution with method value.
@@ -991,7 +991,7 @@
  	q := db.Where("x = ?", 1)
  	find := q.Find
  	find(nil)  // First use - pollutes q
- 	find(nil)  // want `\*gorm\.DB instance reused after chain method`
+ 	find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // methodValueInLoop demonstrates method value in loop.
@@ -1001,7 +1001,7 @@
  	find := q.Find
  
  	for range items {
- 		find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1082,7 +1082,7 @@
 -	q := helperWithNamedReturn(db)
 +	q := helperWithNamedReturn(db).Session(&gorm.Session{})
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1102,7 +1102,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	processQueries(q) // Function call assumed to pollute q
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1123,7 +1123,7 @@
  	q.First(nil)
  
  cleanup:
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1141,7 +1141,7 @@
  		q.Find(nil) // First use in case 0
  		fallthrough
  	case 1:
- 		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1159,10 +1159,10 @@
  	}()
  
  	go func() {
- 		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1180,7 +1180,7 @@
  		}(d)
  	}(q)
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1201,7 +1201,7 @@
  		}()
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // ultimateChaos demonstrates the ultimate evil pattern.
@@ -1225,7 +1225,7 @@
  		}()
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1250,7 +1250,7 @@
  		}
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deepNestedIf demonstrates 4-level nested if.
@@ -1269,7 +1269,7 @@
  		}
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // ifElseChain demonstrates if-else-if chain with mutually exclusive branches.
@@ -1288,7 +1288,7 @@
  		q.Take(nil) // First use in else (mutually exclusive)
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1302,7 +1302,7 @@
  
  	for _, item := range items {
  		if item != "" {
- 			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -1314,9 +1314,9 @@
  
  	for _, item := range items {
  		if item > 0 {
- 			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		} else {
- 			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -1329,7 +1329,7 @@
  	for _, item := range items {
  		if item > 0 {
  			if flag {
- 				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
@@ -1346,11 +1346,11 @@
  
  	if flag {
  		for _, item := range items {
- 			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // forInsideIfElse demonstrates for inside if-else branches.
@@ -1360,15 +1360,15 @@
  
  	if flag {
  		for _, item := range items {
- 			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	} else {
  		for _, item := range items {
- 			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1382,7 +1382,7 @@
  
  	for _, o := range outer {
  		for _, i := range inner {
- 			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -1395,7 +1395,7 @@
  	for i := 0; i < 3; i++ {
  		for j := 0; j < 3; j++ {
  			for k := 0; k < 3; k++ {
- 				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
@@ -1413,10 +1413,10 @@
  		if item > 100 {
  			break
  		}
- 		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1429,7 +1429,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
- 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1442,9 +1442,9 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
- 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	} else {
- 		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1458,7 +1458,7 @@
  
  	if a {
  		if b {
- 			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
@@ -1471,8 +1471,8 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if flag {
- 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1489,7 +1489,7 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	for range items {
- 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Find(nil) // LIMITATION: Not detected (defer inside loop)
@@ -1507,7 +1507,7 @@
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deferInsideNestedFor demonstrates defer inside nested for.
@@ -1522,7 +1522,7 @@
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1540,7 +1540,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedForInsideDefer demonstrates nested for inside defer.
@@ -1556,7 +1556,7 @@
  		}
  	}()
  
- 	q.Where("setup").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("setup").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1574,7 +1574,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // ifElseInsideDefer demonstrates if-else inside defer closure.
@@ -1590,7 +1590,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfInsideDefer demonstrates nested if inside defer.
@@ -1608,7 +1608,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1622,7 +1622,7 @@
  
  	if flag {
  		for range items {
- 			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
@@ -1641,7 +1641,7 @@
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deferIfFor demonstrates defer closure containing if containing for.
@@ -1657,7 +1657,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deferForIf demonstrates defer closure containing for containing if.
@@ -1673,7 +1673,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestingIfForDefer demonstrates 3-level nesting: if -> for -> defer.
@@ -1692,7 +1692,7 @@
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestingForIfDefer demonstrates 3-level nesting: for -> if -> defer.
@@ -1709,7 +1709,7 @@
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestingDeferIfFor demonstrates 3-level nesting: defer -> if -> for.
@@ -1725,7 +1725,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestingDeferForIf demonstrates 3-level nesting: defer -> for -> if.
@@ -1741,7 +1741,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1756,7 +1756,7 @@
  	if a {
  		for _, item := range items {
  			if item > 0 {
- 				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
@@ -1772,12 +1772,12 @@
  	for _, flag := range outer {
  		if flag {
  			for range inner {
- 				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // quadNestingDeferIfForIf demonstrates 4-level: defer -> if -> for -> if.
@@ -1795,7 +1795,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // quadNestingDeferForIfFor demonstrates 4-level: defer -> for -> if -> for.
@@ -1813,7 +1813,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1826,11 +1826,11 @@
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
  	if level == 0 {
- 		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	} else if level == 1 {
- 		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	} else {
- 		defer q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		defer q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1843,13 +1843,13 @@
  
  	for _, item := range items {
  		if item > 0 {
- 			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		} else {
- 			defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1862,7 +1862,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	if flag {
  		q.Find(nil) // Pollutes q
@@ -1878,14 +1878,14 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	for _, item := range items {
  		if item < 0 {
- 			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			return
  		}
- 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1898,16 +1898,16 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  outer:
  	for i := 0; i < 3; i++ {
  		for j := 0; j < 3; j++ {
  			if i == 1 && j == 1 {
- 				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  				break outer
  			}
- 			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -1917,16 +1917,16 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  outer:
  	for i := 0; i < 3; i++ {
  		for j := 0; j < 3; j++ {
  			if j == 1 {
- 				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  				continue outer
  			}
- 			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -1953,7 +1953,7 @@
  		break // Prevent actual infinite loop in test
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -1989,7 +1989,7 @@
  		}()
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2007,7 +2007,7 @@
  		}()
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestedDeferClosures demonstrates 3-level nested defer closures.
@@ -2023,7 +2023,7 @@
  		}()
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedDeferWithFor demonstrates nested defer with for.
@@ -2039,7 +2039,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2051,10 +2051,10 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	for item := range ch {
- 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -2068,7 +2068,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	switch v.(type) {
  	case int:
@@ -2088,9 +2088,9 @@
  	for _, item := range items {
  		switch item.(type) {
  		case int:
- 			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		case string:
- 			q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  }
@@ -2120,7 +2120,7 @@
  		}
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2142,7 +2142,7 @@
  	}().Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // tripleNestedIIFEWithBranch demonstrates IIFE with conditional branches.
@@ -2159,7 +2159,7 @@
  	}().Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2184,7 +2184,7 @@
  	}().Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2227,7 +2227,7 @@
  	h.query.Find(nil) // [LIMITATION] Does not trace through struct field
  
  	// Second use of q - violation (q was polluted by IIFE's internal call)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2245,7 +2245,7 @@
  	}().Where("second", 2).Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2263,7 +2263,7 @@
  	}()
  
  	result.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2285,7 +2285,7 @@
  	}().Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2304,7 +2304,7 @@
  	}(q).Find(nil)
  
  	// Second branch - violation
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
@@ -2320,8 +2320,8 @@
  		return inner.Where("arg", 1)
  	}(q1).Find(nil)
  
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2359,9 +2359,9 @@
  	}().Find(nil)
  
  	// All second branches - violations
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2380,8 +2380,8 @@
  	}
  	q2 := fn()         // q2 holds first branch from q1
  	q2.Where("y", 2)   // Continues q2's chain (OK)
--	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
-+	q1 = q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+-	q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
++	q1 = q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // storedClosureReordered demonstrates order of calls with stored closure.
@@ -2397,8 +2397,8 @@
  		return q1.Where("from closure", 1) // Pollutes q1 (closure body processed first in SSA)
  	}
  	q2 := fn()
--	q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
-+	q1 = q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
+-	q1.Where("z", 3) // want `\*gorm\.DB reused: second branch from mutable root`
++	q1 = q1.Where("z", 3) // want `\*gorm\.DB reused: second branch from mutable root`
  	q2.Where("y", 2) // OK: q2 is fresh root
  }
  
@@ -2412,8 +2412,8 @@
  		return q1.Where("from iife", 1)
  	}()
  	q2.Where("y", 2)   // Continues q2's chain (OK)
--	q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
-+	q1 = q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+-	q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
++	q1 = q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2433,7 +2433,7 @@
 -	tx := db.Begin().Where("x = ?", 1)
 +	tx := db.Begin().Where("x = ?", 1).Session(&gorm.Session{})
  	tx.Find(nil)
- 	tx.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	tx.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2448,7 +2448,7 @@
 -		q = db.Where("name = ?", item)
 +		q = db.Where("name = ?", item).Session(&gorm.Session{})
  		q.Find(nil)
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -2473,7 +2473,7 @@
  		q = db.Where("y = ?", 2) // Reassigns q in this branch only
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignConditionalBoth demonstrates reassignment in both branches.
@@ -2498,7 +2498,7 @@
 +	base := db.Where("x = ?", 1).Session(&gorm.Session{})
  	base.Find(nil) // Pollutes base
  
- 	q := base.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+ 	q := base.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
  	q.Count(nil)                // OK: q is a fresh root
  }
  
@@ -2513,10 +2513,10 @@
 -		q := db.Where("y = ?", 2) // New variable (shadows)
 +		q := db.Where("y = ?", 2).Session(&gorm.Session{}) // New variable (shadows)
  		q.Find(nil)               // Pollutes inner q
- 		q.Count(nil)              // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil)              // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignInClosure demonstrates reassignment inside closure.
@@ -2529,7 +2529,7 @@
  		q = db.Where("y = ?", 2) // Reassign in closure
  	}()
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignFromHelper demonstrates reassignment from helper function.
@@ -2540,7 +2540,7 @@
 -	q = helperReturnsDB(db) // Reassign from helper
 +	q = helperReturnsDB(db).Session(&gorm.Session{}) // Reassign from helper
  	q.Find(nil)             // Pollutes new q
- 	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  func helperReturnsDB(db *gorm.DB) *gorm.DB {
@@ -2567,7 +2567,7 @@
 -	q = q.Where("z = ?", 3) // Extend the new chain
 +	q = q.Where("z = ?", 3).Session(&gorm.Session{}) // Extend the new chain
  	q.Find(nil)             // Pollutes new q
- 	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignMultipleTimes demonstrates multiple reassignments.
@@ -2600,7 +2600,7 @@
  		// No reassignment in default - q is still polluted
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignInSwitchAll demonstrates reassignment in all switch branches.
@@ -2628,7 +2628,7 @@
  	where := db.Where
  	q = where("y = ?", 2) // Reassign from method value
  	q.Find(nil)           // Pollutes new q
- 	q.Count(nil)          // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)          // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // reassignDeferredUse demonstrates reassignment with deferred use.
@@ -2637,7 +2637,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q.Count(nil) // Pollutes q, defer will use this polluted q
  
@@ -2655,8 +2655,8 @@
  	*p = db.Where("y = ?", 2) // Reassign through pointer
  
  	// [LIMITATION] FALSE POSITIVE: Pointer reassignment creates new root tracking
- 	q.Find(nil)  // want `\*gorm\.DB instance reused after chain method`
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2685,7 +2685,7 @@
  	(*pp).Find(nil) // Pollutes through pointer
  
  	// q1 is detected because traceAllAllocStores finds the store
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	// q2 detection depends on SSA structure - may or may not be detected
  	q2.Count(nil)
  }
@@ -2711,7 +2711,7 @@
 -	db := wrapper.GetDB()
 +	db := wrapper.GetDB().Session(&gorm.Session{})
  	db.Find(nil)
- 	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2728,8 +2728,8 @@
  
  	q.Where("a").Find(nil) // First branch - pollutes q
  
--	q.Where("b") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyChain demonstrates chained Where without finisher.
@@ -2739,7 +2739,7 @@
  
  	q.Find(nil) // First branch - pollutes q
  
- 	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyClosure demonstrates closure pollution then Where-only outside.
@@ -2751,8 +2751,8 @@
  		q.Find(nil) // Pollutes q inside closure
  	}()
  
--	q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyIIFE demonstrates IIFE pollution then Where-only outside.
@@ -2764,8 +2764,8 @@
  		return q.Where("from iife")
  	}().Find(nil) // First branch (IIFE chain)
  
--	q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyLoop demonstrates loop pollution with Where-only.
@@ -2773,8 +2773,8 @@
  	q := db.Where("x = ?", 1)
  
  	for range items {
--		q.Where("in loop") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("in loop") // want `\*gorm\.DB instance reused after chain method`
+-		q.Where("in loop") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("in loop") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -2789,8 +2789,8 @@
  		q.Count(nil) // First branch (mutually exclusive)
  	}
  
--	q.Where("after conditional") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after conditional") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after conditional") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after conditional") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyDefer demonstrates defer with Where-only.
@@ -2798,7 +2798,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  
- 	defer q.Where("deferred") // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Where("deferred") // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q.Find(nil)
  }
@@ -2813,7 +2813,7 @@
 +		q = q.Where("in goroutine")
  	}()
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyStoredClosure demonstrates stored closure with Where-only violation.
@@ -2826,8 +2826,8 @@
  	}
  	fn()
  
--	q.Where("after stored closure") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after stored closure") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after stored closure") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after stored closure") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyStoredClosureReturn demonstrates stored closure returning chain.
@@ -2840,8 +2840,8 @@
  	}
  	_ = fn().Find(nil) // First branch
  
--	q.Where("after") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyIIFEStored demonstrates stored IIFE result with Where-only.
@@ -2855,8 +2855,8 @@
  	}()
  
  	q2.Where("use stored") // Continues q2's chain (OK)
--	q.Where("original")    // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("original")    // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("original")    // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("original")    // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyBoundMethod demonstrates bound method with Where-only.
@@ -2867,8 +2867,8 @@
  	where := q.Where
  	where("bound method call") // First use - pollutes q
  
--	q.Where("after bound") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after bound") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after bound") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after bound") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyNestedIIFE demonstrates nested IIFE with Where-only.
@@ -2882,8 +2882,8 @@
  		}()
  	}().Find(nil) // First branch (entire nested IIFE chain)
  
--	q.Where("after nested") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after nested") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after nested") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after nested") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyIIFEChainContinued demonstrates IIFE chain with Where continuation.
@@ -2895,8 +2895,8 @@
  		return q.Where("iife inner")
  	}().Where("chained after iife").Find(nil) // First branch
  
--	q.Where("second branch") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("second branch") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("second branch") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("second branch") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyDoubleIIFE demonstrates two IIFEs with Where-only.
@@ -2909,7 +2909,7 @@
  	}().Find(nil) // First branch
  
  	_ = func() *gorm.DB {
- 		return q.Where("second iife") // want `\*gorm\.DB instance reused after chain method`
+ 		return q.Where("second iife") // want `\*gorm\.DB reused: second branch from mutable root`
  	}()
  }
  
@@ -2928,8 +2928,8 @@
  	}
  	h.fn()
  
--	q.Where("after struct field closure") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("after struct field closure") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("after struct field closure") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("after struct field closure") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // whereOnlyMultipleBranches demonstrates multiple Where-only branches.
@@ -2939,12 +2939,12 @@
  
  	q.Where("branch1").Find(nil) // First branch
  
--	q.Where("branch2") // want `\*gorm\.DB instance reused after chain method`
--	q.Where("branch3") // want `\*gorm\.DB instance reused after chain method`
--	q.Where("branch4") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("branch2") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("branch3") // want `\*gorm\.DB instance reused after chain method`
-+	q = q.Where("branch4") // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("branch2") // want `\*gorm\.DB reused: second branch from mutable root`
+-	q.Where("branch3") // want `\*gorm\.DB reused: second branch from mutable root`
+-	q.Where("branch4") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("branch2") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("branch3") // want `\*gorm\.DB reused: second branch from mutable root`
++	q = q.Where("branch4") // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -2956,10 +2956,10 @@
  func chainingWithoutReassignmentViolation(db *gorm.DB) {
  	q := db.Where("base")
 -	q.Where("a")     // first branch - OK
--	q.Where("b")     // want `\*gorm\.DB instance reused after chain method`
+-	q.Where("b")     // want `\*gorm\.DB reused: second branch from mutable root`
 +	q = q.Where("a")     // first branch - OK
-+	q = q.Where("b")     // want `\*gorm\.DB instance reused after chain method`
- 	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
++	q = q.Where("b")     // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chainingWithReassignmentSafe demonstrates the solution: reassign each step.
@@ -2993,7 +2993,7 @@
  	}
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // phiSessionInMiddle demonstrates Session in the middle of a chain.
@@ -3008,7 +3008,7 @@
  	}
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // phiThreeBranchesMiddleImmutable demonstrates if/else if/else with middle branch immutable.
@@ -3026,7 +3026,7 @@
  	}
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // phiSwitchMixedSession demonstrates switch with mixed Session.
@@ -3048,7 +3048,7 @@
  	}
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // phiSwitchAllImmutable demonstrates switch where all cases are immutable.
@@ -3086,7 +3086,7 @@
 -		q := db.Where("x")
 +		q := db.Where("x").Session(&gorm.Session{})
  		q.Find(nil)
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	})
  }
  
@@ -3096,8 +3096,8 @@
 -		q := db.Where("base")
 +		q := db.Where("base").Session(&gorm.Session{})
  		q.Find(nil)
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	})
  }
  
@@ -3108,7 +3108,7 @@
 -			q := db.Where("nested")
 +			q := db.Where("nested").Session(&gorm.Session{})
  			q.Find(nil)
- 			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		})
  	})
  }
@@ -3142,7 +3142,7 @@
  	}
  	// h.db may be q1 (polluted) or q2 (clean)
  	// Should detect pollution from q1
- 	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalFieldAssignOnePollutedReverse demonstrates the same pattern
@@ -3164,7 +3164,7 @@
  	}
  	// h.db may be q1 (clean) or q2 (polluted)
  	// Should detect pollution from q2
- 	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
@@ -3183,7 +3183,7 @@
  		h.db = q2 // Branch 2: also polluted
  	}
  	// h.db may be q1 or q2, both are polluted
- 	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // conditionalFieldAssignThenUseInBothBranches demonstrates field assignment
@@ -3197,7 +3197,7 @@
  		h.db = db.Where("b")
  	}
  	h.db.Find(nil) // First use - OK
- 	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -3219,7 +3219,7 @@
  	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
  
  	fn := func() {
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	fn()
  }
@@ -3242,7 +3242,7 @@
  	fn := func() {
  		// FreeVar captures the Phi
  		// Should detect pollution from q1
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	fn()
  }
@@ -3264,7 +3264,7 @@
  	fn := func() {
  		// FreeVar captures the Phi
  		// Should detect pollution from q2
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	fn()
  }
@@ -3285,7 +3285,7 @@
  	}
  	// q is Phi(q_polluted, q_clean)
  	find := q.Find // Bound method
- 	find(nil)      // want `\*gorm\.DB instance reused after chain method`
+ 	find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // [LIMITATION] boundMethodWithPhiOnePollutedReverse tests bound method with reversed branch order.
@@ -3315,7 +3315,7 @@
  		q = db.Where("b")
  	}
  	// q is Phi(q_polluted, q_clean)
- 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // goStatementWithPhiOnePollutedReverse tests go with reversed branch order.
@@ -3328,7 +3328,7 @@
  		q.Find(nil) // pollutes q from this branch
  	}
  	// q is Phi(q_clean, q_polluted)
- 	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deferStatementWithPhiOnePolluted tests defer where one branch of Phi is polluted.
@@ -3341,7 +3341,7 @@
  		q = db.Where("b")
  	}
  	// q is Phi(q_polluted, q_clean)
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // deferStatementWithPhiOnePollutedReverse tests defer with reversed branch order.
@@ -3354,5 +3354,5 @@
  		q.Find(nil) // pollutes q from this branch
  	}
  	// q is Phi(q_clean, q_polluted)
- 	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -18,7 +18,7 @@ func conditionalUsageBothMayExecute(db *gorm.DB, flag1, flag2 bool) {
 	}
 
 	if flag2 {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -42,7 +42,7 @@ func conditionalUsageOneConditionalOneUnconditional(db *gorm.DB, flag bool) {
 		q.Find(nil)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalUsageNestedConditions demonstrates nested conditionals with usage.
@@ -52,7 +52,7 @@ func conditionalUsageNestedConditions(db *gorm.DB, a, b bool) {
 	if a {
 		q.Find(nil)
 		if b {
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		q.First(nil) // OK: mutually exclusive with Find branch
@@ -72,7 +72,7 @@ func loopAssignmentOnly(db *gorm.DB, items []int) {
 	}
 
 	q.Find(nil)   // OK: first actual use (loop only had assignments)
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // loopConditionalAssignment demonstrates loop with conditional assignment.
@@ -88,7 +88,7 @@ func loopConditionalAssignment(db *gorm.DB, flags []bool) {
 	}
 
 	q.Find(nil)   // OK: first use after loop with conditional assignments only
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -107,7 +107,7 @@ func closureReuse(db *gorm.DB) {
 	fn()
 
 	// Detected: q was polluted inside the closure
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closurePollutesOutside demonstrates closure polluting, then using outside.
@@ -118,7 +118,7 @@ func closurePollutesOutside(db *gorm.DB) {
 		q.Find(nil) // Pollutes q inside closure
 	}()
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedClosure demonstrates nested closure detection.
@@ -133,7 +133,7 @@ func nestedClosure(db *gorm.DB) {
 	}
 	outer()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -179,7 +179,7 @@ func conditionalReuse(db *gorm.DB, flag bool) {
 		q.Where("b = ?", 2).Find(nil) // First use in else-branch (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalBothBranches demonstrates that if/else branches are mutually exclusive.
@@ -194,7 +194,7 @@ func conditionalBothBranches(db *gorm.DB, flag bool) {
 	}
 
 	// After either branch, q is polluted - this IS a reuse
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // switchReuse demonstrates that switch cases are mutually exclusive.
@@ -224,7 +224,7 @@ func loopReuse(db *gorm.DB, items []string) {
 
 	for _, item := range items {
 		// Second iteration reuses polluted q
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -234,7 +234,7 @@ func forLoopReuse(db *gorm.DB) {
 
 	for i := 0; i < 3; i++ {
 		// Second iteration reuses polluted q
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -269,7 +269,7 @@ func deferReuse(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	// Defer is processed in second pass, after q.Find pollutes q
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil) // LIMITATION: Not detected (defer executes after, but q.Find is first in code order)
 }
@@ -280,7 +280,7 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
-	defer helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+	defer helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // twoDefersNoDirectUse: two deferred branches from the same root with NO direct
@@ -288,7 +288,7 @@ func deferFunctionCallWithDB(db *gorm.DB) {
 func twoDefersNoDirectUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	defer q.Find(nil)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -320,7 +320,7 @@ func interProceduralPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	helperPollute(q) // Marks q as polluted (function assumed to pollute)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -373,7 +373,7 @@ func pureFactoryFunction() *gorm.DB {
 func pureFactoryUsage() {
 	db := pureFactoryFunction().Session(&gorm.Session{})
 	db.Find(nil)
-	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -391,7 +391,7 @@ func interfaceMethodPollution(db *gorm.DB, repo Repository) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	repo.Query(q) // Interface method assumed to pollute q
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -404,7 +404,7 @@ func channelPollution(db *gorm.DB, ch chan *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	ch <- q // Sending to channel marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -420,7 +420,7 @@ func goroutineClosureReuse(db *gorm.DB) {
 		q.Find(nil) // Pollutes q in goroutine closure
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineDirectMethodCall demonstrates direct method call in goroutine.
@@ -429,7 +429,7 @@ func goroutineDirectMethodCall(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineFunctionCallWithDB demonstrates passing *gorm.DB to function in goroutine.
@@ -438,7 +438,7 @@ func goroutineFunctionCallWithDB(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // First use - pollutes q
 
-	go helperPollute(q) // want `\*gorm\.DB instance reused after chain method`
+	go helperPollute(q) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goroutineCrossFunctionPollution demonstrates cross-function pollution with goroutine.
@@ -454,7 +454,7 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 
 	// Start goroutine that uses the already-polluted q
 	// isPollutedAt should detect pollution from different function (closure)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // twoGoroutinesNoDirectUse: two goroutine branches from the same root with NO
@@ -462,7 +462,7 @@ func goroutineCrossFunctionPollution(db *gorm.DB) {
 func twoGoroutinesNoDirectUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	go q.Find(nil)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -511,7 +511,7 @@ func tripleNestedClosure(db *gorm.DB) {
 	}
 	level1()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadrupleNestedClosure demonstrates 4-level nested closure detection.
@@ -528,7 +528,7 @@ func quadrupleNestedClosure(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedClosureSafe demonstrates 3-level nested closure with Session.
@@ -555,7 +555,7 @@ func parentPollutesNestedClosureUses(db *gorm.DB) {
 
 	func() {
 		func() {
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}()
 	}()
 }
@@ -569,7 +569,7 @@ func parentPollutesTripleNestedUses(db *gorm.DB) {
 	func() {
 		func() {
 			func() {
-				q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}()
 		}()
 	}()
@@ -592,7 +592,7 @@ func higherOrderGoroutine(db *gorm.DB) {
 
 	go makeWorker(q)() // Pollutes q through higher-order function
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // makeWorkerMaker returns a function that returns a function.
@@ -610,7 +610,7 @@ func doubleHigherOrderGoroutine(db *gorm.DB) {
 
 	go makeWorkerMaker(q)()() // Pollutes q through double higher-order
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleHigherOrder demonstrates go fn()()()() pattern.
@@ -629,7 +629,7 @@ func tripleHigherOrder(db *gorm.DB) {
 
 	go maker(q)()()() // Pollutes q through triple higher-order
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -659,7 +659,7 @@ func goroutineInsideDefer(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedDeferGoroutineDefer demonstrates defer->goroutine->defer chain.
@@ -681,8 +681,8 @@ func nestedDeferGoroutineDefer(db *gorm.DB) {
 func multipleDefers(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil) // LIMITATION: Not detected (defers execute after, but q.Find is first in code order)
 }
@@ -713,7 +713,7 @@ func freeVarFrom4To2(db *gorm.DB) {
 	}
 	level1()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // freeVarMixedLevels demonstrates FreeVar with mixed usage levels.
@@ -736,7 +736,7 @@ func freeVarMixedLevels(db *gorm.DB) {
 	}
 	outer()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -751,7 +751,7 @@ func iifeReuse(db *gorm.DB) {
 		q.Find(nil)
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIIFE demonstrates nested IIFE pattern.
@@ -764,7 +764,7 @@ func nestedIIFE(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeWithArgument demonstrates IIFE with argument passing.
@@ -775,7 +775,7 @@ func iifeWithArgument(db *gorm.DB) {
 		d.Find(nil)
 	}(q)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeReturnChain demonstrates IIFE returning chain result.
@@ -789,7 +789,7 @@ func iifeReturnChain(db *gorm.DB) {
 	}().Find(nil) // First branch (IIFE chain counts as single branch)
 
 	// Second branch from q - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -821,7 +821,7 @@ func multiStructField(db *gorm.DB) {
 	h := multiHolder{q1: q, q2: q}
 	h.q1.Find(nil) // First use - pollutes underlying q
 
-	h.q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -834,7 +834,7 @@ func pointerIndirection(db *gorm.DB) {
 	ptr := &q
 	(*ptr).Find(nil) // Pollutes q through pointer
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // doublePointer demonstrates double pointer indirection.
@@ -844,7 +844,7 @@ func doublePointer(db *gorm.DB) {
 	ptr2 := &ptr
 	(**ptr2).Find(nil) // Pollutes q through double pointer
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -872,7 +872,7 @@ func slicePollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	_ = []*gorm.DB{q} // Storing in slice marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // mapPollution demonstrates pollution through map storage.
@@ -881,7 +881,7 @@ func mapPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	_ = map[string]*gorm.DB{"main": q} // Storing in map marks q as polluted
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -898,7 +898,7 @@ func panicRecover(db *gorm.DB) {
 		}
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -917,7 +917,7 @@ func selectStatement(db *gorm.DB, ch chan int) {
 		q.First(nil) // First use in default (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -932,7 +932,7 @@ func methodValue(db *gorm.DB) {
 	find := q.Find
 	find(nil) // Pollutes q through method value
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // methodValueSameBlock demonstrates same-block pollution with method value.
@@ -941,7 +941,7 @@ func methodValueSameBlock(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	find := q.Find
 	find(nil)  // First use - pollutes q
-	find(nil)  // want `\*gorm\.DB instance reused after chain method`
+	find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // methodValueInLoop demonstrates method value in loop.
@@ -951,7 +951,7 @@ func methodValueInLoop(db *gorm.DB, items []string) {
 	find := q.Find
 
 	for range items {
-		find(nil) // want `\*gorm\.DB instance reused after chain method`
+		find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1031,7 +1031,7 @@ func helperWithNamedReturn(db *gorm.DB) (result *gorm.DB) {
 func namedReturn(db *gorm.DB) {
 	q := helperWithNamedReturn(db).Session(&gorm.Session{})
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1050,7 +1050,7 @@ func variadicPollution(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	processQueries(q) // Function call assumed to pollute q
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1070,7 +1070,7 @@ func gotoStatement(db *gorm.DB, flag bool) {
 	q.First(nil)
 
 cleanup:
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1087,7 +1087,7 @@ func switchFallthrough(db *gorm.DB, level int) {
 		q.Find(nil) // First use in case 0
 		fallthrough
 	case 1:
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1104,10 +1104,10 @@ func multipleGoroutines(db *gorm.DB) {
 	}()
 
 	go func() {
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1124,7 +1124,7 @@ func interleavedCalls(db *gorm.DB) {
 		}(d)
 	}(q)
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1144,7 +1144,7 @@ func combinedChaos(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ultimateChaos demonstrates the ultimate evil pattern.
@@ -1167,7 +1167,7 @@ func ultimateChaos(db *gorm.DB) {
 		}()
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1191,7 +1191,7 @@ func nestedIf(db *gorm.DB, a, b, c bool) {
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deepNestedIf demonstrates 4-level nested if.
@@ -1209,7 +1209,7 @@ func deepNestedIf(db *gorm.DB, a, b, c, d bool) {
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ifElseChain demonstrates if-else-if chain with mutually exclusive branches.
@@ -1227,7 +1227,7 @@ func ifElseChain(db *gorm.DB, level int) {
 		q.Take(nil) // First use in else (mutually exclusive)
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1240,7 +1240,7 @@ func ifInsideFor(db *gorm.DB, items []string) {
 
 	for _, item := range items {
 		if item != "" {
-			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1251,9 +1251,9 @@ func ifElseInsideFor(db *gorm.DB, items []int) {
 
 	for _, item := range items {
 		if item > 0 {
-			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("positive = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
-			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("negative = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1265,7 +1265,7 @@ func nestedIfInsideFor(db *gorm.DB, items []int, flag bool) {
 	for _, item := range items {
 		if item > 0 {
 			if flag {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1281,11 +1281,11 @@ func forInsideIf(db *gorm.DB, items []string, flag bool) {
 
 	if flag {
 		for _, item := range items {
-			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // forInsideIfElse demonstrates for inside if-else branches.
@@ -1294,15 +1294,15 @@ func forInsideIfElse(db *gorm.DB, items []string, flag bool) {
 
 	if flag {
 		for _, item := range items {
-			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("a = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		for _, item := range items {
-			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1315,7 +1315,7 @@ func nestedFor(db *gorm.DB, outer, inner []string) {
 
 	for _, o := range outer {
 		for _, i := range inner {
-			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("o = ? AND i = ?", o, i).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1327,7 +1327,7 @@ func tripleNestedFor(db *gorm.DB) {
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			for k := 0; k < 3; k++ {
-				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("i = ? AND j = ? AND k = ?", i, j, k).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1344,10 +1344,10 @@ func forWithBreakContinue(db *gorm.DB, items []int) {
 		if item > 100 {
 			break
 		}
-		q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1359,7 +1359,7 @@ func deferInsideIf(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1371,9 +1371,9 @@ func deferInsideIfElse(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1386,7 +1386,7 @@ func deferInsideNestedIf(db *gorm.DB, a, b bool) {
 
 	if a {
 		if b {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
@@ -1398,8 +1398,8 @@ func multipleDeferInsideIf(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if flag {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (conditional defer)
@@ -1415,7 +1415,7 @@ func deferInsideFor(db *gorm.DB, items []string) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	for range items {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // LIMITATION: Not detected (defer inside loop)
@@ -1432,7 +1432,7 @@ func deferInsideForWithCondition(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferInsideNestedFor demonstrates defer inside nested for.
@@ -1446,7 +1446,7 @@ func deferInsideNestedFor(db *gorm.DB) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1464,7 +1464,7 @@ func forInsideDefer(db *gorm.DB, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedForInsideDefer demonstrates nested for inside defer.
@@ -1480,7 +1480,7 @@ func nestedForInsideDefer(db *gorm.DB) {
 		}
 	}()
 
-	q.Where("setup").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("setup").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1497,7 +1497,7 @@ func ifInsideDefer(db *gorm.DB, flag bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // ifElseInsideDefer demonstrates if-else inside defer closure.
@@ -1512,7 +1512,7 @@ func ifElseInsideDefer(db *gorm.DB, flag bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfInsideDefer demonstrates nested if inside defer.
@@ -1529,7 +1529,7 @@ func nestedIfInsideDefer(db *gorm.DB, a, b bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1542,7 +1542,7 @@ func ifForDefer(db *gorm.DB, flag bool, items []string) {
 
 	if flag {
 		for range items {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
@@ -1560,7 +1560,7 @@ func forIfDefer(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferIfFor demonstrates defer closure containing if containing for.
@@ -1576,7 +1576,7 @@ func deferIfFor(db *gorm.DB, flag bool, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferForIf demonstrates defer closure containing for containing if.
@@ -1592,7 +1592,7 @@ func deferForIf(db *gorm.DB, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingIfForDefer demonstrates 3-level nesting: if -> for -> defer.
@@ -1610,7 +1610,7 @@ func tripleNestingIfForDefer(db *gorm.DB, flag bool, items []string) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingForIfDefer demonstrates 3-level nesting: for -> if -> defer.
@@ -1626,7 +1626,7 @@ func tripleNestingForIfDefer(db *gorm.DB, items []int) {
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingDeferIfFor demonstrates 3-level nesting: defer -> if -> for.
@@ -1642,7 +1642,7 @@ func tripleNestingDeferIfFor(db *gorm.DB, flag bool, items []string) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestingDeferForIf demonstrates 3-level nesting: defer -> for -> if.
@@ -1658,7 +1658,7 @@ func tripleNestingDeferForIf(db *gorm.DB, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1672,7 +1672,7 @@ func quadNestingIfForIfDefer(db *gorm.DB, a bool, items []int) {
 	if a {
 		for _, item := range items {
 			if item > 0 {
-				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
@@ -1687,12 +1687,12 @@ func quadNestingForIfForDefer(db *gorm.DB, outer []bool, inner []int) {
 	for _, flag := range outer {
 		if flag {
 			for range inner {
-				defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+				defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadNestingDeferIfForIf demonstrates 4-level: defer -> if -> for -> if.
@@ -1710,7 +1710,7 @@ func quadNestingDeferIfForIf(db *gorm.DB, a bool, items []int) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // quadNestingDeferForIfFor demonstrates 4-level: defer -> for -> if -> for.
@@ -1728,7 +1728,7 @@ func quadNestingDeferForIfFor(db *gorm.DB, outer []bool) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1740,11 +1740,11 @@ func multipleDefersInDifferentBranches(db *gorm.DB, level int) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
 	if level == 0 {
-		defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else if level == 1 {
-		defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		defer q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		defer q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Find(nil) // First use - defers execute AFTER this at function exit
@@ -1756,13 +1756,13 @@ func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
 
 	for _, item := range items {
 		if item > 0 {
-			defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
-			defer q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+			defer q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1774,7 +1774,7 @@ func multipleDefersInLoopBranches(db *gorm.DB, items []int) {
 func earlyReturnWithDefer(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if flag {
 		q.Find(nil) // Pollutes q
@@ -1789,14 +1789,14 @@ func earlyReturnWithDefer(db *gorm.DB, flag bool) {
 func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	for _, item := range items {
 		if item < 0 {
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			return
 		}
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1808,16 +1808,16 @@ func earlyReturnInLoopWithDefer(db *gorm.DB, items []int) {
 func labeledBreakWithDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 outer:
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			if i == 1 && j == 1 {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				break outer
 			}
-			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1826,16 +1826,16 @@ outer:
 func labeledContinueWithDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 outer:
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			if j == 1 {
-				q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				continue outer
 			}
-			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("i = ? AND j = ?", i, j).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -1861,7 +1861,7 @@ func foreverLoopWithBreak(db *gorm.DB, ch chan bool) {
 		break // Prevent actual infinite loop in test
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1896,7 +1896,7 @@ func deferCapturingLoopVar(db *gorm.DB, items []string) {
 		}()
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1913,7 +1913,7 @@ func nestedDeferClosures(db *gorm.DB) {
 		}()
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedDeferClosures demonstrates 3-level nested defer closures.
@@ -1928,7 +1928,7 @@ func tripleNestedDeferClosures(db *gorm.DB) {
 		}()
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedDeferWithFor demonstrates nested defer with for.
@@ -1943,7 +1943,7 @@ func nestedDeferWithFor(db *gorm.DB) {
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -1954,10 +1954,10 @@ func nestedDeferWithFor(db *gorm.DB) {
 func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	for item := range ch {
-		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item = ?", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1970,7 +1970,7 @@ func rangeOverChannelWithDefer(db *gorm.DB, ch chan int) {
 func typeSwitchWithDefer(db *gorm.DB, v interface{}) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	switch v.(type) {
 	case int:
@@ -1989,9 +1989,9 @@ func typeSwitchInsideFor(db *gorm.DB, items []interface{}) {
 	for _, item := range items {
 		switch item.(type) {
 		case int:
-			q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		case string:
-			q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 }
@@ -2020,7 +2020,7 @@ func ultimateIfForDeferChaos(db *gorm.DB, a, b bool, outer []int, inner []string
 		}
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2041,7 +2041,7 @@ func tripleNestedIIFE(db *gorm.DB) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // tripleNestedIIFEWithBranch demonstrates IIFE with conditional branches.
@@ -2057,7 +2057,7 @@ func tripleNestedIIFEWithBranch(db *gorm.DB, cond bool) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2081,7 +2081,7 @@ func iifeMultipleReturns(db *gorm.DB, flag int) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2123,7 +2123,7 @@ func structFieldIIFE(db *gorm.DB) {
 	h.query.Find(nil) // [LIMITATION] Does not trace through struct field
 
 	// Second use of q - violation (q was polluted by IIFE's internal call)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2140,7 +2140,7 @@ func chainedIIFE(db *gorm.DB) {
 	}().Where("second", 2).Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2157,7 +2157,7 @@ func iifeCaptureAndModify(db *gorm.DB) {
 	}()
 
 	result.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2179,7 +2179,7 @@ func iifeWithPhiNode(db *gorm.DB, cond bool) {
 	}().Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2197,7 +2197,7 @@ func iifeArgumentReturnsChain(db *gorm.DB) {
 	}(q).Find(nil)
 
 	// Second branch - violation
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
@@ -2211,8 +2211,8 @@ func iifeArgumentAndFreeVarMixed(db *gorm.DB) {
 		return inner.Where("arg", 1)
 	}(q1).Find(nil)
 
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2247,9 +2247,9 @@ func deepNestedMixedCapture(db *gorm.DB) {
 	}().Find(nil)
 
 	// All second branches - violations
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2267,7 +2267,7 @@ func storedClosureChain(db *gorm.DB) {
 	}
 	q2 := fn()         // q2 holds first branch from q1
 	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1 = q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q1 = q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // storedClosureReordered demonstrates order of calls with stored closure.
@@ -2282,7 +2282,7 @@ func storedClosureReordered(db *gorm.DB) {
 		return q1.Where("from closure", 1) // Pollutes q1 (closure body processed first in SSA)
 	}
 	q2 := fn()
-	q1 = q1.Where("z", 3) // want `\*gorm\.DB instance reused after chain method`
+	q1 = q1.Where("z", 3) // want `\*gorm\.DB reused: second branch from mutable root`
 	q2.Where("y", 2) // OK: q2 is fresh root
 }
 
@@ -2295,7 +2295,7 @@ func iifeStoredResult(db *gorm.DB) {
 		return q1.Where("from iife", 1)
 	}()
 	q2.Where("y", 2)   // Continues q2's chain (OK)
-	q1 = q1.Where("z", 3)   // want `\*gorm\.DB instance reused after chain method`
+	q1 = q1.Where("z", 3)   // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2314,7 +2314,7 @@ func beginReturnsImmutable(db *gorm.DB) {
 func beginChainedBecomesMutable(db *gorm.DB) {
 	tx := db.Begin().Where("x = ?", 1).Session(&gorm.Session{})
 	tx.Find(nil)
-	tx.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	tx.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2328,7 +2328,7 @@ func reassignInLoop(db *gorm.DB, items []string) {
 	for _, item := range items {
 		q = db.Where("name = ?", item).Session(&gorm.Session{})
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -2353,7 +2353,7 @@ func reassignConditionalPartial(db *gorm.DB, flag bool) {
 		q = db.Where("y = ?", 2) // Reassigns q in this branch only
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignConditionalBoth demonstrates reassignment in both branches.
@@ -2377,7 +2377,7 @@ func reassignAfterPollutionSameValue(db *gorm.DB) {
 	base := db.Where("x = ?", 1).Session(&gorm.Session{})
 	base.Find(nil) // Pollutes base
 
-	q := base.Where("y = ?", 2) // want `\*gorm\.DB instance reused after chain method`
+	q := base.Where("y = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 	q.Count(nil)                // OK: q is a fresh root
 }
 
@@ -2390,10 +2390,10 @@ func reassignShadowing(db *gorm.DB) {
 	{
 		q := db.Where("y = ?", 2).Session(&gorm.Session{}) // New variable (shadows)
 		q.Find(nil)               // Pollutes inner q
-		q.Count(nil)              // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil)              // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignInClosure demonstrates reassignment inside closure.
@@ -2405,7 +2405,7 @@ func reassignInClosure(db *gorm.DB) {
 		q = db.Where("y = ?", 2) // Reassign in closure
 	}()
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignFromHelper demonstrates reassignment from helper function.
@@ -2415,7 +2415,7 @@ func reassignFromHelper(db *gorm.DB) {
 
 	q = helperReturnsDB(db).Session(&gorm.Session{}) // Reassign from helper
 	q.Find(nil)             // Pollutes new q
-	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func helperReturnsDB(db *gorm.DB) *gorm.DB {
@@ -2441,7 +2441,7 @@ func reassignChainExtension(db *gorm.DB) {
 	q = db.Where("y = ?", 2)
 	q = q.Where("z = ?", 3).Session(&gorm.Session{}) // Extend the new chain
 	q.Find(nil)             // Pollutes new q
-	q.Count(nil)            // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)            // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignMultipleTimes demonstrates multiple reassignments.
@@ -2474,7 +2474,7 @@ func reassignInSwitch(db *gorm.DB, mode int) {
 		// No reassignment in default - q is still polluted
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignInSwitchAll demonstrates reassignment in all switch branches.
@@ -2502,7 +2502,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 	where := db.Where
 	q = where("y = ?", 2) // Reassign from method value
 	q.Find(nil)           // Pollutes new q
-	q.Count(nil)          // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)          // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // reassignDeferredUse demonstrates reassignment with deferred use.
@@ -2510,7 +2510,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 func reassignDeferredUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Count(nil) // Pollutes q, defer will use this polluted q
 
@@ -2528,8 +2528,8 @@ func reassignPointerDeref(db *gorm.DB) {
 	*p = db.Where("y = ?", 2) // Reassign through pointer
 
 	// [LIMITATION] FALSE POSITIVE: Pointer reassignment creates new root tracking
-	q.Find(nil)  // want `\*gorm\.DB instance reused after chain method`
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2557,7 +2557,7 @@ func pointerPhiCase(db *gorm.DB, flag bool) {
 	(*pp).Find(nil) // Pollutes through pointer
 
 	// q1 is detected because traceAllAllocStores finds the store
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	// q2 detection depends on SSA structure - may or may not be detected
 	q2.Count(nil)
 }
@@ -2582,7 +2582,7 @@ func pureMethodUsage() {
 	wrapper := &OrmWrapper{}
 	db := wrapper.GetDB().Session(&gorm.Session{})
 	db.Find(nil)
-	db.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	db.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2598,7 +2598,7 @@ func whereOnlyBasic(db *gorm.DB) {
 
 	q.Where("a").Find(nil) // First branch - pollutes q
 
-	q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyChain demonstrates chained Where without finisher.
@@ -2607,7 +2607,7 @@ func whereOnlyChain(db *gorm.DB) {
 
 	q.Find(nil) // First branch - pollutes q
 
-	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB instance reused after chain method`
+	q.Where("a").Where("b").Order("c") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyClosure demonstrates closure pollution then Where-only outside.
@@ -2618,7 +2618,7 @@ func whereOnlyClosure(db *gorm.DB) {
 		q.Find(nil) // Pollutes q inside closure
 	}()
 
-	q = q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFE demonstrates IIFE pollution then Where-only outside.
@@ -2629,7 +2629,7 @@ func whereOnlyIIFE(db *gorm.DB) {
 		return q.Where("from iife")
 	}().Find(nil) // First branch (IIFE chain)
 
-	q = q.Where("outside") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("outside") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyLoop demonstrates loop pollution with Where-only.
@@ -2637,7 +2637,7 @@ func whereOnlyLoop(db *gorm.DB, items []int) {
 	q := db.Where("x = ?", 1)
 
 	for range items {
-		q = q.Where("in loop") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("in loop") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -2651,14 +2651,14 @@ func whereOnlyConditional(db *gorm.DB, flag bool) {
 		q.Count(nil) // First branch (mutually exclusive)
 	}
 
-	q = q.Where("after conditional") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after conditional") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyDefer demonstrates defer with Where-only.
 func whereOnlyDefer(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
-	defer q.Where("deferred") // want `\*gorm\.DB instance reused after chain method`
+	defer q.Where("deferred") // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q.Find(nil)
 }
@@ -2672,7 +2672,7 @@ func whereOnlyGoroutine(db *gorm.DB) {
 		q = q.Where("in goroutine")
 	}()
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyStoredClosure demonstrates stored closure with Where-only violation.
@@ -2684,7 +2684,7 @@ func whereOnlyStoredClosure(db *gorm.DB) {
 	}
 	fn()
 
-	q = q.Where("after stored closure") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after stored closure") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyStoredClosureReturn demonstrates stored closure returning chain.
@@ -2696,7 +2696,7 @@ func whereOnlyStoredClosureReturn(db *gorm.DB) {
 	}
 	_ = fn().Find(nil) // First branch
 
-	q = q.Where("after") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFEStored demonstrates stored IIFE result with Where-only.
@@ -2709,7 +2709,7 @@ func whereOnlyIIFEStored(db *gorm.DB) {
 	}()
 
 	q2.Where("use stored") // Continues q2's chain (OK)
-	q = q.Where("original")    // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("original")    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyBoundMethod demonstrates bound method with Where-only.
@@ -2719,7 +2719,7 @@ func whereOnlyBoundMethod(db *gorm.DB) {
 	where := q.Where
 	where("bound method call") // First use - pollutes q
 
-	q = q.Where("after bound") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after bound") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyNestedIIFE demonstrates nested IIFE with Where-only.
@@ -2732,7 +2732,7 @@ func whereOnlyNestedIIFE(db *gorm.DB) {
 		}()
 	}().Find(nil) // First branch (entire nested IIFE chain)
 
-	q = q.Where("after nested") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after nested") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyIIFEChainContinued demonstrates IIFE chain with Where continuation.
@@ -2743,7 +2743,7 @@ func whereOnlyIIFEChainContinued(db *gorm.DB) {
 		return q.Where("iife inner")
 	}().Where("chained after iife").Find(nil) // First branch
 
-	q = q.Where("second branch") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("second branch") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyDoubleIIFE demonstrates two IIFEs with Where-only.
@@ -2755,7 +2755,7 @@ func whereOnlyDoubleIIFE(db *gorm.DB) {
 	}().Find(nil) // First branch
 
 	_ = func() *gorm.DB {
-		return q.Where("second iife") // want `\*gorm\.DB instance reused after chain method`
+		return q.Where("second iife") // want `\*gorm\.DB reused: second branch from mutable root`
 	}()
 }
 
@@ -2773,7 +2773,7 @@ func whereOnlyStructFieldClosure(db *gorm.DB) {
 	}
 	h.fn()
 
-	q = q.Where("after struct field closure") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("after struct field closure") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // whereOnlyMultipleBranches demonstrates multiple Where-only branches.
@@ -2782,9 +2782,9 @@ func whereOnlyMultipleBranches(db *gorm.DB) {
 
 	q.Where("branch1").Find(nil) // First branch
 
-	q = q.Where("branch2") // want `\*gorm\.DB instance reused after chain method`
-	q = q.Where("branch3") // want `\*gorm\.DB instance reused after chain method`
-	q = q.Where("branch4") // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("branch2") // want `\*gorm\.DB reused: second branch from mutable root`
+	q = q.Where("branch3") // want `\*gorm\.DB reused: second branch from mutable root`
+	q = q.Where("branch4") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -2796,8 +2796,8 @@ func whereOnlyMultipleBranches(db *gorm.DB) {
 func chainingWithoutReassignmentViolation(db *gorm.DB) {
 	q := db.Where("base")
 	q = q.Where("a")     // first branch - OK
-	q = q.Where("b")     // want `\*gorm\.DB instance reused after chain method`
-	q.Find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	q = q.Where("b")     // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chainingWithReassignmentSafe demonstrates the solution: reassign each step.
@@ -2830,7 +2830,7 @@ func phiOneHasSession(db *gorm.DB, cond bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSessionInMiddle demonstrates Session in the middle of a chain.
@@ -2844,7 +2844,7 @@ func phiSessionInMiddle(db *gorm.DB, cond bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiThreeBranchesMiddleImmutable demonstrates if/else if/else with middle branch immutable.
@@ -2860,7 +2860,7 @@ func phiThreeBranchesMiddleImmutable(db *gorm.DB, mode int) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSwitchMixedSession demonstrates switch with mixed Session.
@@ -2879,7 +2879,7 @@ func phiSwitchMixedSession(db *gorm.DB, mode int) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // phiSwitchAllImmutable demonstrates switch where all cases are immutable.
@@ -2916,7 +2916,7 @@ func callbackViolationInWrapper(db *gorm.DB) {
 	wrapperFunc(func() {
 		q := db.Where("x").Session(&gorm.Session{})
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -2925,8 +2925,8 @@ func callbackMultipleViolationsInWrapper(db *gorm.DB) {
 	wrapperFunc(func() {
 		q := db.Where("base").Session(&gorm.Session{})
 		q.Find(nil)
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-		q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -2936,7 +2936,7 @@ func callbackNestedWrappers(db *gorm.DB) {
 		wrapperFunc(func() {
 			q := db.Where("nested").Session(&gorm.Session{})
 			q.Find(nil)
-			q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		})
 	})
 }
@@ -2969,7 +2969,7 @@ func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 	}
 	// h.db may be q1 (polluted) or q2 (clean)
 	// Should detect pollution from q1
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignOnePollutedReverse demonstrates the same pattern
@@ -2990,7 +2990,7 @@ func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 	}
 	// h.db may be q1 (clean) or q2 (polluted)
 	// Should detect pollution from q2
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
@@ -3008,7 +3008,7 @@ func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
 		h.db = q2 // Branch 2: also polluted
 	}
 	// h.db may be q1 or q2, both are polluted
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // conditionalFieldAssignThenUseInBothBranches demonstrates field assignment
@@ -3021,7 +3021,7 @@ func conditionalFieldAssignThenUseInBothBranches(db *gorm.DB, cond bool) {
 		h.db = db.Where("b")
 	}
 	h.db.Find(nil) // First use - OK
-	h.db.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	h.db.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -3043,7 +3043,7 @@ func closureCapturesPhi(db *gorm.DB, cond bool) {
 	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
 
 	fn := func() {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3066,7 +3066,7 @@ func closureCaputresPhiOnePolluted(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q1
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3088,7 +3088,7 @@ func closureCaputresPhiOnePollutedReverse(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q2
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	fn()
 }
@@ -3109,7 +3109,7 @@ func boundMethodWithPhiOnePolluted(db *gorm.DB, flag bool) {
 	}
 	// q is Phi(q_polluted, q_clean)
 	find := q.Find // Bound method
-	find(nil)      // want `\*gorm\.DB instance reused after chain method`
+	find(nil)      // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // [LIMITATION] boundMethodWithPhiOnePollutedReverse tests bound method with reversed branch order.
@@ -3139,7 +3139,7 @@ func goStatementWithPhiOnePolluted(db *gorm.DB, flag bool) {
 		q = db.Where("b")
 	}
 	// q is Phi(q_polluted, q_clean)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // goStatementWithPhiOnePollutedReverse tests go with reversed branch order.
@@ -3152,7 +3152,7 @@ func goStatementWithPhiOnePollutedReverse(db *gorm.DB, flag bool) {
 		q.Find(nil) // pollutes q from this branch
 	}
 	// q is Phi(q_clean, q_polluted)
-	go q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	go q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferStatementWithPhiOnePolluted tests defer where one branch of Phi is polluted.
@@ -3165,7 +3165,7 @@ func deferStatementWithPhiOnePolluted(db *gorm.DB, flag bool) {
 		q = db.Where("b")
 	}
 	// q is Phi(q_polluted, q_clean)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // deferStatementWithPhiOnePollutedReverse tests defer with reversed branch order.
@@ -3178,5 +3178,5 @@ func deferStatementWithPhiOnePollutedReverse(db *gorm.DB, flag bool) {
 		q.Find(nil) // pollutes q from this branch
 	}
 	// q is Phi(q_clean, q_polluted)
-	defer q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	defer q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/interface_patterns.go
+++ b/testdata/src/gormreuse/interface_patterns.go
@@ -68,7 +68,7 @@ func variadicInterfaceArgs(db *gorm.DB) {
 	// Passing to non-pure function - marks q as polluted
 	acceptVariadic(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // variadicInterfaceArgsMultiple: Multiple args to variadic
@@ -79,8 +79,8 @@ func variadicInterfaceArgsMultiple(db *gorm.DB) {
 	// Both passed to non-pure function - both polluted
 	acceptVariadic(q1, q2)
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
-	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
@@ -91,7 +91,7 @@ func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 	// Only q1 is passed to function
 	acceptVariadic(q1)
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 	q2.Find(nil) // q2 is fresh - should NOT report
 }
 
@@ -109,7 +109,7 @@ func interfaceRoundtripReuse(db *gorm.DB) {
 	var i interface{} = q
 	q2 := i.(*gorm.DB)
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
@@ -118,7 +118,7 @@ func interfaceRoundtripCommaOk(db *gorm.DB) {
 	var i interface{} = q
 	if q2, ok := i.(*gorm.DB); ok {
 		q2.Find(nil)
-		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -143,7 +143,7 @@ func gormOrMethodReceiver(db *gorm.DB) {
 	// Or takes interface{} - base is polluted by method call
 	base.Or("x = ?", 1)
 
-	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodArg: GORM's Or method - argument pollution
@@ -155,7 +155,7 @@ func gormOrMethodArg(db *gorm.DB) {
 	// q is passed to Or as interface{} - pollutes q
 	base.Or(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodChain: Chain passed to Or
@@ -167,7 +167,7 @@ func gormOrMethodChain(db *gorm.DB) {
 	// q is polluted by .Where("y") chain call
 	base.Or(q.Where("y"))
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodFresh: Fresh query passed to Or (no reuse)
@@ -177,7 +177,7 @@ func gormOrMethodFresh(db *gorm.DB) {
 	// Fresh query passed to Or - no reuse issue for the fresh query
 	base.Or(db.Where("x"))
 
-	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -192,7 +192,7 @@ func interfaceSliceLiteral(db *gorm.DB) {
 	// Slice literal - storage pollutes
 	_ = []interface{}{q}
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // interfaceSliceMultiple: Multiple *gorm.DB in slice
@@ -202,8 +202,8 @@ func interfaceSliceMultiple(db *gorm.DB) {
 
 	_ = []interface{}{q1, q2}
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
-	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -216,7 +216,7 @@ func interfaceMapLiteral(db *gorm.DB) {
 
 	_ = map[string]interface{}{"query": q}
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -251,7 +251,7 @@ func closureAcceptsInterface(db *gorm.DB) {
 	// Passing to non-pure closure - pollutes q
 	process(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -318,7 +318,7 @@ func channelSendInterface(db *gorm.DB) {
 	ch := make(chan interface{}, 1)
 	ch <- q // Channel send pollutes
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -375,5 +375,5 @@ func gormUseThenInterfaceConversionThenGormUse(db *gorm.DB) {
 
 	q.Find(nil)        // First use - pollutes q
 	_ = interface{}(q) // Just conversion
-	q.Count(nil)       // want "\\*gorm\\.DB instance reused"
+	q.Count(nil)       // want "\\*gorm\\.DB reused: second branch from mutable root"
 }

--- a/testdata/src/gormreuse/interface_patterns.go.diff
+++ b/testdata/src/gormreuse/interface_patterns.go.diff
@@ -72,7 +72,7 @@
  	// Passing to non-pure function - marks q as polluted
  	acceptVariadic(q)
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // variadicInterfaceArgsMultiple: Multiple args to variadic
@@ -85,8 +85,8 @@
  	// Both passed to non-pure function - both polluted
  	acceptVariadic(q1, q2)
  
- 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
- 	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+ 	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
@@ -98,7 +98,7 @@
  	// Only q1 is passed to function
  	acceptVariadic(q1)
  
- 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  	q2.Find(nil) // q2 is fresh - should NOT report
  }
  
@@ -117,7 +117,7 @@
  	var i interface{} = q
  	q2 := i.(*gorm.DB)
  	q2.Find(nil)
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
@@ -127,7 +127,7 @@
  	var i interface{} = q
  	if q2, ok := i.(*gorm.DB); ok {
  		q2.Find(nil)
- 		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -153,7 +153,7 @@
 -	base.Or("x = ?", 1)
 +	base = base.Or("x = ?", 1)
  
- 	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // gormOrMethodArg: GORM's Or method - argument pollution
@@ -166,7 +166,7 @@
 -	base.Or(q)
 +	base = base.Or(q)
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // gormOrMethodChain: Chain passed to Or
@@ -179,7 +179,7 @@
 -	base.Or(q.Where("y"))
 +	base = base.Or(q.Where("y"))
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // gormOrMethodFresh: Fresh query passed to Or (no reuse)
@@ -190,7 +190,7 @@
 -	base.Or(db.Where("x"))
 +	base = base.Or(db.Where("x"))
  
- 	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================
@@ -206,7 +206,7 @@
  	// Slice literal - storage pollutes
  	_ = []interface{}{q}
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // interfaceSliceMultiple: Multiple *gorm.DB in slice
@@ -218,8 +218,8 @@
  
  	_ = []interface{}{q1, q2}
  
- 	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
- 	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+ 	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================
@@ -233,7 +233,7 @@
  
  	_ = map[string]interface{}{"query": q}
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================
@@ -269,7 +269,7 @@
  	// Passing to non-pure closure - pollutes q
  	process(q)
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================
@@ -337,7 +337,7 @@
  	ch := make(chan interface{}, 1)
  	ch <- q // Channel send pollutes
  
- 	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+ 	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
  }
  
  // =============================================================================
@@ -395,5 +395,5 @@
  
  	q.Find(nil)        // First use - pollutes q
  	_ = interface{}(q) // Just conversion
- 	q.Count(nil)       // want "\\*gorm\\.DB instance reused"
+ 	q.Count(nil)       // want "\\*gorm\\.DB reused: second branch from mutable root"
  }

--- a/testdata/src/gormreuse/interface_patterns.go.golden
+++ b/testdata/src/gormreuse/interface_patterns.go.golden
@@ -68,7 +68,7 @@ func variadicInterfaceArgs(db *gorm.DB) {
 	// Passing to non-pure function - marks q as polluted
 	acceptVariadic(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // variadicInterfaceArgsMultiple: Multiple args to variadic
@@ -79,8 +79,8 @@ func variadicInterfaceArgsMultiple(db *gorm.DB) {
 	// Both passed to non-pure function - both polluted
 	acceptVariadic(q1, q2)
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
-	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
@@ -91,7 +91,7 @@ func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 	// Only q1 is passed to function
 	acceptVariadic(q1)
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 	q2.Find(nil) // q2 is fresh - should NOT report
 }
 
@@ -109,7 +109,7 @@ func interfaceRoundtripReuse(db *gorm.DB) {
 	var i interface{} = q
 	q2 := i.(*gorm.DB)
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // interfaceRoundtripCommaOk: comma-ok extraction form also keeps tracking.
@@ -118,7 +118,7 @@ func interfaceRoundtripCommaOk(db *gorm.DB) {
 	var i interface{} = q
 	if q2, ok := i.(*gorm.DB); ok {
 		q2.Find(nil)
-		q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -143,7 +143,7 @@ func gormOrMethodReceiver(db *gorm.DB) {
 	// Or takes interface{} - base is polluted by method call
 	base = base.Or("x = ?", 1)
 
-	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodArg: GORM's Or method - argument pollution
@@ -155,7 +155,7 @@ func gormOrMethodArg(db *gorm.DB) {
 	// q is passed to Or as interface{} - pollutes q
 	base = base.Or(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodChain: Chain passed to Or
@@ -167,7 +167,7 @@ func gormOrMethodChain(db *gorm.DB) {
 	// q is polluted by .Where("y") chain call
 	base = base.Or(q.Where("y"))
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // gormOrMethodFresh: Fresh query passed to Or (no reuse)
@@ -177,7 +177,7 @@ func gormOrMethodFresh(db *gorm.DB) {
 	// Fresh query passed to Or - no reuse issue for the fresh query
 	base = base.Or(db.Where("x"))
 
-	base.Find(nil) // want "\\*gorm\\.DB instance reused"
+	base.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -192,7 +192,7 @@ func interfaceSliceLiteral(db *gorm.DB) {
 	// Slice literal - storage pollutes
 	_ = []interface{}{q}
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // interfaceSliceMultiple: Multiple *gorm.DB in slice
@@ -202,8 +202,8 @@ func interfaceSliceMultiple(db *gorm.DB) {
 
 	_ = []interface{}{q1, q2}
 
-	q1.Find(nil) // want "\\*gorm\\.DB instance reused"
-	q2.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q1.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
+	q2.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -216,7 +216,7 @@ func interfaceMapLiteral(db *gorm.DB) {
 
 	_ = map[string]interface{}{"query": q}
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -251,7 +251,7 @@ func closureAcceptsInterface(db *gorm.DB) {
 	// Passing to non-pure closure - pollutes q
 	process(q)
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -318,7 +318,7 @@ func channelSendInterface(db *gorm.DB) {
 	ch := make(chan interface{}, 1)
 	ch <- q // Channel send pollutes
 
-	q.Find(nil) // want "\\*gorm\\.DB instance reused"
+	q.Find(nil) // want "\\*gorm\\.DB reused: second branch from mutable root"
 }
 
 // =============================================================================
@@ -375,5 +375,5 @@ func gormUseThenInterfaceConversionThenGormUse(db *gorm.DB) {
 
 	q.Find(nil)        // First use - pollutes q
 	_ = interface{}(q) // Just conversion
-	q.Count(nil)       // want "\\*gorm\\.DB instance reused"
+	q.Count(nil)       // want "\\*gorm\\.DB reused: second branch from mutable root"
 }

--- a/testdata/src/gormreuse/name_collision.go
+++ b/testdata/src/gormreuse/name_collision.go
@@ -21,7 +21,7 @@ func Open(db *gorm.DB) *gorm.DB { return db.Where("x = ?", 1) }
 func collisionFreeFuncOpen(db *gorm.DB) {
 	q := Open(db)
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // Debug is a user-defined package-level function sharing a name with the gorm
@@ -31,7 +31,7 @@ func Debug(db *gorm.DB) { db.Find(&[]User{}) }
 func collisionFreeFuncDebug(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	Debug(q)
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // collisionRepo has methods whose names collide with gorm builtins.
@@ -47,13 +47,13 @@ func (r *collisionRepo) Begin() *gorm.DB { return r.db.Where("open = ?", true) }
 func collisionMethodSession(r *collisionRepo) {
 	q := r.Session()
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func collisionMethodBegin(r *collisionRepo) {
 	q := r.Begin()
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/name_collision.go.diff
+++ b/testdata/src/gormreuse/name_collision.go.diff
@@ -25,7 +25,7 @@
 -	q := Open(db)
 +	q := Open(db).Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // Debug is a user-defined package-level function sharing a name with the gorm
@@ -36,7 +36,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	Debug(q)
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // collisionRepo has methods whose names collide with gorm builtins.
@@ -53,14 +53,14 @@
 -	q := r.Session()
 +	q := r.Session().Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  func collisionMethodBegin(r *collisionRepo) {
 -	q := r.Begin()
 +	q := r.Begin().Session(&gorm.Session{})
  	q.Find(&[]User{})
- 	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/name_collision.go.golden
+++ b/testdata/src/gormreuse/name_collision.go.golden
@@ -21,7 +21,7 @@ func Open(db *gorm.DB) *gorm.DB { return db.Where("x = ?", 1) }
 func collisionFreeFuncOpen(db *gorm.DB) {
 	q := Open(db).Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // Debug is a user-defined package-level function sharing a name with the gorm
@@ -31,7 +31,7 @@ func Debug(db *gorm.DB) { db.Find(&[]User{}) }
 func collisionFreeFuncDebug(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	Debug(q)
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // collisionRepo has methods whose names collide with gorm builtins.
@@ -47,13 +47,13 @@ func (r *collisionRepo) Begin() *gorm.DB { return r.db.Where("open = ?", true) }
 func collisionMethodSession(r *collisionRepo) {
 	q := r.Session().Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func collisionMethodBegin(r *collisionRepo) {
 	q := r.Begin().Session(&gorm.Session{})
 	q.Find(&[]User{})
-	q.Count(new(int64)) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/nested_chaos.go
+++ b/testdata/src/gormreuse/nested_chaos.go
@@ -64,7 +64,7 @@ func nestedIfDoubleUse(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a")
 	}
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfDoubleUseDeeper demonstrates 3-level nested if with two Find() calls.
@@ -84,7 +84,7 @@ func nestedIfDoubleUseDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a")
 	}
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -144,7 +144,7 @@ func nestedIfImmediateChainDouble(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a")
 	}
 	q.Where("extra1").Find(nil)
-	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfImmediateChainDoubleDeeper demonstrates 3-level nesting with two chains.
@@ -164,7 +164,7 @@ func nestedIfImmediateChainDoubleDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a")
 	}
 	q.Where("extra1").Find(nil)
-	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -185,7 +185,7 @@ func nestedIfFindThenWhere(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a")
 	}
 	q.Find(nil)                    // Pollutes q
-	q.Where("extra").Find(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra").Find(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfFindThenWhereDeeper demonstrates 3-level nesting with Find then Where.
@@ -205,7 +205,7 @@ func nestedIfFindThenWhereDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a")
 	}
 	q.Find(nil)                // Pollutes q
-	q.Where("extra").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -267,9 +267,9 @@ func nestedIfMixedChainLevel1(db *gorm.DB, a, b bool) {
 		q.Where("immediate_a").Find(nil) // Immediate chain - pollutes q
 	}
 	if b {
-		q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfMixedChainLevel2 demonstrates mixed chains at inner level.
@@ -281,12 +281,12 @@ func nestedIfMixedChainLevel2(db *gorm.DB, a, b, c bool) {
 		} else {
 			q = q.Where("stored_not_b") // Stored
 		}
-		q = q.Where("stored_a") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_a") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	if c {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -322,7 +322,7 @@ func nestedIfMultiplePhiLevels(db *gorm.DB, a, b, c bool) {
 	// q_3 = Phi(q_2_c, q_2_not_c)
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfMultiplePhiSingleUse demonstrates multiple Phi but single final use.
@@ -375,7 +375,7 @@ func nestedIfAsymmetricDepth(db *gorm.DB, a, b, c bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfAsymmetricWithEarlyReturn demonstrates asymmetric with early return.
@@ -409,7 +409,7 @@ func nestedIfChaosKitchenSink(db *gorm.DB, a, b, c, d bool) {
 		q.Where("immediate_a").Find(nil) // Pollutes q
 		if b {
 			// Level 2: Early return after stored chain
-			q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Count(nil)
 			return
 		}
@@ -424,19 +424,19 @@ func nestedIfChaosKitchenSink(db *gorm.DB, a, b, c, d bool) {
 	if c {
 		if d {
 			// Immediate chain
-			q.Where("immediate_d").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("immediate_d").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
 			// Stored chain
-			q = q.Where("stored_not_d") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("stored_not_d") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
-		q = q.Where("stored_not_c") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Level 2 Phi: q_2 = Phi(q_1_c_not_d, q_1_not_c, q_1_c_d)
 
-	q.Find(nil)                    // want `\*gorm\.DB instance reused after chain method`
-	q.Where("final").Count(nil)    // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("final").Count(nil)    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosWithLoops demonstrates nested if inside a loop.
@@ -456,7 +456,7 @@ func nestedIfChaosWithLoops(db *gorm.DB, flags []bool) {
 	}
 
 	q.Find(nil)   // OK: first use after nested conditionals with assignments only
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosMultipleVars demonstrates multiple variables with nested ifs.
@@ -477,10 +477,10 @@ func nestedIfChaosMultipleVars(db *gorm.DB, a, b bool) {
 	}
 
 	q1.Find(nil)
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosReassignmentInBranch demonstrates reassignment in nested branches.
@@ -502,7 +502,7 @@ func nestedIfChaosReassignmentInBranch(db *gorm.DB, a, b, c bool) {
 	}
 
 	// Complex: q might be polluted or fresh depending on path
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -519,10 +519,10 @@ func chaosPolluteInNestedIf(db *gorm.DB, a, b, c bool) {
 			q = q.Where("b")
 			q.Find(nil) // Pollute q deep inside
 			if c {
-				q = q.Where("c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("c") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
-		q = q.Where("after_b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("after_b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Count(nil) // OK: Phi result used once (optimizer limitation - pollution inside nested if not tracked through Phi)
@@ -537,21 +537,21 @@ func chaosPolluteMultipleTimes(db *gorm.DB, a, b, c, d bool) {
 		q.Find(nil) // First pollution
 
 		if b {
-			q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Count(nil)
 
 			if c {
-				q = q.Where("c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("c") // want `\*gorm\.DB reused: second branch from mutable root`
 				q.First(nil)
 			}
 		}
 
 		if d {
-			q = q.Where("d") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("d") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPolluteThenReassign demonstrates pollution followed by reassignment in nested branches.
@@ -575,7 +575,7 @@ func chaosPolluteThenReassign(db *gorm.DB, a, b, c bool) {
 		}
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPollutionPropagation demonstrates how pollution propagates through Phi nodes.
@@ -593,16 +593,16 @@ func chaosPollutionPropagation(db *gorm.DB, a, b, c bool) {
 
 	// Level 2: Extend from Phi result
 	if b {
-		q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	// Phi2: q2 = Phi(q1, q1.Where("b"))
 
 	// Level 3: Pollute Phi2 result
 	if c {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosAsymmetricPollution demonstrates pollution on one side of asymmetric branches.
@@ -616,9 +616,9 @@ func chaosAsymmetricPollution(db *gorm.DB, a, b, c bool) {
 			q.Find(nil) // Pollute
 
 			if c {
-				q = q.Where("a_b_c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("a_b_c") // want `\*gorm\.DB reused: second branch from mutable root`
 			} else {
-				q = q.Where("a_b_not_c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("a_b_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		} else {
 			// Clean path
@@ -640,16 +640,16 @@ func chaosMixedPollutionAndChaining(db *gorm.DB, a, b, c bool) {
 		q.Where("immediate1").Find(nil) // Immediate chain - pollutes q
 
 		if b {
-			q = q.Where("extend_polluted") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("extend_polluted") // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Where("immediate2").Count(nil)
 
 			if c {
-				q = q.Where("deeper") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("deeper") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPolluteInLoop demonstrates pollution inside loop with nested ifs.
@@ -664,13 +664,13 @@ func chaosPolluteInLoop(db *gorm.DB, items []int, threshold int) {
 				q.Find(nil)
 
 				if item > threshold*2 {
-					q = q.Where("double", item) // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("double", item) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosNestedLoopsWithPollution demonstrates nested loops with pollution.
@@ -685,14 +685,14 @@ func chaosNestedLoopsWithPollution(db *gorm.DB, outer, inner []int) {
 				q = q.Where("inner_even", i)
 				q.Find(nil)
 			} else {
-				q = q.Where("inner_odd", i) // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("inner_odd", i) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosConditionalReassignmentMaze demonstrates a maze of conditional reassignments.
@@ -714,11 +714,11 @@ func chaosConditionalReassignmentMaze(db *gorm.DB, a, b, c, d, e bool) {
 					q = db.Where("fresh_d") // Fresh
 					q = q.Where("d")
 				} else {
-					q = q.Where("not_d") // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("not_d") // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		} else {
-			q = q.Where("not_b") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("not_b") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		if e {
@@ -727,7 +727,7 @@ func chaosConditionalReassignmentMaze(db *gorm.DB, a, b, c, d, e bool) {
 	}
 
 	// Mega-Phi merging multiple complex paths
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPhiCascade demonstrates cascading Phi nodes with pollution at each level.
@@ -745,28 +745,28 @@ func chaosPhiCascade(db *gorm.DB, a, b, c, d bool) {
 
 	// Level 2
 	if b {
-		q = q.Where("b1") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b1") // want `\*gorm\.DB reused: second branch from mutable root`
 		q.Count(nil)
 	} else {
-		q = q.Where("b2") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b2") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	// Phi2: q2 = Phi(Phi1.Where.polluted, Phi1.Where)
 
 	// Level 3
 	if c {
-		q = q.Where("c1") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c1") // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		q = q.Where("c2") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c2") // want `\*gorm\.DB reused: second branch from mutable root`
 		q.First(nil)
 	}
 	// Phi3: q3 = Phi(Phi2.Where, Phi2.Where.polluted)
 
 	// Level 4
 	if d {
-		q = q.Where("d1") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("d1") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosInterwovenVariables demonstrates multiple variables with interwoven pollution.
@@ -782,18 +782,18 @@ func chaosInterwovenVariables(db *gorm.DB, a, b, c bool) {
 		q2.Count(nil) // Pollute q2
 
 		if b {
-			q1 = q1.Where("q1_b") // want `\*gorm\.DB instance reused after chain method`
-			q2 = q2.Where("q2_b") // want `\*gorm\.DB instance reused after chain method`
+			q1 = q1.Where("q1_b") // want `\*gorm\.DB reused: second branch from mutable root`
+			q2 = q2.Where("q2_b") // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
 				q1.Where("q1_c_imm").First(nil) // OK: First use of q1 after reassignment on line 781
-				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB instance reused after chain method`
+				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q1.Last(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwap demonstrates variable swapping patterns.
@@ -810,8 +810,8 @@ func chaosVariableSwap(db *gorm.DB, a, b bool) {
 	q2 = q3
 
 	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
-	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapConditional demonstrates conditional swapping.
@@ -829,8 +829,8 @@ func chaosVariableSwapConditional(db *gorm.DB, swap bool) {
 	}
 
 	// After conditional: q1 might be swapped or not
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapChain demonstrates swapping with chaining.
@@ -844,10 +844,10 @@ func chaosVariableSwapChain(db *gorm.DB) {
 	q2 = temp
 
 	q1.Find(nil)
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapLoop demonstrates swapping in loop.
@@ -899,9 +899,9 @@ func chaosMultipleSwaps(db *gorm.DB, a, b, c bool) {
 	}
 
 	// Complex Phi patterns after multiple conditional swaps
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
@@ -916,8 +916,8 @@ func chaosModernSwapSyntax(db *gorm.DB, a bool) {
 	q1, q2 = q2, q1
 
 	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
-	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapConditional demonstrates modern swap syntax with conditionals.
@@ -937,9 +937,9 @@ func chaosModernSwapConditional(db *gorm.DB, a, b bool) {
 	}
 
 	// All three may be polluted depending on branches
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapLoop demonstrates modern swap syntax in loops.
@@ -953,11 +953,11 @@ func chaosModernSwapLoop(db *gorm.DB, flags []bool) {
 		if flag {
 			q1, q2 = q2, q1 // Swap back and forth
 		}
-		q1 = q1.Where("extend", flag) // want `\*gorm\.DB instance reused after chain method`
+		q1 = q1.Where("extend", flag) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosUltimateStressTest demonstrates the ultimate stress test with everything mixed.
@@ -972,17 +972,17 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 				q.Find(nil)
 
 				if i > 5 {
-					temp = q.Where("temp_from_q") // want `\*gorm\.DB instance reused after chain method`
+					temp = q.Where("temp_from_q") // want `\*gorm\.DB reused: second branch from mutable root`
 					temp.Count(nil)
-					q = temp.Where("back_to_q") // want `\*gorm\.DB instance reused after chain method`
+					q = temp.Where("back_to_q") // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			} else if i%3 == 1 {
-				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 				if i < 10 {
 					q = db.Where("fresh", i) // Fresh
 				} else {
-					q = q.Where("mod3_1_ext") // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("mod3_1_ext") // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			} else {
 				temp = db.Where("temp_fresh")
@@ -992,18 +992,18 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 					q = temp // Transfer temp to q
 				} else {
 					temp.Last(nil)
-					q = q.Where("mod3_2") // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("mod3_2") // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		} else {
-			q = q.Where("no_flag", i) // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("no_flag", i) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if temp != nil {
-		temp.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		temp.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1015,8 +1015,8 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 func chaosWhereChainNoReassignment(db *gorm.DB) {
 	q := db.Where("base")
 	q.Where("filter1").Find(nil)
-	q.Where("filter2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
-	q.Where("filter3").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("filter2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("filter3").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosNestedIfWhereNoReassignment demonstrates Where chaining in nested if without reassignment.
@@ -1027,14 +1027,14 @@ func chaosNestedIfWhereNoReassignment(db *gorm.DB, a, b bool) {
 		q.Where("a1").Find(nil)
 
 		if b {
-			q.Where("b1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-			q.Where("b2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+			q.Where("b2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
-		q.Where("a2").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a2").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainAfterPollution demonstrates Where chaining after pollution.
@@ -1042,14 +1042,14 @@ func chaosWhereChainAfterPollution(db *gorm.DB, a bool) {
 	q := db.Where("base")
 	q.Find(nil) // Pollute
 
-	q.Where("after1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q.Where("after2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("after2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if a {
-		q.Where("if_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("if_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainInLoop demonstrates Where chaining in loop without reassignment.
@@ -1057,10 +1057,10 @@ func chaosWhereChainInLoop(db *gorm.DB, items []string) {
 	q := db.Where("base")
 
 	for _, item := range items {
-		q.Where("item", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("after_loop").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_loop").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainMixedWithReassignment demonstrates mixing Where chains and reassignment.
@@ -1072,18 +1072,18 @@ func chaosWhereChainMixedWithReassignment(db *gorm.DB, a, b bool) {
 
 	if a {
 		// Second use: Where chain (violation)
-		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 		// Reassignment - extends polluted q
-		q = q.Where("reassign") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("reassign") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Third use: Where chain on Phi(polluted_q, reassigned_q)
-	q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if b {
 		// Fourth use: Where chain
-		q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1095,25 +1095,25 @@ func chaosWhereChainDeepNesting(db *gorm.DB, a, b, c, d bool) {
 		q.Where("a").Find(nil)
 
 		if b {
-			q.Where("b").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
-				q.Where("c").First(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("c").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 				if d {
-					q.Where("d").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+					q.Where("d").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 
-				q.Where("after_d").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("after_d").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 
-			q.Where("after_c").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("after_c").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
-		q.Where("after_b").First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("after_b").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("after_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainWithImmediateAndStored demonstrates immediate vs stored Where chains.
@@ -1124,15 +1124,15 @@ func chaosWhereChainWithImmediateAndStored(db *gorm.DB, a bool) {
 	q.Where("imm1").Find(nil)
 
 	// Stored chain - violation
-	filtered := q.Where("stored1") // want `\*gorm\.DB instance reused after chain method`
+	filtered := q.Where("stored1") // want `\*gorm\.DB reused: second branch from mutable root`
 	filtered.Count(nil)
 
 	// Another immediate chain - violation
-	q.Where("imm2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("imm2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if a {
 		// Yet another violation
-		q.Where("imm3").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("imm3").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1144,8 +1144,8 @@ func chaosWhereChainAsymmetric(db *gorm.DB, a, b bool) {
 		// Deep Where chaining on one side
 		if b {
 			q.Where("a_b_1").Find(nil)
-			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-			q.Where("a_b_3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+			q.Where("a_b_3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
 			q.Where("a_not_b").Last(nil)
 		}
@@ -1155,7 +1155,7 @@ func chaosWhereChainAsymmetric(db *gorm.DB, a, b bool) {
 	}
 
 	// After Phi - violation on all paths
-	q.Where("after_phi").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_phi").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainInterwovenPollution demonstrates Where chains with interwoven pollution.
@@ -1167,27 +1167,27 @@ func chaosWhereChainInterwovenPollution(db *gorm.DB, a, b, c bool) {
 
 	if a {
 		// Use 2 - violation
-		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 		if b {
 			// Use 3 - violation
-			q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
 				// Use 4 - violation
-				q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 
 			// Use 5 - violation
-			q.Where("use5").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("use5").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
 		// Use 6 - violation
-		q.Where("use6").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use6").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Use 7 - violation
-	q.Where("use7").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("use7").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainLoopAccumulation demonstrates Where chains accumulating in loop.
@@ -1197,9 +1197,9 @@ func chaosWhereChainLoopAccumulation(db *gorm.DB, filters []string) {
 
 	for _, filter := range filters {
 		// Each iteration is a violation - reusing polluted q
-		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// After loop - still violation
-	q.Where("final").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/nested_chaos.go.diff
+++ b/testdata/src/gormreuse/nested_chaos.go.diff
@@ -70,7 +70,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfDoubleUseDeeper demonstrates 3-level nested if with two Find() calls.
@@ -94,7 +94,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -157,7 +157,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Where("extra1").Find(nil)
- 	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfImmediateChainDoubleDeeper demonstrates 3-level nesting with two chains.
@@ -181,7 +181,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Where("extra1").Find(nil)
- 	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -205,7 +205,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Find(nil)                    // Pollutes q
- 	q.Where("extra").Find(nil)     // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("extra").Find(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfFindThenWhereDeeper demonstrates 3-level nesting with Find then Where.
@@ -229,7 +229,7 @@
 +		q = q.Where("not_a").Session(&gorm.Session{})
  	}
  	q.Find(nil)                // Pollutes q
- 	q.Where("extra").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("extra").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -291,9 +291,9 @@
  		q.Where("immediate_a").Find(nil) // Immediate chain - pollutes q
  	}
  	if b {
- 		q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfMixedChainLevel2 demonstrates mixed chains at inner level.
@@ -306,13 +306,13 @@
  		} else {
  			q = q.Where("stored_not_b") // Stored
  		}
--		q = q.Where("stored_a") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("stored_a").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("stored_a") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("stored_a").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	if c {
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -350,7 +350,7 @@
  	// q_3 = Phi(q_2_c, q_2_not_c)
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfMultiplePhiSingleUse demonstrates multiple Phi but single final use.
@@ -407,7 +407,7 @@
  	}
  
  	q.Find(nil)
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfAsymmetricWithEarlyReturn demonstrates asymmetric with early return.
@@ -442,7 +442,7 @@
  		q.Where("immediate_a").Find(nil) // Pollutes q
  		if b {
  			// Level 2: Early return after stored chain
- 			q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+ 			q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
  			q.Count(nil)
  			return
  		}
@@ -458,19 +458,19 @@
  	if c {
  		if d {
  			// Immediate chain
- 			q.Where("immediate_d").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("immediate_d").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		} else {
  			// Stored chain
- 			q = q.Where("stored_not_d") // want `\*gorm\.DB instance reused after chain method`
+ 			q = q.Where("stored_not_d") // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	} else {
- 		q = q.Where("stored_not_c") // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("stored_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	// Level 2 Phi: q_2 = Phi(q_1_c_not_d, q_1_not_c, q_1_c_d)
  
- 	q.Find(nil)                    // want `\*gorm\.DB instance reused after chain method`
- 	q.Where("final").Count(nil)    // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Where("final").Count(nil)    // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfChaosWithLoops demonstrates nested if inside a loop.
@@ -493,7 +493,7 @@
  	}
  
  	q.Find(nil)   // OK: first use after nested conditionals with assignments only
- 	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfChaosMultipleVars demonstrates multiple variables with nested ifs.
@@ -519,10 +519,10 @@
  	}
  
  	q1.Find(nil)
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q2.Find(nil)
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // nestedIfChaosReassignmentInBranch demonstrates reassignment in nested branches.
@@ -544,7 +544,7 @@
  	}
  
  	// Complex: q might be polluted or fresh depending on path
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================
@@ -561,10 +561,10 @@
  			q = q.Where("b")
  			q.Find(nil) // Pollute q deep inside
  			if c {
- 				q = q.Where("c") // want `\*gorm\.DB instance reused after chain method`
+ 				q = q.Where("c") // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
- 		q = q.Where("after_b") // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("after_b") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	q.Count(nil) // OK: Phi result used once (optimizer limitation - pollution inside nested if not tracked through Phi)
@@ -580,23 +580,23 @@
  		q.Find(nil) // First pollution
  
  		if b {
--			q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
-+			q = q.Where("b").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-			q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
++			q = q.Where("b").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  			q.Count(nil)
  
  			if c {
--				q = q.Where("c") // want `\*gorm\.DB instance reused after chain method`
-+				q = q.Where("c").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-				q = q.Where("c") // want `\*gorm\.DB reused: second branch from mutable root`
++				q = q.Where("c").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  				q.First(nil)
  			}
  		}
  
  		if d {
- 			q = q.Where("d") // want `\*gorm\.DB instance reused after chain method`
+ 			q = q.Where("d") // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
- 	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosPolluteThenReassign demonstrates pollution followed by reassignment in nested branches.
@@ -620,7 +620,7 @@
  		}
  	}
  
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosPollutionPropagation demonstrates how pollution propagates through Phi nodes.
@@ -640,16 +640,16 @@
  
  	// Level 2: Extend from Phi result
  	if b {
- 		q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	// Phi2: q2 = Phi(q1, q1.Where("b"))
  
  	// Level 3: Pollute Phi2 result
  	if c {
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosAsymmetricPollution demonstrates pollution on one side of asymmetric branches.
@@ -664,9 +664,9 @@
  			q.Find(nil) // Pollute
  
  			if c {
- 				q = q.Where("a_b_c") // want `\*gorm\.DB instance reused after chain method`
+ 				q = q.Where("a_b_c") // want `\*gorm\.DB reused: second branch from mutable root`
  			} else {
- 				q = q.Where("a_b_not_c") // want `\*gorm\.DB instance reused after chain method`
+ 				q = q.Where("a_b_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		} else {
  			// Clean path
@@ -688,16 +688,16 @@
  		q.Where("immediate1").Find(nil) // Immediate chain - pollutes q
  
  		if b {
- 			q = q.Where("extend_polluted") // want `\*gorm\.DB instance reused after chain method`
+ 			q = q.Where("extend_polluted") // want `\*gorm\.DB reused: second branch from mutable root`
  			q.Where("immediate2").Count(nil)
  
  			if c {
- 				q = q.Where("deeper") // want `\*gorm\.DB instance reused after chain method`
+ 				q = q.Where("deeper") // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
  
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosPolluteInLoop demonstrates pollution inside loop with nested ifs.
@@ -714,14 +714,14 @@
  				q.Find(nil)
  
  				if item > threshold*2 {
--					q = q.Where("double", item) // want `\*gorm\.DB instance reused after chain method`
-+					q = q.Where("double", item).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-					q = q.Where("double", item) // want `\*gorm\.DB reused: second branch from mutable root`
++					q = q.Where("double", item).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  			}
  		}
  	}
  
- 	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosNestedLoopsWithPollution demonstrates nested loops with pollution.
@@ -738,15 +738,15 @@
 +				q = q.Where("inner_even", i).Session(&gorm.Session{})
  				q.Find(nil)
  			} else {
--				q = q.Where("inner_odd", i) // want `\*gorm\.DB instance reused after chain method`
-+				q = q.Where("inner_odd", i).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-				q = q.Where("inner_odd", i) // want `\*gorm\.DB reused: second branch from mutable root`
++				q = q.Where("inner_odd", i).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  
- 		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosConditionalReassignmentMaze demonstrates a maze of conditional reassignments.
@@ -769,11 +769,11 @@
  					q = db.Where("fresh_d") // Fresh
  					q = q.Where("d")
  				} else {
- 					q = q.Where("not_d") // want `\*gorm\.DB instance reused after chain method`
+ 					q = q.Where("not_d") // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  			}
  		} else {
- 			q = q.Where("not_b") // want `\*gorm\.DB instance reused after chain method`
+ 			q = q.Where("not_b") // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	} else {
  		if e {
@@ -782,7 +782,7 @@
  	}
  
  	// Mega-Phi merging multiple complex paths
- 	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosPhiCascade demonstrates cascading Phi nodes with pollution at each level.
@@ -802,32 +802,32 @@
  
  	// Level 2
  	if b {
--		q = q.Where("b1") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("b1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("b1") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("b1").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  		q.Count(nil)
  	} else {
--		q = q.Where("b2") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("b2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("b2") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("b2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  	// Phi2: q2 = Phi(Phi1.Where.polluted, Phi1.Where)
  
  	// Level 3
  	if c {
--		q = q.Where("c1") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("c1") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  	} else {
--		q = q.Where("c2") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("c2") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  		q.First(nil)
  	}
  	// Phi3: q3 = Phi(Phi2.Where, Phi2.Where.polluted)
  
  	// Level 4
  	if d {
- 		q = q.Where("d1") // want `\*gorm\.DB instance reused after chain method`
+ 		q = q.Where("d1") // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosInterwovenVariables demonstrates multiple variables with interwoven pollution.
@@ -843,18 +843,18 @@
  		q2.Count(nil) // Pollute q2
  
  		if b {
- 			q1 = q1.Where("q1_b") // want `\*gorm\.DB instance reused after chain method`
- 			q2 = q2.Where("q2_b") // want `\*gorm\.DB instance reused after chain method`
+ 			q1 = q1.Where("q1_b") // want `\*gorm\.DB reused: second branch from mutable root`
+ 			q2 = q2.Where("q2_b") // want `\*gorm\.DB reused: second branch from mutable root`
  
  			if c {
  				q1.Where("q1_c_imm").First(nil) // OK: First use of q1 after reassignment on line 781
- 				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB instance reused after chain method`
+ 				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  		}
  	}
  
- 	q1.Last(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosVariableSwap demonstrates variable swapping patterns.
@@ -873,8 +873,8 @@
  	q2 = q3
  
  	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
- 	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosVariableSwapConditional demonstrates conditional swapping.
@@ -892,8 +892,8 @@
  	}
  
  	// After conditional: q1 might be swapped or not
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosVariableSwapChain demonstrates swapping with chaining.
@@ -909,10 +909,10 @@
  	q2 = temp
  
  	q1.Find(nil)
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q2.Find(nil)
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosVariableSwapLoop demonstrates swapping in loop.
@@ -966,9 +966,9 @@
  	}
  
  	// Complex Phi patterns after multiple conditional swaps
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
@@ -985,8 +985,8 @@
  	q1, q2 = q2, q1
  
  	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
- 	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosModernSwapConditional demonstrates modern swap syntax with conditionals.
@@ -1006,9 +1006,9 @@
  	}
  
  	// All three may be polluted depending on branches
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosModernSwapLoop demonstrates modern swap syntax in loops.
@@ -1023,12 +1023,12 @@
  		if flag {
  			q1, q2 = q2, q1 // Swap back and forth
  		}
--		q1 = q1.Where("extend", flag) // want `\*gorm\.DB instance reused after chain method`
-+		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q1 = q1.Where("extend", flag) // want `\*gorm\.DB reused: second branch from mutable root`
++		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosUltimateStressTest demonstrates the ultimate stress test with everything mixed.
@@ -1045,20 +1045,20 @@
  				q.Find(nil)
  
  				if i > 5 {
- 					temp = q.Where("temp_from_q") // want `\*gorm\.DB instance reused after chain method`
+ 					temp = q.Where("temp_from_q") // want `\*gorm\.DB reused: second branch from mutable root`
  					temp.Count(nil)
--					q = temp.Where("back_to_q") // want `\*gorm\.DB instance reused after chain method`
-+					q = temp.Where("back_to_q").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-					q = temp.Where("back_to_q") // want `\*gorm\.DB reused: second branch from mutable root`
++					q = temp.Where("back_to_q").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  			} else if i%3 == 1 {
- 				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  				if i < 10 {
 -					q = db.Where("fresh", i) // Fresh
 +					q = db.Where("fresh", i).Session(&gorm.Session{}) // Fresh
  				} else {
--					q = q.Where("mod3_1_ext") // want `\*gorm\.DB instance reused after chain method`
-+					q = q.Where("mod3_1_ext").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-					q = q.Where("mod3_1_ext") // want `\*gorm\.DB reused: second branch from mutable root`
++					q = q.Where("mod3_1_ext").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  			} else {
  				temp = db.Where("temp_fresh")
@@ -1069,20 +1069,20 @@
  					q = temp // Transfer temp to q
  				} else {
  					temp.Last(nil)
--					q = q.Where("mod3_2") // want `\*gorm\.DB instance reused after chain method`
-+					q = q.Where("mod3_2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-					q = q.Where("mod3_2") // want `\*gorm\.DB reused: second branch from mutable root`
++					q = q.Where("mod3_2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  			}
  		} else {
--			q = q.Where("no_flag", i) // want `\*gorm\.DB instance reused after chain method`
-+			q = q.Where("no_flag", i).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-			q = q.Where("no_flag", i) // want `\*gorm\.DB reused: second branch from mutable root`
++			q = q.Where("no_flag", i).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  	}
  
- 	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	if temp != nil {
- 		temp.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		temp.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1095,8 +1095,8 @@
 -	q := db.Where("base")
 +	q := db.Where("base").Session(&gorm.Session{})
  	q.Where("filter1").Find(nil)
- 	q.Where("filter2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q.Where("filter3").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("filter2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Where("filter3").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosNestedIfWhereNoReassignment demonstrates Where chaining in nested if without reassignment.
@@ -1108,14 +1108,14 @@
  		q.Where("a1").Find(nil)
  
  		if b {
- 			q.Where("b1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 			q.Where("b2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("b1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 			q.Where("b2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  
- 		q.Where("a2").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("a2").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainAfterPollution demonstrates Where chaining after pollution.
@@ -1124,14 +1124,14 @@
 +	q := db.Where("base").Session(&gorm.Session{})
  	q.Find(nil) // Pollute
  
- 	q.Where("after1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 	q.Where("after2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("after1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	q.Where("after2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	if a {
- 		q.Where("if_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("if_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainInLoop demonstrates Where chaining in loop without reassignment.
@@ -1140,10 +1140,10 @@
 +	q := db.Where("base").Session(&gorm.Session{})
  
  	for _, item := range items {
- 		q.Where("item", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("item", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Where("after_loop").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("after_loop").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainMixedWithReassignment demonstrates mixing Where chains and reassignment.
@@ -1156,19 +1156,19 @@
  
  	if a {
  		// Second use: Where chain (violation)
- 		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  		// Reassignment - extends polluted q
--		q = q.Where("reassign") // want `\*gorm\.DB instance reused after chain method`
-+		q = q.Where("reassign").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+-		q = q.Where("reassign") // want `\*gorm\.DB reused: second branch from mutable root`
++		q = q.Where("reassign").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	// Third use: Where chain on Phi(polluted_q, reassigned_q)
- 	q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	if b {
  		// Fourth use: Where chain
- 		q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1181,25 +1181,25 @@
  		q.Where("a").Find(nil)
  
  		if b {
- 			q.Where("b").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("b").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  			if c {
- 				q.Where("c").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Where("c").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  				if d {
- 					q.Where("d").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 					q.Where("d").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  				}
  
- 				q.Where("after_d").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Where("after_d").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  
- 			q.Where("after_c").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("after_c").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  
- 		q.Where("after_b").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("after_b").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
- 	q.Where("after_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("after_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainWithImmediateAndStored demonstrates immediate vs stored Where chains.
@@ -1211,15 +1211,15 @@
  	q.Where("imm1").Find(nil)
  
  	// Stored chain - violation
- 	filtered := q.Where("stored1") // want `\*gorm\.DB instance reused after chain method`
+ 	filtered := q.Where("stored1") // want `\*gorm\.DB reused: second branch from mutable root`
  	filtered.Count(nil)
  
  	// Another immediate chain - violation
- 	q.Where("imm2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("imm2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	if a {
  		// Yet another violation
- 		q.Where("imm3").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("imm3").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  }
  
@@ -1232,8 +1232,8 @@
  		// Deep Where chaining on one side
  		if b {
  			q.Where("a_b_1").Find(nil)
- 			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
- 			q.Where("a_b_3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 			q.Where("a_b_3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		} else {
  			q.Where("a_not_b").Last(nil)
  		}
@@ -1243,7 +1243,7 @@
  	}
  
  	// After Phi - violation on all paths
- 	q.Where("after_phi").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("after_phi").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainInterwovenPollution demonstrates Where chains with interwoven pollution.
@@ -1256,27 +1256,27 @@
  
  	if a {
  		// Use 2 - violation
- 		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  		if b {
  			// Use 3 - violation
- 			q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  
  			if c {
  				// Use 4 - violation
- 				q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+ 				q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  			}
  
  			// Use 5 - violation
- 			q.Where("use5").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+ 			q.Where("use5").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  		}
  
  		// Use 6 - violation
- 		q.Where("use6").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("use6").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	// Use 7 - violation
- 	q.Where("use7").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("use7").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // chaosWhereChainLoopAccumulation demonstrates Where chains accumulating in loop.
@@ -1287,9 +1287,9 @@
  
  	for _, filter := range filters {
  		// Each iteration is a violation - reusing polluted q
- 		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+ 		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  	}
  
  	// After loop - still violation
- 	q.Where("final").First(nil) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Where("final").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/nested_chaos.go.golden
+++ b/testdata/src/gormreuse/nested_chaos.go.golden
@@ -64,7 +64,7 @@ func nestedIfDoubleUse(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfDoubleUseDeeper demonstrates 3-level nested if with two Find() calls.
@@ -84,7 +84,7 @@ func nestedIfDoubleUseDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -144,7 +144,7 @@ func nestedIfImmediateChainDouble(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Where("extra1").Find(nil)
-	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfImmediateChainDoubleDeeper demonstrates 3-level nesting with two chains.
@@ -164,7 +164,7 @@ func nestedIfImmediateChainDoubleDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Where("extra1").Find(nil)
-	q.Where("extra2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -185,7 +185,7 @@ func nestedIfFindThenWhere(db *gorm.DB, a, b bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Find(nil)                    // Pollutes q
-	q.Where("extra").Find(nil)     // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra").Find(nil)     // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfFindThenWhereDeeper demonstrates 3-level nesting with Find then Where.
@@ -205,7 +205,7 @@ func nestedIfFindThenWhereDeeper(db *gorm.DB, a, b, c bool) {
 		q = q.Where("not_a").Session(&gorm.Session{})
 	}
 	q.Find(nil)                // Pollutes q
-	q.Where("extra").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("extra").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -267,9 +267,9 @@ func nestedIfMixedChainLevel1(db *gorm.DB, a, b bool) {
 		q.Where("immediate_a").Find(nil) // Immediate chain - pollutes q
 	}
 	if b {
-		q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfMixedChainLevel2 demonstrates mixed chains at inner level.
@@ -281,12 +281,12 @@ func nestedIfMixedChainLevel2(db *gorm.DB, a, b, c bool) {
 		} else {
 			q = q.Where("stored_not_b") // Stored
 		}
-		q = q.Where("stored_a").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_a").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	if c {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -322,7 +322,7 @@ func nestedIfMultiplePhiLevels(db *gorm.DB, a, b, c bool) {
 	// q_3 = Phi(q_2_c, q_2_not_c)
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfMultiplePhiSingleUse demonstrates multiple Phi but single final use.
@@ -375,7 +375,7 @@ func nestedIfAsymmetricDepth(db *gorm.DB, a, b, c bool) {
 	}
 
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfAsymmetricWithEarlyReturn demonstrates asymmetric with early return.
@@ -409,7 +409,7 @@ func nestedIfChaosKitchenSink(db *gorm.DB, a, b, c, d bool) {
 		q.Where("immediate_a").Find(nil) // Pollutes q
 		if b {
 			// Level 2: Early return after stored chain
-			q = q.Where("stored_b") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("stored_b") // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Count(nil)
 			return
 		}
@@ -424,19 +424,19 @@ func nestedIfChaosKitchenSink(db *gorm.DB, a, b, c, d bool) {
 	if c {
 		if d {
 			// Immediate chain
-			q.Where("immediate_d").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("immediate_d").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
 			// Stored chain
-			q = q.Where("stored_not_d") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("stored_not_d") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
-		q = q.Where("stored_not_c") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("stored_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Level 2 Phi: q_2 = Phi(q_1_c_not_d, q_1_not_c, q_1_c_d)
 
-	q.Find(nil)                    // want `\*gorm\.DB instance reused after chain method`
-	q.Where("final").Count(nil)    // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("final").Count(nil)    // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosWithLoops demonstrates nested if inside a loop.
@@ -456,7 +456,7 @@ func nestedIfChaosWithLoops(db *gorm.DB, flags []bool) {
 	}
 
 	q.Find(nil)   // OK: first use after nested conditionals with assignments only
-	q.Count(nil)  // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil)  // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosMultipleVars demonstrates multiple variables with nested ifs.
@@ -477,10 +477,10 @@ func nestedIfChaosMultipleVars(db *gorm.DB, a, b bool) {
 	}
 
 	q1.Find(nil)
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // nestedIfChaosReassignmentInBranch demonstrates reassignment in nested branches.
@@ -502,7 +502,7 @@ func nestedIfChaosReassignmentInBranch(db *gorm.DB, a, b, c bool) {
 	}
 
 	// Complex: q might be polluted or fresh depending on path
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================
@@ -519,10 +519,10 @@ func chaosPolluteInNestedIf(db *gorm.DB, a, b, c bool) {
 			q = q.Where("b")
 			q.Find(nil) // Pollute q deep inside
 			if c {
-				q = q.Where("c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("c") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
-		q = q.Where("after_b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("after_b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	q.Count(nil) // OK: Phi result used once (optimizer limitation - pollution inside nested if not tracked through Phi)
@@ -537,21 +537,21 @@ func chaosPolluteMultipleTimes(db *gorm.DB, a, b, c, d bool) {
 		q.Find(nil) // First pollution
 
 		if b {
-			q = q.Where("b").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("b").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Count(nil)
 
 			if c {
-				q = q.Where("c").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("c").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 				q.First(nil)
 			}
 		}
 
 		if d {
-			q = q.Where("d") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("d") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPolluteThenReassign demonstrates pollution followed by reassignment in nested branches.
@@ -575,7 +575,7 @@ func chaosPolluteThenReassign(db *gorm.DB, a, b, c bool) {
 		}
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPollutionPropagation demonstrates how pollution propagates through Phi nodes.
@@ -593,16 +593,16 @@ func chaosPollutionPropagation(db *gorm.DB, a, b, c bool) {
 
 	// Level 2: Extend from Phi result
 	if b {
-		q = q.Where("b") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	// Phi2: q2 = Phi(q1, q1.Where("b"))
 
 	// Level 3: Pollute Phi2 result
 	if c {
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosAsymmetricPollution demonstrates pollution on one side of asymmetric branches.
@@ -616,9 +616,9 @@ func chaosAsymmetricPollution(db *gorm.DB, a, b, c bool) {
 			q.Find(nil) // Pollute
 
 			if c {
-				q = q.Where("a_b_c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("a_b_c") // want `\*gorm\.DB reused: second branch from mutable root`
 			} else {
-				q = q.Where("a_b_not_c") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("a_b_not_c") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		} else {
 			// Clean path
@@ -640,16 +640,16 @@ func chaosMixedPollutionAndChaining(db *gorm.DB, a, b, c bool) {
 		q.Where("immediate1").Find(nil) // Immediate chain - pollutes q
 
 		if b {
-			q = q.Where("extend_polluted") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("extend_polluted") // want `\*gorm\.DB reused: second branch from mutable root`
 			q.Where("immediate2").Count(nil)
 
 			if c {
-				q = q.Where("deeper") // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("deeper") // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPolluteInLoop demonstrates pollution inside loop with nested ifs.
@@ -664,13 +664,13 @@ func chaosPolluteInLoop(db *gorm.DB, items []int, threshold int) {
 				q.Find(nil)
 
 				if item > threshold*2 {
-					q = q.Where("double", item).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("double", item).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		}
 	}
 
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosNestedLoopsWithPollution demonstrates nested loops with pollution.
@@ -685,14 +685,14 @@ func chaosNestedLoopsWithPollution(db *gorm.DB, outer, inner []int) {
 				q = q.Where("inner_even", i).Session(&gorm.Session{})
 				q.Find(nil)
 			} else {
-				q = q.Where("inner_odd", i).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+				q = q.Where("inner_odd", i).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 
-		q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosConditionalReassignmentMaze demonstrates a maze of conditional reassignments.
@@ -714,11 +714,11 @@ func chaosConditionalReassignmentMaze(db *gorm.DB, a, b, c, d, e bool) {
 					q = db.Where("fresh_d") // Fresh
 					q = q.Where("d")
 				} else {
-					q = q.Where("not_d") // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("not_d") // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		} else {
-			q = q.Where("not_b") // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("not_b") // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	} else {
 		if e {
@@ -727,7 +727,7 @@ func chaosConditionalReassignmentMaze(db *gorm.DB, a, b, c, d, e bool) {
 	}
 
 	// Mega-Phi merging multiple complex paths
-	q.First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosPhiCascade demonstrates cascading Phi nodes with pollution at each level.
@@ -745,28 +745,28 @@ func chaosPhiCascade(db *gorm.DB, a, b, c, d bool) {
 
 	// Level 2
 	if b {
-		q = q.Where("b1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b1").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 		q.Count(nil)
 	} else {
-		q = q.Where("b2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("b2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 	// Phi2: q2 = Phi(Phi1.Where.polluted, Phi1.Where)
 
 	// Level 3
 	if c {
-		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c1").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 	} else {
-		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("c2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 		q.First(nil)
 	}
 	// Phi3: q3 = Phi(Phi2.Where, Phi2.Where.polluted)
 
 	// Level 4
 	if d {
-		q = q.Where("d1") // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("d1") // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosInterwovenVariables demonstrates multiple variables with interwoven pollution.
@@ -782,18 +782,18 @@ func chaosInterwovenVariables(db *gorm.DB, a, b, c bool) {
 		q2.Count(nil) // Pollute q2
 
 		if b {
-			q1 = q1.Where("q1_b") // want `\*gorm\.DB instance reused after chain method`
-			q2 = q2.Where("q2_b") // want `\*gorm\.DB instance reused after chain method`
+			q1 = q1.Where("q1_b") // want `\*gorm\.DB reused: second branch from mutable root`
+			q2 = q2.Where("q2_b") // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
 				q1.Where("q1_c_imm").First(nil) // OK: First use of q1 after reassignment on line 781
-				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB instance reused after chain method`
+				q2 = q1.Where("q2_from_q1")     // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 		}
 	}
 
-	q1.Last(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwap demonstrates variable swapping patterns.
@@ -810,8 +810,8 @@ func chaosVariableSwap(db *gorm.DB, a, b bool) {
 	q2 = q3
 
 	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
-	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapConditional demonstrates conditional swapping.
@@ -829,8 +829,8 @@ func chaosVariableSwapConditional(db *gorm.DB, swap bool) {
 	}
 
 	// After conditional: q1 might be swapped or not
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapChain demonstrates swapping with chaining.
@@ -844,10 +844,10 @@ func chaosVariableSwapChain(db *gorm.DB) {
 	q2 = temp
 
 	q1.Find(nil)
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q2.Find(nil)
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosVariableSwapLoop demonstrates swapping in loop.
@@ -899,9 +899,9 @@ func chaosMultipleSwaps(db *gorm.DB, a, b, c bool) {
 	}
 
 	// Complex Phi patterns after multiple conditional swaps
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
@@ -916,8 +916,8 @@ func chaosModernSwapSyntax(db *gorm.DB, a bool) {
 	q1, q2 = q2, q1
 
 	// After swap: q1 = old q2 (polluted), q2 = old q1 (polluted)
-	q1.First(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapConditional demonstrates modern swap syntax with conditionals.
@@ -937,9 +937,9 @@ func chaosModernSwapConditional(db *gorm.DB, a, b bool) {
 	}
 
 	// All three may be polluted depending on branches
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q3.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q3.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosModernSwapLoop demonstrates modern swap syntax in loops.
@@ -953,11 +953,11 @@ func chaosModernSwapLoop(db *gorm.DB, flags []bool) {
 		if flag {
 			q1, q2 = q2, q1 // Swap back and forth
 		}
-		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q1 = q1.Where("extend", flag).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q1.Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q2.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q1.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosUltimateStressTest demonstrates the ultimate stress test with everything mixed.
@@ -972,17 +972,17 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 				q.Find(nil)
 
 				if i > 5 {
-					temp = q.Where("temp_from_q") // want `\*gorm\.DB instance reused after chain method`
+					temp = q.Where("temp_from_q") // want `\*gorm\.DB reused: second branch from mutable root`
 					temp.Count(nil)
-					q = temp.Where("back_to_q").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+					q = temp.Where("back_to_q").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			} else if i%3 == 1 {
-				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("mod3_1_imm").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 				if i < 10 {
 					q = db.Where("fresh", i).Session(&gorm.Session{}) // Fresh
 				} else {
-					q = q.Where("mod3_1_ext").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("mod3_1_ext").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			} else {
 				temp = db.Where("temp_fresh")
@@ -992,18 +992,18 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 					q = temp // Transfer temp to q
 				} else {
 					temp.Last(nil)
-					q = q.Where("mod3_2").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+					q = q.Where("mod3_2").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 			}
 		} else {
-			q = q.Where("no_flag", i).Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+			q = q.Where("no_flag", i).Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 	}
 
-	q.Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if temp != nil {
-		temp.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		temp.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1015,8 +1015,8 @@ func chaosUltimateStressTest(db *gorm.DB, flags []bool) {
 func chaosWhereChainNoReassignment(db *gorm.DB) {
 	q := db.Where("base").Session(&gorm.Session{})
 	q.Where("filter1").Find(nil)
-	q.Where("filter2").Find(nil) // want `\*gorm\.DB instance reused after chain method`
-	q.Where("filter3").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("filter2").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("filter3").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosNestedIfWhereNoReassignment demonstrates Where chaining in nested if without reassignment.
@@ -1027,14 +1027,14 @@ func chaosNestedIfWhereNoReassignment(db *gorm.DB, a, b bool) {
 		q.Where("a1").Find(nil)
 
 		if b {
-			q.Where("b1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-			q.Where("b2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+			q.Where("b2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
-		q.Where("a2").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("a2").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainAfterPollution demonstrates Where chaining after pollution.
@@ -1042,14 +1042,14 @@ func chaosWhereChainAfterPollution(db *gorm.DB, a bool) {
 	q := db.Where("base").Session(&gorm.Session{})
 	q.Find(nil) // Pollute
 
-	q.Where("after1").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-	q.Where("after2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after1").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+	q.Where("after2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if a {
-		q.Where("if_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("if_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("final").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainInLoop demonstrates Where chaining in loop without reassignment.
@@ -1057,10 +1057,10 @@ func chaosWhereChainInLoop(db *gorm.DB, items []string) {
 	q := db.Where("base").Session(&gorm.Session{})
 
 	for _, item := range items {
-		q.Where("item", item).Find(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("item", item).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("after_loop").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_loop").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainMixedWithReassignment demonstrates mixing Where chains and reassignment.
@@ -1072,18 +1072,18 @@ func chaosWhereChainMixedWithReassignment(db *gorm.DB, a, b bool) {
 
 	if a {
 		// Second use: Where chain (violation)
-		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 		// Reassignment - extends polluted q
-		q = q.Where("reassign").Session(&gorm.Session{}) // want `\*gorm\.DB instance reused after chain method`
+		q = q.Where("reassign").Session(&gorm.Session{}) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Third use: Where chain on Phi(polluted_q, reassigned_q)
-	q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if b {
 		// Fourth use: Where chain
-		q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1095,25 +1095,25 @@ func chaosWhereChainDeepNesting(db *gorm.DB, a, b, c, d bool) {
 		q.Where("a").Find(nil)
 
 		if b {
-			q.Where("b").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("b").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
-				q.Where("c").First(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("c").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 				if d {
-					q.Where("d").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+					q.Where("d").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 				}
 
-				q.Where("after_d").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("after_d").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 
-			q.Where("after_c").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("after_c").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
-		q.Where("after_b").First(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("after_b").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
-	q.Where("after_a").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_a").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainWithImmediateAndStored demonstrates immediate vs stored Where chains.
@@ -1124,15 +1124,15 @@ func chaosWhereChainWithImmediateAndStored(db *gorm.DB, a bool) {
 	q.Where("imm1").Find(nil)
 
 	// Stored chain - violation
-	filtered := q.Where("stored1") // want `\*gorm\.DB instance reused after chain method`
+	filtered := q.Where("stored1") // want `\*gorm\.DB reused: second branch from mutable root`
 	filtered.Count(nil)
 
 	// Another immediate chain - violation
-	q.Where("imm2").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("imm2").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	if a {
 		// Yet another violation
-		q.Where("imm3").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("imm3").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 }
 
@@ -1144,8 +1144,8 @@ func chaosWhereChainAsymmetric(db *gorm.DB, a, b bool) {
 		// Deep Where chaining on one side
 		if b {
 			q.Where("a_b_1").Find(nil)
-			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
-			q.Where("a_b_3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("a_b_2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+			q.Where("a_b_3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		} else {
 			q.Where("a_not_b").Last(nil)
 		}
@@ -1155,7 +1155,7 @@ func chaosWhereChainAsymmetric(db *gorm.DB, a, b bool) {
 	}
 
 	// After Phi - violation on all paths
-	q.Where("after_phi").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("after_phi").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainInterwovenPollution demonstrates Where chains with interwoven pollution.
@@ -1167,27 +1167,27 @@ func chaosWhereChainInterwovenPollution(db *gorm.DB, a, b, c bool) {
 
 	if a {
 		// Use 2 - violation
-		q.Where("use2").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use2").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 		if b {
 			// Use 3 - violation
-			q.Where("use3").First(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("use3").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 
 			if c {
 				// Use 4 - violation
-				q.Where("use4").Last(nil) // want `\*gorm\.DB instance reused after chain method`
+				q.Where("use4").Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 			}
 
 			// Use 5 - violation
-			q.Where("use5").Find(nil) // want `\*gorm\.DB instance reused after chain method`
+			q.Where("use5").Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 		}
 
 		// Use 6 - violation
-		q.Where("use6").Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("use6").Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// Use 7 - violation
-	q.Where("use7").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("use7").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // chaosWhereChainLoopAccumulation demonstrates Where chains accumulating in loop.
@@ -1197,9 +1197,9 @@ func chaosWhereChainLoopAccumulation(db *gorm.DB, filters []string) {
 
 	for _, filter := range filters {
 		// Each iteration is a violation - reusing polluted q
-		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB instance reused after chain method`
+		q.Where("filter", filter).Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 	}
 
 	// After loop - still violation
-	q.Where("final").First(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Where("final").First(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/readonly_calls.go
+++ b/testdata/src/gormreuse/readonly_calls.go
@@ -51,7 +51,7 @@ func userVariadicSink(args ...interface{}) {}
 func userVariadicPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	userVariadicSink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // Concrete ...*gorm.DB variadic: value is packed directly (not interface-boxed),
@@ -61,7 +61,7 @@ func concreteVariadicSink(dbs ...*gorm.DB) {}
 func concreteVariadicPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	concreteVariadicSink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // A func-value (dynamic) variadic call has no static callee, so it is not on the
@@ -69,7 +69,7 @@ func concreteVariadicPollutes(db *gorm.DB) {
 func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
 	q := db.Where("x = ?", 1)
 	sink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // A user composite slice literal escapes the value and still pollutes; it does
@@ -77,5 +77,5 @@ func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
 func sliceLiteralPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	_ = []interface{}{q}
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/readonly_calls.go.diff
+++ b/testdata/src/gormreuse/readonly_calls.go.diff
@@ -55,7 +55,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	userVariadicSink(q)
- 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // Concrete ...*gorm.DB variadic: value is packed directly (not interface-boxed),
@@ -66,7 +66,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	concreteVariadicSink(q)
- 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // A func-value (dynamic) variadic call has no static callee, so it is not on the
@@ -75,7 +75,7 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	sink(q)
- 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // A user composite slice literal escapes the value and still pollutes; it does
@@ -84,5 +84,5 @@
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
  	_ = []interface{}{q}
- 	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+ 	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/readonly_calls.go.golden
+++ b/testdata/src/gormreuse/readonly_calls.go.golden
@@ -51,7 +51,7 @@ func userVariadicSink(args ...interface{}) {}
 func userVariadicPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	userVariadicSink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // Concrete ...*gorm.DB variadic: value is packed directly (not interface-boxed),
@@ -61,7 +61,7 @@ func concreteVariadicSink(dbs ...*gorm.DB) {}
 func concreteVariadicPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	concreteVariadicSink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // A func-value (dynamic) variadic call has no static callee, so it is not on the
@@ -69,7 +69,7 @@ func concreteVariadicPollutes(db *gorm.DB) {
 func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	sink(q)
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // A user composite slice literal escapes the value and still pollutes; it does
@@ -77,5 +77,5 @@ func funcValueVariadicPollutes(db *gorm.DB, sink func(...interface{})) {
 func sliceLiteralPollutes(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	_ = []interface{}{q}
-	q.Find(&[]User{}) // want `\*gorm\.DB instance reused after chain method`
+	q.Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/scopes_callback.go
+++ b/testdata/src/gormreuse/scopes_callback.go
@@ -20,7 +20,7 @@ import "gorm.io/gorm"
 func scopesCallbackReuse(db *gorm.DB) {
 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
 		tx.Where("a").Find(nil) // first branch from tx
-		return tx.Where("b")    // want `\*gorm\.DB instance reused after chain method`
+		return tx.Where("b")    // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -29,7 +29,7 @@ func scopesCallbackReuse(db *gorm.DB) {
 func preloadCallbackReuse(db *gorm.DB) {
 	db.Preload("Orders", func(tx *gorm.DB) *gorm.DB {
 		tx.Where("a").Find(nil)
-		return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+		return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -37,7 +37,7 @@ func preloadCallbackReuse(db *gorm.DB) {
 // function; its *gorm.DB parameter is a mutable root too.
 func namedScope(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
-	return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func useNamedScope(db *gorm.DB) {

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -20,7 +20,7 @@ import "gorm.io/gorm"
 func scopesCallbackReuse(db *gorm.DB) {
 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
 		tx.Where("a").Find(nil) // first branch from tx
-		return tx.Where("b")    // want `\*gorm\.DB instance reused after chain method`
+		return tx.Where("b")    // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -29,7 +29,7 @@ func scopesCallbackReuse(db *gorm.DB) {
 func preloadCallbackReuse(db *gorm.DB) {
 	db.Preload("Orders", func(tx *gorm.DB) *gorm.DB {
 		tx.Where("a").Find(nil)
-		return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+		return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 	})
 }
 
@@ -37,7 +37,7 @@ func preloadCallbackReuse(db *gorm.DB) {
 // function; its *gorm.DB parameter is a mutable root too.
 func namedScope(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
-	return tx.Where("b") // want `\*gorm\.DB instance reused after chain method`
+	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 func useNamedScope(db *gorm.DB) {

--- a/testdata/src/noimport/grouped.go
+++ b/testdata/src/noimport/grouped.go
@@ -13,5 +13,5 @@ func violationWithGroupedImport() {
 	fmt.Println("test")
 	q := internal.GetDB()
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/noimport/grouped.go.golden
+++ b/testdata/src/noimport/grouped.go.golden
@@ -14,5 +14,5 @@ func violationWithGroupedImport() {
 	fmt.Println("test")
 	q := internal.GetDB().Session(&gorm.Session{})
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/noimport/noimport.go
+++ b/testdata/src/noimport/noimport.go
@@ -9,5 +9,5 @@ import internal "gormreuse"
 func violationWithoutGormImport() {
 	q := internal.GetDB()
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/noimport/noimport.go.golden
+++ b/testdata/src/noimport/noimport.go.golden
@@ -10,5 +10,5 @@ import "gorm.io/gorm"
 func violationWithoutGormImport() {
 	q := internal.GetDB().Session(&gorm.Session{})
 	q.Find(nil)
-	q.Count(nil) // want `\*gorm\.DB instance reused after chain method`
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }


### PR DESCRIPTION
Closes #76 (C3). The reuse diagnostic previously pointed only at the *second* branch with generic advice. It now names all three sites:

```
*gorm.DB reused: second branch from mutable root (root at foo.go:10, first branch at foo.go:12); make the root immutable with .Session(&gorm.Session{})
```

## Changes
- `pollution.Tracker.New` takes a `*token.FileSet` (from `fn.Prog.Fset`) and renders the **root position** (`root.Pos()`) and the **first-branch position** (earliest polluting use) as `base-name:line`. Positions are omitted if unknown / fset nil (defensive).
- Message construction stays in the tracker (one place); the analyzer just threads the FileSet through.
- Distinct diagnostic kinds keep their own specific messages — pure-contract (`pure function ...`) and unused-directive reports are unchanged and remain greppable.
- All reuse `// want` fixtures across **every** testdata package updated to the new base phrase (partial-match, so no hardcoded line numbers); `basic.go`'s first case asserts the full `(root at ...:\d+, first branch at ...:\d+)` format to lock it. Goldens/diffs regenerated.

## Out of scope (per #76, rejected from #22)
Multi-line art, `[CATEGORY]` prefixes, doc URLs — `go vet` output stays single-line.

## Testing
`go test ./...`, both e2e modules, `golangci-lint run ./...` all green.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv