### PR TITLE
fix: order closure captured-uses by call-site position (#68 fix-direction-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,8 @@ When refactoring code, follow these rules strictly:
 
 These are documented in `testdata/src/gormreuse/evil.go` with `[LIMITATION]` markers.
 
+**Closure use ordering (#68)**: uses inside a closure that is invoked at a *single* later call site (`f := func() { q.Find(nil) }; …; f()`) are ordered by that **call-site position**, not the closure body's source position — so define-early/call-late reuse is reported at the call site and the earlier direct use is correctly treated as the first branch. This applies only to the unambiguous single-invocation case; IIFEs (invoked inline), deferred/spawned closures, and closures invoked from multiple sites keep their body positions.
+
 ### IIFE/Closure Stored Result Limitation
 
 When a closure result is stored (in a variable or struct field) rather than directly chained to a gorm method, branch tracking may differ from runtime behavior:

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -34,6 +34,7 @@
 package ssa
 
 import (
+	"go/ast"
 	"go/token"
 
 	"golang.org/x/tools/go/ssa"
@@ -109,7 +110,7 @@ func (a *Analyzer) Analyze() []Violation {
 
 	// PHASE 1: TRACKING
 	// Process all instructions and record usages
-	a.processFunction(a.fn, tracker, make(map[*ssa.Function]bool))
+	a.processFunction(a.fn, tracker, make(map[*ssa.Function]bool), token.NoPos)
 
 	// PHASE 2: DETECTION
 	// Detect violations using CFG reachability
@@ -130,7 +131,12 @@ func (a *Analyzer) Analyze() []Violation {
 //     - Defers are processed last because they execute at function exit
 //
 // The visited map prevents infinite recursion for mutually recursive closures.
-func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker, visited map[*ssa.Function]bool) {
+//
+// posOverride, when valid, is the call-site position at which fn (a closure) is
+// invoked; uses recorded while analyzing fn adopt it instead of their body
+// position, so define-early/call-late reuse orders by execution, not source,
+// position (#68).
+func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker, visited map[*ssa.Function]bool, posOverride token.Pos) {
 	if fn == nil || fn.Blocks == nil {
 		return
 	}
@@ -144,11 +150,12 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 
 	// Create handler context shared across all instruction handlers
 	ctx := &handler.Context{
-		Tracker:    tracker,
-		RootTracer: a.rootTracer,
-		CFG:        a.cfgAnalyzer,
-		LoopInfo:   loopInfo,
-		CurrentFn:  fn,
+		Tracker:     tracker,
+		RootTracer:  a.rootTracer,
+		CFG:         a.cfgAnalyzer,
+		LoopInfo:    loopInfo,
+		CurrentFn:   fn,
+		PosOverride: posOverride,
 	}
 
 	// Collect defers and go statements for second pass
@@ -168,7 +175,15 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 					// Skip provably-dead closures: their uses never execute, so
 					// analyzing them yields false positives (#68).
 					if (tracer.ClosureCapturesGormDB(mc) || a.rootTracer.IsScopesCallbackFunc(closureFn)) && !isDeadClosure(mc) {
-						a.processFunction(closureFn, tracker, visited)
+						// If the closure is invoked at a single call site, order
+						// its captured uses by that call-site position (#68). When
+						// there is no single such site (IIFE, defer/go, multiple
+						// or no invocations), inherit the enclosing override.
+						childOverride := posOverride
+						if p := closureInvocationPos(mc, a.fset()); p.IsValid() {
+							childOverride = p
+						}
+						a.processFunction(closureFn, tracker, visited, childOverride)
 					}
 				}
 				continue
@@ -216,4 +231,60 @@ func (a *Analyzer) processFunction(fn *ssa.Function, tracker *pollution.Tracker,
 func isDeadClosure(mc *ssa.MakeClosure) bool {
 	refs := mc.Referrers()
 	return refs == nil || len(*refs) == 0
+}
+
+// closureInvocationPos returns the source position at which the closure value
+// mc is invoked, but ONLY for the define-early/call-late case that #68 targets:
+// a closure invoked by exactly one plain call whose call site is on a LATER line
+// than the closure literal's end (i.e. `f := func(){...}; …; f()`). It returns
+// token.NoPos otherwise — an IIFE (invoked on its own closing-brace line), a
+// deferred/spawned closure, a closure passed as an argument or stored, or one
+// invoked more than once — so those keep their body positions unchanged.
+func closureInvocationPos(mc *ssa.MakeClosure, fset *token.FileSet) token.Pos {
+	if fset == nil {
+		return token.NoPos
+	}
+	refs := mc.Referrers()
+	if refs == nil {
+		return token.NoPos
+	}
+	found := token.NoPos
+	for _, r := range *refs {
+		call, ok := r.(*ssa.Call)
+		if !ok || call.Call.Value != ssa.Value(mc) {
+			// A non-call referrer (store, defer, go, arg) makes the invocation
+			// site ambiguous; bail out to the safe (no-override) behavior.
+			return token.NoPos
+		}
+		if found.IsValid() {
+			return token.NoPos // more than one call site
+		}
+		found = call.Pos()
+	}
+	if !found.IsValid() {
+		return token.NoPos
+	}
+
+	// Distinguish define-early/call-late from an inline IIFE: the former's call
+	// is on a later line than the closure literal's closing brace.
+	closureFn, ok := mc.Fn.(*ssa.Function)
+	if !ok {
+		return token.NoPos
+	}
+	lit, ok := closureFn.Syntax().(*ast.FuncLit)
+	if !ok {
+		return token.NoPos
+	}
+	if fset.Position(found).Line <= fset.Position(lit.End()).Line {
+		return token.NoPos // IIFE / same-line invocation: keep body positions
+	}
+	return found
+}
+
+// fset returns the program's FileSet (nil if unavailable).
+func (a *Analyzer) fset() *token.FileSet {
+	if a.fn != nil && a.fn.Prog != nil {
+		return a.fn.Prog.Fset
+	}
+	return nil
 }

--- a/internal/ssa/handler/call.go
+++ b/internal/ssa/handler/call.go
@@ -57,6 +57,22 @@ type Context struct {
 	CFG        *cfg.Analyzer      // Control flow graph analysis
 	LoopInfo   *cfg.LoopInfo      // Loop detection results for current function
 	CurrentFn  *ssa.Function      // The function being analyzed
+
+	// PosOverride, when valid, replaces the source position recorded for uses
+	// inside this function. It is set when analyzing a closure that is invoked
+	// at a single known call site, so the closure's captured-value uses are
+	// ordered by the call-site (execution) position rather than the closure's
+	// (earlier) body position — the define-early/call-late case of #68.
+	PosOverride token.Pos
+}
+
+// pos returns the effective source position to record for a use: the
+// PosOverride when set (closure analyzed at its call site), otherwise raw.
+func (c *Context) pos(raw token.Pos) token.Pos {
+	if c.PosOverride.IsValid() {
+		return c.PosOverride
+	}
+	return raw
 }
 
 // CallHandler handles *ssa.Call instructions.
@@ -203,20 +219,23 @@ func (h *CallHandler) Handle(call *ssa.Call, ctx *Context) {
 	}
 
 	// KEY CHANGE: Process ALL calls uniformly (no isTerminal skip)
-	// Record usage (violations detected later in DetectViolations)
+	// Record usage (violations detected later in DetectViolations).
+	// pos is the effective position (call-site override inside an invoked
+	// closure, else the call's own position) — see Context.pos / #68.
+	pos := ctx.pos(call.Pos())
 	if isImmutableReturning {
 		// Pure methods check for pollution but don't pollute
-		ctx.Tracker.RecordPureUse(root, call.Block(), call.Pos())
+		ctx.Tracker.RecordPureUse(root, call.Block(), pos)
 	} else if isAssignment(call, ctx) {
 		// Assignment creates new root - record but doesn't pollute
-		ctx.Tracker.RecordAssignment(root, call.Block(), call.Pos())
+		ctx.Tracker.RecordAssignment(root, call.Block(), pos)
 	} else {
 		// Actual use - pollutes the root
-		ctx.Tracker.ProcessBranch(root, call.Block(), call.Pos())
+		ctx.Tracker.ProcessBranch(root, call.Block(), pos)
 
 		// Loop with external root - immediate violation (only for non-pure methods)
 		if isInLoop && ctx.CFG.IsDefinedOutsideLoop(root, ctx.LoopInfo) {
-			ctx.Tracker.AddViolationWithRoot(call.Pos(), root)
+			ctx.Tracker.AddViolationWithRoot(pos, root)
 		}
 	}
 
@@ -227,7 +246,7 @@ func (h *CallHandler) Handle(call *ssa.Call, ctx *Context) {
 			continue
 		}
 		if ctx.Tracker.IsPollutedAt(r, call.Block()) {
-			ctx.Tracker.AddViolationWithRoot(call.Pos(), r)
+			ctx.Tracker.AddViolationWithRoot(pos, r)
 		}
 	}
 }
@@ -265,24 +284,26 @@ func (h *CallHandler) processBoundMethodCall(call *ssa.Call, mc *ssa.MakeClosure
 	// Get ALL possible roots BEFORE recording usage (needed for pollution check)
 	allRoots := ctx.RootTracer.FindAllMutableRoots(recv, ctx.LoopInfo)
 
+	pos := ctx.pos(call.Pos())
+
 	// Check if ANY root was already polluted BEFORE this call
 	for _, r := range allRoots {
 		if ctx.Tracker.IsPollutedAt(r, call.Block()) {
-			ctx.Tracker.AddViolationWithRoot(call.Pos(), r)
+			ctx.Tracker.AddViolationWithRoot(pos, r)
 		}
 	}
 
 	// Record usage (violations detected later)
 	if isImmutableReturning {
 		// Pure methods check for pollution but don't pollute
-		ctx.Tracker.RecordPureUse(root, call.Block(), call.Pos())
+		ctx.Tracker.RecordPureUse(root, call.Block(), pos)
 	} else {
 		// Non-pure methods pollute the root
-		ctx.Tracker.ProcessBranch(root, call.Block(), call.Pos())
+		ctx.Tracker.ProcessBranch(root, call.Block(), pos)
 
 		// Loop with external root - immediate violation (only for non-pure methods)
 		if isInLoop && ctx.CFG.IsDefinedOutsideLoop(root, ctx.LoopInfo) {
-			ctx.Tracker.AddViolationWithRoot(call.Pos(), root)
+			ctx.Tracker.AddViolationWithRoot(pos, root)
 		}
 	}
 }
@@ -337,10 +358,10 @@ func (h *CallHandler) checkFunctionCallPollution(call *ssa.Call, ctx *Context) {
 		if isReassignment {
 			// For reassignment pattern: check if already polluted, but don't add pollution.
 			// This is similar to how gorm methods handle RecordAssignment.
-			ctx.Tracker.RecordAssignment(root, call.Block(), call.Pos())
+			ctx.Tracker.RecordAssignment(root, call.Block(), ctx.pos(call.Pos()))
 		} else {
 			// Mark polluted (function may use the value)
-			ctx.Tracker.MarkPolluted(root, call.Block(), call.Pos())
+			ctx.Tracker.MarkPolluted(root, call.Block(), ctx.pos(call.Pos()))
 		}
 	}
 }
@@ -397,7 +418,7 @@ func (h *SendHandler) Handle(send *ssa.Send, ctx *Context) {
 		return
 	}
 
-	ctx.Tracker.MarkPolluted(root, send.Block(), send.Pos())
+	ctx.Tracker.MarkPolluted(root, send.Block(), ctx.pos(send.Pos()))
 }
 
 // StoreHandler handles *ssa.Store instructions.
@@ -419,7 +440,7 @@ func (h *StoreHandler) Handle(store *ssa.Store, ctx *Context) {
 		return
 	}
 
-	ctx.Tracker.MarkPolluted(root, store.Block(), store.Pos())
+	ctx.Tracker.MarkPolluted(root, store.Block(), ctx.pos(store.Pos()))
 }
 
 // MapUpdateHandler handles *ssa.MapUpdate instructions.
@@ -438,7 +459,7 @@ func (h *MapUpdateHandler) Handle(mapUpdate *ssa.MapUpdate, ctx *Context) {
 		return
 	}
 
-	ctx.Tracker.MarkPolluted(root, mapUpdate.Block(), mapUpdate.Pos())
+	ctx.Tracker.MarkPolluted(root, mapUpdate.Block(), ctx.pos(mapUpdate.Pos()))
 }
 
 // MakeInterfaceHandler handles *ssa.MakeInterface instructions.

--- a/testdata/src/gormreuse/closure_exec_order.go
+++ b/testdata/src/gormreuse/closure_exec_order.go
@@ -29,17 +29,13 @@ func deadClosureNeverAssigned(db *gorm.DB) {
 // ===== SHOULD REPORT =====
 
 // execOrderMismatch: the closure is defined before q.Count but EXECUTES after
-// (when later() runs). The reuse is real and is reported — but at q.Count rather
-// than the call site, because detection currently orders uses by source
-// position, not execution order.
-//
-// [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
-// ordering key for a closure's captured uses) is not yet implemented, so the
-// reported site is q.Count and the "first branch" in the message points at
-// q.Find inside the closure. The violation itself is correctly detected.
+// (when later() runs). Because a closure invoked at a single later call site now
+// orders its captured uses by that call-site position (#68 fix-direction-2), the
+// reuse is reported at later() — the execution site — with q.Count correctly
+// treated as the (safe) first branch, not misreported.
 func execOrderMismatch(db *gorm.DB) {
 	q := db.Where("x")
 	later := func() { q.Find(nil) } // executes last, via later()
-	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
-	later()
+	q.Count(nil)                    // first branch (executes first) - OK
+	later()                         // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/closure_exec_order.go.diff
+++ b/testdata/src/gormreuse/closure_exec_order.go.diff
@@ -1,6 +1,6 @@
 --- closure_exec_order.go	1970-01-01 00:00:00
 +++ closure_exec_order.go.golden	1970-01-01 00:00:00
-@@ -1,45 +1,45 @@
+@@ -1,41 +1,41 @@
  package internal
  
  import "gorm.io/gorm"
@@ -32,18 +32,14 @@
  // ===== SHOULD REPORT =====
  
  // execOrderMismatch: the closure is defined before q.Count but EXECUTES after
- // (when later() runs). The reuse is real and is reported — but at q.Count rather
- // than the call site, because detection currently orders uses by source
- // position, not execution order.
- //
- // [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
- // ordering key for a closure's captured uses) is not yet implemented, so the
- // reported site is q.Count and the "first branch" in the message points at
- // q.Find inside the closure. The violation itself is correctly detected.
+ // (when later() runs). Because a closure invoked at a single later call site now
+ // orders its captured uses by that call-site position (#68 fix-direction-2), the
+ // reuse is reported at later() — the execution site — with q.Count correctly
+ // treated as the (safe) first branch, not misreported.
  func execOrderMismatch(db *gorm.DB) {
 -	q := db.Where("x")
 +	q := db.Where("x").Session(&gorm.Session{})
  	later := func() { q.Find(nil) } // executes last, via later()
- 	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
- 	later()
+ 	q.Count(nil)                    // first branch (executes first) - OK
+ 	later()                         // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/closure_exec_order.go.golden
+++ b/testdata/src/gormreuse/closure_exec_order.go.golden
@@ -29,17 +29,13 @@ func deadClosureNeverAssigned(db *gorm.DB) {
 // ===== SHOULD REPORT =====
 
 // execOrderMismatch: the closure is defined before q.Count but EXECUTES after
-// (when later() runs). The reuse is real and is reported — but at q.Count rather
-// than the call site, because detection currently orders uses by source
-// position, not execution order.
-//
-// [LIMITATION] fix-direction-2 of #68 (use the call-site position as the
-// ordering key for a closure's captured uses) is not yet implemented, so the
-// reported site is q.Count and the "first branch" in the message points at
-// q.Find inside the closure. The violation itself is correctly detected.
+// (when later() runs). Because a closure invoked at a single later call site now
+// orders its captured uses by that call-site position (#68 fix-direction-2), the
+// reuse is reported at later() — the execution site — with q.Count correctly
+// treated as the (safe) first branch, not misreported.
 func execOrderMismatch(db *gorm.DB) {
 	q := db.Where("x").Session(&gorm.Session{})
 	later := func() { q.Find(nil) } // executes last, via later()
-	q.Count(nil)                    // want `\*gorm\.DB reused: second branch from mutable root`
-	later()
+	q.Count(nil)                    // first branch (executes first) - OK
+	later()                         // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -3043,9 +3043,9 @@ func closureCapturesPhi(db *gorm.DB, cond bool) {
 	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
 
 	fn := func() {
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureCaputresPhiOnePolluted demonstrates closure with Phi where only one branch is polluted.
@@ -3066,9 +3066,9 @@ func closureCaputresPhiOnePolluted(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q1
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureCaputresPhiOnePollutedReverse demonstrates the reverse ordering.
@@ -3088,9 +3088,9 @@ func closureCaputresPhiOnePollutedReverse(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q2
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -3219,9 +3219,9 @@
  	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
  
  	fn := func() {
- 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.Count(nil)
  	}
- 	fn()
+ 	fn() // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // closureCaputresPhiOnePolluted demonstrates closure with Phi where only one branch is polluted.
@@ -3242,9 +3242,9 @@
  	fn := func() {
  		// FreeVar captures the Phi
  		// Should detect pollution from q1
- 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.Count(nil)
  	}
- 	fn()
+ 	fn() // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // closureCaputresPhiOnePollutedReverse demonstrates the reverse ordering.
@@ -3264,9 +3264,9 @@
  	fn := func() {
  		// FreeVar captures the Phi
  		// Should detect pollution from q2
- 		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+ 		q.Count(nil)
  	}
- 	fn()
+ 	fn() // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -3043,9 +3043,9 @@ func closureCapturesPhi(db *gorm.DB, cond bool) {
 	q.Find(nil) // Pollute (both branches get polluted because Phi merges them)
 
 	fn := func() {
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureCaputresPhiOnePolluted demonstrates closure with Phi where only one branch is polluted.
@@ -3066,9 +3066,9 @@ func closureCaputresPhiOnePolluted(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q1
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // closureCaputresPhiOnePollutedReverse demonstrates the reverse ordering.
@@ -3088,9 +3088,9 @@ func closureCaputresPhiOnePollutedReverse(db *gorm.DB, cond bool) {
 	fn := func() {
 		// FreeVar captures the Phi
 		// Should detect pollution from q2
-		q.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
+		q.Count(nil)
 	}
-	fn()
+	fn() // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #68 (fix-direction-2; direction-1 was #101).

A closure invoked at a single later call site (`f := func() { q.Find(nil) }; …; f()`) recorded its captured `*gorm.DB` uses at the **closure body** position, so define-early/call-late reuse was ordered by *source* position, not execution order: the safe direct use (`q.Count`) was reported as the violation and the real reuse (`q.Find`, executed via `f()`) was mislabeled the "first branch".

## Fix
When a closure is invoked at exactly one plain call site whose line is **later than the closure literal's end** (the unambiguous define-early/call-late shape), its uses adopt the call-site position:
- `handler.Context.PosOverride` — effective position for recorded uses; `Context.pos()` applies it across the recording sites.
- `processFunction` threads the override; `closureInvocationPos` computes the single call site and gates on the later-line check.

The reuse is now reported at the call site, with the earlier direct use correctly the first branch.

## Deliberately narrow
IIFEs (invoked on their closing-brace line), deferred/spawned closures, closures passed as args, and closures invoked from multiple sites **keep their body positions** — verified by the line-check excluding all IIFE/defer fixtures (initial broad version churned 8 sites; narrowed to the 4 genuine define-early/call-late cases).

## Fixtures
- `execOrderMismatch` flipped from a `[LIMITATION]` to a passing SHOULD-REPORT at `later()`.
- Three `evil.go` `closureCaptures*` cases now report at `fn()`.
- CLAUDE.md documents the ordering model.

## Testing
`go test ./...`, both e2e modules, `golangci-lint` green.

With #101, **#68 is complete**. Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv