### PR TITLE
fix: treat FirstOrCreate/FirstOrInit as finishers in fix generation (#71 secondary)

### DIFF
--- a/internal/fix/generator.go
+++ b/internal/fix/generator.go
@@ -255,23 +255,25 @@ func (g *Generator) isNonFinisherExprStmt(pos token.Pos) bool {
 // isFinisher checks if a method name is a GORM finisher method.
 func isFinisher(methodName string) bool {
 	finishers := map[string]bool{
-		"Find":        true,
-		"First":       true,
-		"Last":        true,
-		"Take":        true,
-		"Count":       true,
-		"Pluck":       true,
-		"Scan":        true,
-		"Row":         true,
-		"Rows":        true,
-		"ScanRows":    true,
-		"Create":      true,
-		"Save":        true,
-		"Update":      true,
-		"Updates":     true,
-		"Delete":      true,
-		"Exec":        true,
-		"Transaction": true,
+		"Find":          true,
+		"First":         true,
+		"Last":          true,
+		"Take":          true,
+		"Count":         true,
+		"Pluck":         true,
+		"Scan":          true,
+		"Row":           true,
+		"Rows":          true,
+		"ScanRows":      true,
+		"Create":        true,
+		"Save":          true,
+		"Update":        true,
+		"Updates":       true,
+		"Delete":        true,
+		"Exec":          true,
+		"Transaction":   true,
+		"FirstOrCreate": true, // terminal (executes); #71 secondary
+		"FirstOrInit":   true, // terminal (executes); #71 secondary
 	}
 	return finishers[methodName]
 }

--- a/testdata/src/gormreuse/firstorcreate.go
+++ b/testdata/src/gormreuse/firstorcreate.go
@@ -1,0 +1,13 @@
+package internal
+
+import "gorm.io/gorm"
+
+// firstOrCreateReuse: FirstOrCreate/FirstOrInit are terminal finishers (they
+// execute). Reusing the root across two of them is a violation whose fix makes
+// the ROOT immutable — the finishers must NOT be rewritten into reassignments
+// (#71 secondary: they were missing from the finisher allow-list).
+func firstOrCreateReuse(db *gorm.DB) {
+	q := db.Where("x")
+	q.FirstOrCreate(&User{})
+	q.FirstOrInit(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
+}

--- a/testdata/src/gormreuse/firstorcreate.go.diff
+++ b/testdata/src/gormreuse/firstorcreate.go.diff
@@ -1,0 +1,17 @@
+--- firstorcreate.go	1970-01-01 00:00:00
++++ firstorcreate.go.golden	1970-01-01 00:00:00
+@@ -1,13 +1,13 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // firstOrCreateReuse: FirstOrCreate/FirstOrInit are terminal finishers (they
+ // execute). Reusing the root across two of them is a violation whose fix makes
+ // the ROOT immutable — the finishers must NOT be rewritten into reassignments
+ // (#71 secondary: they were missing from the finisher allow-list).
+ func firstOrCreateReuse(db *gorm.DB) {
+-	q := db.Where("x")
++	q := db.Where("x").Session(&gorm.Session{})
+ 	q.FirstOrCreate(&User{})
+ 	q.FirstOrInit(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
+ }

--- a/testdata/src/gormreuse/firstorcreate.go.golden
+++ b/testdata/src/gormreuse/firstorcreate.go.golden
@@ -1,0 +1,13 @@
+package internal
+
+import "gorm.io/gorm"
+
+// firstOrCreateReuse: FirstOrCreate/FirstOrInit are terminal finishers (they
+// execute). Reusing the root across two of them is a violation whose fix makes
+// the ROOT immutable — the finishers must NOT be rewritten into reassignments
+// (#71 secondary: they were missing from the finisher allow-list).
+func firstOrCreateReuse(db *gorm.DB) {
+	q := db.Where("x").Session(&gorm.Session{})
+	q.FirstOrCreate(&User{})
+	q.FirstOrInit(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
+}


### PR DESCRIPTION
`isFinisher` secondary item of #71. `FirstOrCreate`/`FirstOrInit` are terminal (they execute) but were missing from the allow-list, so a reuse ending in them had the finisher rewritten into a reassignment (`q = q.FirstOrCreate(...)`) instead of the fix targeting the root. Added both.

Fixture `firstorcreate.go` locks the correct output: the fix makes the root immutable (`q := db.Where("x").Session(&gorm.Session{})`) and leaves the two finishers untouched.

## Scope
The three primary defects of #71 (defect 1 wrong-variable rewrite; defect 2 non-convergent Session for virtual/field roots; the apply+build+re-lint convergence harness) **remain** — they entangle (defect 2 alone appends Session to defect 1's wrong rewrites, and single-pass golden diffs can't verify convergence) and must land together with the harness. **#71 stays open.**

## Testing
`go test ./...`, both e2e modules, `golangci-lint` green.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv