### PR TITLE
fix: skip provably-dead closures to avoid false positives (#68 fix-direction-1)

### DIFF
--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -165,7 +165,9 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 					// Recurse into closures that capture *gorm.DB, and into
 					// Scopes/Preload callbacks (which operate on their mutable
 					// parameter rather than a captured variable — see #60).
-					if tracer.ClosureCapturesGormDB(mc) || a.rootTracer.IsScopesCallbackFunc(closureFn) {
+					// Skip provably-dead closures: their uses never execute, so
+					// analyzing them yields false positives (#68).
+					if (tracer.ClosureCapturesGormDB(mc) || a.rootTracer.IsScopesCallbackFunc(closureFn)) && !isDeadClosure(mc) {
 						a.processFunction(closureFn, tracker, visited)
 					}
 				}
@@ -202,4 +204,16 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 	for _, d := range defers {
 		handler.DispatchDefer(d, ctx)
 	}
+}
+
+// isDeadClosure reports whether mc's closure value is provably never used: it
+// has no referrers at all, so nothing can invoke it (e.g. `h := func(){...}; _ =
+// h`). Such a closure cannot run, so recording pollution from its body would
+// produce false positives — a captured value "reused" only inside an
+// unreachable closure is not actually reused (#68). Any referrer (a call, a Go/
+// Defer, a store that might escape) makes the closure potentially live, so it is
+// conservatively analyzed.
+func isDeadClosure(mc *ssa.MakeClosure) bool {
+	refs := mc.Referrers()
+	return refs == nil || len(*refs) == 0
 }

--- a/testdata/src/gormreuse/closure_exec_order.go
+++ b/testdata/src/gormreuse/closure_exec_order.go
@@ -1,0 +1,45 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// Closure execution-order cases (#68)
+// =============================================================================
+
+// ===== SHOULD NOT REPORT =====
+
+// deadClosure: a closure that is never invoked contributes no uses. Its body's
+// q.Count never executes, so q.Find is the only real use — clean. Before #68's
+// dead-closure fix this produced a false positive on the closure body.
+func deadClosure(db *gorm.DB) {
+	q := db.Where("x")
+	q.Find(nil)                        // the only use that executes
+	handler := func() { q.Count(nil) } // never called → provably dead (no referrers)
+	_ = handler
+}
+
+// deadClosureNeverAssigned: a bare, never-referenced closure literal is likewise
+// dead and must not contribute uses.
+func deadClosureNeverAssigned(db *gorm.DB) {
+	q := db.Where("x")
+	q.Find(nil)
+	_ = func() { q.Count(nil) } // dead
+}
+
+// ===== SHOULD REPORT =====
+
+// execOrderMismatch: the closure is defined before q.Count but EXECUTES after
+// (when later() runs). The reuse is real and is reported — but at q.Count rather
+// than the call site, because detection currently orders uses by source
+// position, not execution order.
+//
+// [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
+// ordering key for a closure's captured uses) is not yet implemented, so the
+// reported site is q.Count and the "first branch" in the message points at
+// q.Find inside the closure. The violation itself is correctly detected.
+func execOrderMismatch(db *gorm.DB) {
+	q := db.Where("x")
+	later := func() { q.Find(nil) } // executes last, via later()
+	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+	later()
+}

--- a/testdata/src/gormreuse/closure_exec_order.go.diff
+++ b/testdata/src/gormreuse/closure_exec_order.go.diff
@@ -1,0 +1,49 @@
+--- closure_exec_order.go	1970-01-01 00:00:00
++++ closure_exec_order.go.golden	1970-01-01 00:00:00
+@@ -1,45 +1,45 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // =============================================================================
+ // Closure execution-order cases (#68)
+ // =============================================================================
+ 
+ // ===== SHOULD NOT REPORT =====
+ 
+ // deadClosure: a closure that is never invoked contributes no uses. Its body's
+ // q.Count never executes, so q.Find is the only real use — clean. Before #68's
+ // dead-closure fix this produced a false positive on the closure body.
+ func deadClosure(db *gorm.DB) {
+ 	q := db.Where("x")
+ 	q.Find(nil)                        // the only use that executes
+ 	handler := func() { q.Count(nil) } // never called → provably dead (no referrers)
+ 	_ = handler
+ }
+ 
+ // deadClosureNeverAssigned: a bare, never-referenced closure literal is likewise
+ // dead and must not contribute uses.
+ func deadClosureNeverAssigned(db *gorm.DB) {
+ 	q := db.Where("x")
+ 	q.Find(nil)
+ 	_ = func() { q.Count(nil) } // dead
+ }
+ 
+ // ===== SHOULD REPORT =====
+ 
+ // execOrderMismatch: the closure is defined before q.Count but EXECUTES after
+ // (when later() runs). The reuse is real and is reported — but at q.Count rather
+ // than the call site, because detection currently orders uses by source
+ // position, not execution order.
+ //
+ // [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
+ // ordering key for a closure's captured uses) is not yet implemented, so the
+ // reported site is q.Count and the "first branch" in the message points at
+ // q.Find inside the closure. The violation itself is correctly detected.
+ func execOrderMismatch(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 	later := func() { q.Find(nil) } // executes last, via later()
+ 	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+ 	later()
+ }

--- a/testdata/src/gormreuse/closure_exec_order.go.golden
+++ b/testdata/src/gormreuse/closure_exec_order.go.golden
@@ -1,0 +1,45 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// Closure execution-order cases (#68)
+// =============================================================================
+
+// ===== SHOULD NOT REPORT =====
+
+// deadClosure: a closure that is never invoked contributes no uses. Its body's
+// q.Count never executes, so q.Find is the only real use — clean. Before #68's
+// dead-closure fix this produced a false positive on the closure body.
+func deadClosure(db *gorm.DB) {
+	q := db.Where("x")
+	q.Find(nil)                        // the only use that executes
+	handler := func() { q.Count(nil) } // never called → provably dead (no referrers)
+	_ = handler
+}
+
+// deadClosureNeverAssigned: a bare, never-referenced closure literal is likewise
+// dead and must not contribute uses.
+func deadClosureNeverAssigned(db *gorm.DB) {
+	q := db.Where("x")
+	q.Find(nil)
+	_ = func() { q.Count(nil) } // dead
+}
+
+// ===== SHOULD REPORT =====
+
+// execOrderMismatch: the closure is defined before q.Count but EXECUTES after
+// (when later() runs). The reuse is real and is reported — but at q.Count rather
+// than the call site, because detection currently orders uses by source
+// position, not execution order.
+//
+// [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
+// ordering key for a closure's captured uses) is not yet implemented, so the
+// reported site is q.Count and the "first branch" in the message points at
+// q.Find inside the closure. The violation itself is correctly detected.
+func execOrderMismatch(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+	later := func() { q.Find(nil) } // executes last, via later()
+	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
+	later()
+}


### PR DESCRIPTION
Fix-direction-1 of #68. A closure that is **never invoked** was still analyzed, so a captured `*gorm.DB` "reused" only inside that unreachable closure produced a false positive:

```go
q := db.Where("x")
q.Find(nil)                        // the only use that executes
handler := func() { q.Count(nil) } // never called
_ = handler                        // ← q.Count was wrongly flagged as reuse
```

`processFunction` now skips a closure whose `MakeClosure` has **no referrers at all** (`isDeadClosure`) — nothing can invoke it, so its body cannot run. Confirmed via SSA: the dead closure's MakeClosure has zero referrers, while a called one has a `*ssa.Call` referrer. Any referrer (call / go / defer / escaping store) keeps the closure conservatively analyzed, so **no false negatives** are introduced.

## Fixtures
- `deadClosure`, `deadClosureNeverAssigned` — now clean (regression lock).
- `execOrderMismatch` — documents the still-open exec-order case as a `[LIMITATION]`: the reuse is correctly *detected* but reported at `q.Count` rather than the call site, because detection orders uses by source position.

## Scope
Fix-direction-2 of #68 (order a closure's captured uses by the **call-site** position so define-early/call-late reuse is reported at the call site) is the harder half and **remains open** — #68 stays open. No regressions in the existing closure fixtures (evil.go / closure_loop.go / nested_chaos.go).

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv