### PR TITLE
fix: alias-aware Session qualifier in suggested fixes (#71 defect 3)

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -37,6 +37,15 @@ func TestSuggestedFixesWithImport(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, gormreuse.Analyzer, "noimport")
 }
 
+// TestSuggestedFixesWithAlias verifies the Session fix uses the file's local
+// name for gorm (g.Session) under an aliased import, so the output compiles
+// (issue #71, defect 3).
+func TestSuggestedFixesWithAlias(t *testing.T) {
+	t.Parallel()
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, gormreuse.Analyzer, "aliasimport")
+}
+
 func TestGenerateDiffFiles(t *testing.T) {
 	testdata := analysistest.TestData()
 	srcDir := filepath.Join(testdata, "src", "gormreuse")

--- a/internal/fix/generator.go
+++ b/internal/fix/generator.go
@@ -39,6 +39,7 @@ import (
 	"go/ast"
 	"go/token"
 	"sort"
+	"strconv"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/astutil"
@@ -361,11 +362,43 @@ func (g *Generator) generateSessionEdit(pos token.Pos) *analysis.TextEdit {
 		return nil
 	}
 
+	// Qualify Session with the file's actual local name for gorm.io/gorm so the
+	// fix compiles under an aliased or dot import (issue #71, defect 3).
+	qualifier := "gorm."
+	if file := g.findFileContaining(pos); file != nil {
+		qualifier = gormQualifier(file)
+	}
+
 	return &analysis.TextEdit{
 		Pos:     endPos,
 		End:     endPos,
-		NewText: []byte(".Session(&gorm.Session{})"),
+		NewText: []byte(".Session(&" + qualifier + "Session{})"),
 	}
+}
+
+// gormQualifier returns the selector prefix for referring to gorm types in file:
+// "gorm." for a normal import, "<alias>." for an aliased import, or "" for a
+// dot-import. It defaults to "gorm." when gorm is not imported (an import edit is
+// added separately by generateGormImportEdit).
+func gormQualifier(file *ast.File) string {
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != gormImportPath {
+			continue
+		}
+		if imp.Name == nil {
+			return "gorm." // normal import; gorm.io/gorm's package name is "gorm"
+		}
+		switch imp.Name.Name {
+		case ".":
+			return "" // dot-import: reference Session unqualified
+		case "_":
+			return "gorm." // blank import provides no usable name; treat as absent
+		default:
+			return imp.Name.Name + "." // aliased import
+		}
+	}
+	return "gorm."
 }
 
 // generateSessionEditsForRoot generates Session edits, handling Phi nodes specially.

--- a/internal/fix/generator_test.go
+++ b/internal/fix/generator_test.go
@@ -2,8 +2,40 @@ package fix
 
 import (
 	"go/parser"
+	"go/token"
 	"testing"
 )
+
+// TestGormQualifier covers the alias-aware qualifier used when emitting the
+// Session fix (issue #71, defect 3).
+func TestGormQualifier(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"normal", `package p; import "gorm.io/gorm"; var _ = gorm.DB{}`, "gorm."},
+		{"aliased", `package p; import g "gorm.io/gorm"; var _ = g.DB{}`, "g."},
+		{"dot", `package p; import . "gorm.io/gorm"; var _ = DB{}`, ""},
+		{"blank", `package p; import _ "gorm.io/gorm"`, "gorm."},
+		{"not imported", `package p; var x int`, "gorm."},
+		{"other alias", `package p; import orm "gorm.io/gorm"; var _ = orm.DB{}`, "orm."},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f, err := parser.ParseFile(token.NewFileSet(), "x.go", tc.src, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := gormQualifier(f); got != tc.want {
+				t.Errorf("gormQualifier() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
 
 // TestExtractAssignableLHS covers extractAssignableLHSImpl, which reconstructs
 // the assignable left-hand side of an expression (used when rewriting a reused

--- a/testdata/src/aliasimport/aliasimport.go
+++ b/testdata/src/aliasimport/aliasimport.go
@@ -1,0 +1,12 @@
+// Package aliasimport tests that suggested fixes compile when gorm is imported
+// under an alias: the inserted Session must use the local name (g.Session),
+// not a hardcoded gorm.Session (issue #71, defect 3).
+package aliasimport
+
+import g "gorm.io/gorm"
+
+func aliasedReuse(db *g.DB) {
+	q := db.Where("x")
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+}

--- a/testdata/src/aliasimport/aliasimport.go.golden
+++ b/testdata/src/aliasimport/aliasimport.go.golden
@@ -1,0 +1,12 @@
+// Package aliasimport tests that suggested fixes compile when gorm is imported
+// under an alias: the inserted Session must use the local name (g.Session),
+// not a hardcoded gorm.Session (issue #71, defect 3).
+package aliasimport
+
+import g "gorm.io/gorm"
+
+func aliasedReuse(db *g.DB) {
+	q := db.Where("x").Session(&g.Session{})
+	q.Find(nil)
+	q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+}


### PR DESCRIPTION
Defect 3 of #71. Under an **aliased** gorm import the generator emitted a hardcoded `.Session(&gorm.Session{})`, but `gorm` is not in scope — the fixed code failed to compile (`undefined: gorm`). `generateGormImportEdit` didn't add an import either, since `astutil.UsesImport` is satisfied by the alias.

`generateSessionEdit` now resolves the file's local name for `gorm.io/gorm` via a new `gormQualifier` helper:
| import form | emitted |
|---|---|
| `import "gorm.io/gorm"` | `gorm.Session` |
| `import g "gorm.io/gorm"` | `g.Session` |
| `import . "gorm.io/gorm"` | `Session` (unqualified) |
| not imported | `gorm.Session` (+ existing import edit) |

All Session insertions route through `generateSessionEdit` (including Phi-edge edits), so this one change covers every path.

## Fixtures
- New `testdata/src/aliasimport` package + golden: the fix compiles as `g.Session`.
- `TestSuggestedFixesWithAlias` (golden lock) + a `gormQualifier` unit test (normal/aliased/dot/blank/absent).

## Scope
Defects **1** (wrong-variable rewrite — key the fix to the violation root) and **2** (non-convergent: Session never emitted for virtual/field roots), plus the convergence-harness upgrade, remain — **#71 stays open**. Those are the deeper structural fixes.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv