### PR TITLE
feat: recognize //gormreuse:immutable-param directive (Phase 1b stage 1, #61)

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -76,6 +76,7 @@ func run(pass *analysis.Pass) (any, error) {
 	funcIgnores := make(map[string]map[token.Pos]directive.FunctionIgnoreEntry)
 	pureFuncs := directive.NewPureFuncSet(pass.Fset, pass.TypesInfo)
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(pass.Fset, pass.TypesInfo)
+	immutableParamFuncs := directive.NewImmutableParamFuncSet(pass.Fset, pass.TypesInfo)
 
 	pkgPath := pass.Pkg.Path()
 	for _, file := range pass.Files {
@@ -89,6 +90,7 @@ func run(pass *analysis.Pass) (any, error) {
 		// Add original file to sets (for position-correct directive detection)
 		pureFuncs.AddFile(file)
 		immutableReturnFuncs.AddFile(file)
+		immutableParamFuncs.AddFile(file)
 
 		// Build pure function set for this file
 		for key := range directive.BuildPureFunctionSet(file, pkgPath) {
@@ -98,10 +100,14 @@ func run(pass *analysis.Pass) (any, error) {
 		for key := range directive.BuildImmutableReturnFunctionSet(file, pkgPath) {
 			immutableReturnFuncs.Add(key)
 		}
+		// Build immutable-param function set for this file
+		for key := range directive.BuildImmutableParamFunctionSet(file, pkgPath) {
+			immutableParamFuncs.Add(key)
+		}
 	}
 
 	// Run SSA-based analysis
-	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, skipFiles)
+	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, immutableParamFuncs, skipFiles)
 
 	return nil, nil
 }

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -72,7 +72,7 @@ func RunSSA(
 	ssaInfo *buildssa.SSA,
 	ignoreMaps map[string]directive.IgnoreMap,
 	funcIgnores map[string]map[token.Pos]directive.FunctionIgnoreEntry,
-	pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet,
+	pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet,
 	skipFiles map[string]bool,
 ) {
 	// Share a single reported map across all functions to deduplicate
@@ -163,29 +163,38 @@ func RunSSA(
 		}
 	}
 
-	// Report unused pure directives
-	// For combined directives (e.g., //gormreuse:pure,immutable-return),
-	// if either part is used, don't report the other as unused
-	if pureFuncs != nil {
-		for _, pos := range pureFuncs.GetUnusedDirectives() {
-			// Skip if used by immutable-return (combined directive)
-			if immutableReturnFuncs != nil && immutableReturnFuncs.IsUsed(pos) {
+	reportUnusedDirectiveFuncs(pass, pureFuncs, immutableReturnFuncs, immutableParamFuncs)
+}
+
+// reportUnusedDirectiveFuncs reports pure / immutable-return / immutable-param
+// directives that matched no valid function. For combined directives (e.g.
+// //gormreuse:pure,immutable-return,immutable-param) a directive at a position
+// is "used" if ANY of its combined siblings is used, so each set is suppressed
+// when another set reports that position as used.
+func reportUnusedDirectiveFuncs(pass *analysis.Pass, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet) {
+	usedByOther := func(pos token.Pos, others ...*directive.DirectiveFuncSet) bool {
+		for _, s := range others {
+			if s != nil && s.IsUsed(pos) {
+				return true
+			}
+		}
+		return false
+	}
+	report := func(set *directive.DirectiveFuncSet, message string, others ...*directive.DirectiveFuncSet) {
+		if set == nil {
+			return
+		}
+		for _, pos := range set.GetUnusedDirectives() {
+			if usedByOther(pos, others...) {
 				continue
 			}
-			pass.Reportf(pos, "unused gormreuse:pure directive")
+			pass.Reportf(pos, "%s", message)
 		}
 	}
 
-	// Report unused immutable-return directives
-	if immutableReturnFuncs != nil {
-		for _, pos := range immutableReturnFuncs.GetUnusedDirectives() {
-			// Skip if used by pure (combined directive)
-			if pureFuncs != nil && pureFuncs.IsUsed(pos) {
-				continue
-			}
-			pass.Reportf(pos, "unused gormreuse:immutable-return directive")
-		}
-	}
+	report(pureFuncs, "unused gormreuse:pure directive", immutableReturnFuncs, immutableParamFuncs)
+	report(immutableReturnFuncs, "unused gormreuse:immutable-return directive", pureFuncs, immutableParamFuncs)
+	report(immutableParamFuncs, "unused gormreuse:immutable-param directive", pureFuncs, immutableReturnFuncs)
 }
 
 // recoverPerFunction runs work, recovering from any panic so that a single

--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -105,3 +105,9 @@ func IsPureDirective(text string) bool { return hasDirective(text, "pure") }
 // IsImmutableReturnDirective checks if a comment contains the immutable-return directive.
 // Functions with this directive return immutable *gorm.DB (like Session, WithContext).
 func IsImmutableReturnDirective(text string) bool { return hasDirective(text, "immutable-return") }
+
+// IsImmutableParamDirective checks if a comment contains the immutable-param directive.
+// Functions with this directive assert that their callers guarantee forkable
+// (clone>0) *gorm.DB arguments, so the parameter can be reused safely. It is the
+// escape hatch for the default-mutable parameter treatment (Phase 1b, #61).
+func IsImmutableParamDirective(text string) bool { return hasDirective(text, "immutable-param") }

--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -62,6 +62,36 @@ func TestIsPureDirective(t *testing.T) {
 	}
 }
 
+func TestIsImmutableParamDirective(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		text     string
+		expected bool
+	}{
+		{"exact match", "//gormreuse:immutable-param", true},
+		{"with space", "// gormreuse:immutable-param", true},
+		{"block comment", "/*gormreuse:immutable-param*/", true},
+		{"combined with pure", "//gormreuse:pure,immutable-param", true},
+		{"combined with immutable-return", "//gormreuse:immutable-return,immutable-param", true},
+		{"trailing comment", "//gormreuse:immutable-param // callers pass root handles", true},
+		{"not a prefix of immutable-return", "//gormreuse:immutable-return", false},
+		{"wrong directive", "//gormreuse:pure", false},
+		{"random comment", "// some comment", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsImmutableParamDirective(tt.text); got != tt.expected {
+				t.Errorf("IsImmutableParamDirective(%q) = %v, want %v", tt.text, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIgnoreMapShouldIgnore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/directive/pure.go
+++ b/internal/directive/pure.go
@@ -991,6 +991,14 @@ func NewImmutableReturnFuncSet(fset *token.FileSet, typesInfo *types.Info) *Dire
 	return newDirectiveFuncSet(fset, typesInfo, IsImmutableReturnDirective, hasGormDBReturn)
 }
 
+// NewImmutableParamFuncSet creates a DirectiveFuncSet for //gormreuse:immutable-param.
+// Like pure, the directive is only meaningful on a function with a *gorm.DB
+// parameter, so it reuses hasGormDBParameter for signature validation (an
+// immutable-param directive on a parameter-less function is reported unused).
+func NewImmutableParamFuncSet(fset *token.FileSet, typesInfo *types.Info) *DirectiveFuncSet {
+	return newDirectiveFuncSet(fset, typesInfo, IsImmutableParamDirective, hasGormDBParameter)
+}
+
 // BuildPureFunctionSet builds a set of functions marked with //gormreuse:pure.
 func BuildPureFunctionSet(file *ast.File, pkgPath string) map[FuncKey]struct{} {
 	return buildFunctionSet(file, pkgPath, IsPureDirective)
@@ -999,6 +1007,11 @@ func BuildPureFunctionSet(file *ast.File, pkgPath string) map[FuncKey]struct{} {
 // BuildImmutableReturnFunctionSet builds a set of functions marked with //gormreuse:immutable-return.
 func BuildImmutableReturnFunctionSet(file *ast.File, pkgPath string) map[FuncKey]struct{} {
 	return buildFunctionSet(file, pkgPath, IsImmutableReturnDirective)
+}
+
+// BuildImmutableParamFunctionSet builds a set of functions marked with //gormreuse:immutable-param.
+func BuildImmutableParamFunctionSet(file *ast.File, pkgPath string) map[FuncKey]struct{} {
+	return buildFunctionSet(file, pkgPath, IsImmutableParamDirective)
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -1148,3 +1148,35 @@ func blockCommentPureBad(db *gorm.DB) *gorm.DB {
 func blockCommentPureGood(db *gorm.DB) *gorm.DB {
 	return db.Session(&gorm.Session{}).Where("x")
 }
+
+// =============================================================================
+// //gormreuse:immutable-param directive (Phase 1b escape hatch, #61) — Stage 1
+//
+// The directive is recognized and validated, but parameters are still treated
+// as immutable in this release, so it does not yet change reuse detection.
+// These cases lock the plumbing: signature validation, unused detection, and
+// combination with pure / immutable-return.
+// =============================================================================
+
+// IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
+// reported unused). Reuse of db is clean today because parameters are still
+// immutable; this annotation is what will keep it clean once Phase 1b flips.
+//
+//gormreuse:immutable-param
+func immutableParamValid(db *gorm.DB) {
+	db.Where("a").Find(nil)
+	db.Where("b").Find(nil)
+}
+
+// IPARAM002: immutable-param on a function without a *gorm.DB parameter is unused.
+//
+//gormreuse:immutable-param // want `unused gormreuse:immutable-param directive`
+func immutableParamNoGormArg(x int) int { return x }
+
+// IPARAM003: combined pure,immutable-param — both recognized, neither reported
+// unused (the function has a *gorm.DB param and satisfies the pure contract).
+//
+//gormreuse:pure,immutable-param
+func pureAndImmutableParam(db *gorm.DB) {
+	_ = db
+}

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1150 +1,1150 @@
+@@ -1,1182 +1,1182 @@
  package internal
  
  import (
@@ -1153,4 +1153,36 @@
  /*gormreuse:pure*/
  func blockCommentPureGood(db *gorm.DB) *gorm.DB {
  	return db.Session(&gorm.Session{}).Where("x")
+ }
+ 
+ // =============================================================================
+ // //gormreuse:immutable-param directive (Phase 1b escape hatch, #61) — Stage 1
+ //
+ // The directive is recognized and validated, but parameters are still treated
+ // as immutable in this release, so it does not yet change reuse detection.
+ // These cases lock the plumbing: signature validation, unused detection, and
+ // combination with pure / immutable-return.
+ // =============================================================================
+ 
+ // IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
+ // reported unused). Reuse of db is clean today because parameters are still
+ // immutable; this annotation is what will keep it clean once Phase 1b flips.
+ //
+ //gormreuse:immutable-param
+ func immutableParamValid(db *gorm.DB) {
+ 	db.Where("a").Find(nil)
+ 	db.Where("b").Find(nil)
+ }
+ 
+ // IPARAM002: immutable-param on a function without a *gorm.DB parameter is unused.
+ //
+ //gormreuse:immutable-param // want `unused gormreuse:immutable-param directive`
+ func immutableParamNoGormArg(x int) int { return x }
+ 
+ // IPARAM003: combined pure,immutable-param — both recognized, neither reported
+ // unused (the function has a *gorm.DB param and satisfies the pure contract).
+ //
+ //gormreuse:pure,immutable-param
+ func pureAndImmutableParam(db *gorm.DB) {
+ 	_ = db
  }

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -1148,3 +1148,35 @@ func blockCommentPureBad(db *gorm.DB) *gorm.DB {
 func blockCommentPureGood(db *gorm.DB) *gorm.DB {
 	return db.Session(&gorm.Session{}).Where("x")
 }
+
+// =============================================================================
+// //gormreuse:immutable-param directive (Phase 1b escape hatch, #61) — Stage 1
+//
+// The directive is recognized and validated, but parameters are still treated
+// as immutable in this release, so it does not yet change reuse detection.
+// These cases lock the plumbing: signature validation, unused detection, and
+// combination with pure / immutable-return.
+// =============================================================================
+
+// IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
+// reported unused). Reuse of db is clean today because parameters are still
+// immutable; this annotation is what will keep it clean once Phase 1b flips.
+//
+//gormreuse:immutable-param
+func immutableParamValid(db *gorm.DB) {
+	db.Where("a").Find(nil)
+	db.Where("b").Find(nil)
+}
+
+// IPARAM002: immutable-param on a function without a *gorm.DB parameter is unused.
+//
+//gormreuse:immutable-param // want `unused gormreuse:immutable-param directive`
+func immutableParamNoGormArg(x int) int { return x }
+
+// IPARAM003: combined pure,immutable-param — both recognized, neither reported
+// unused (the function has a *gorm.DB param and satisfies the pure contract).
+//
+//gormreuse:pure,immutable-param
+func pureAndImmutableParam(db *gorm.DB) {
+	_ = db
+}


### PR DESCRIPTION
**Stage 1 of Phase 1b** (#61) — inert, additive, no behavior change.

Adds the `//gormreuse:immutable-param` directive: the escape hatch that will let a function assert *"my callers guarantee forkable (clone>0) `*gorm.DB` arguments"* once parameters become mutable by default. In this release the directive is **recognized, signature-validated, and unused-detected**, but parameters are still treated as immutable, so it does **not yet change reuse detection**. Landing the plumbing separately keeps the breaking flip (stage 2) a focused review.

## Changes
- `IsImmutableParamDirective` + `NewImmutableParamFuncSet` + `BuildImmutableParamFunctionSet` — mirror `pure`; validated with `hasGormDBParameter` (unused on a parameterless function).
- Wired through the public analyzer and `RunSSA`. Unused-directive reporting for the three sets (pure / immutable-return / immutable-param) unified in `reportUnusedDirectiveFuncs` with **combined-directive suppression across all three** (a position is "used" if any combined sibling is used).
- Fixtures IPARAM001-003 (valid on a gorm-param fn; unused without a gorm param; combined `pure,immutable-param`) + an `IsImmutableParamDirective` unit test (combos, block comment, trailing comment).

## Decisions baked in (from planning w/ @mpyw)
- `pure` × `immutable-param` **combine** (allowed).

## Next (stage 2, #61 stays open)
Flip `*gorm.DB` params to mutable roots (except immutable-param-annotated fns and Transaction/Begin callback tx params); reject immutable-param on Scopes/Preload callbacks; caller-side verification; migrate the 55-violation/45-function fixture inventory (7 → `// want`, 37 → annotate, 1 carve-out); README migration guide.

## Testing
`go test ./...`, both e2e modules, `golangci-lint` green.

Part of #59, Track A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kzXtRZJf5QUBK1XMyPWhv