### PR TITLE
feat: treat *gorm.DB parameters as mutable roots by default (Phase 1b stage 2a, #61)

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -143,13 +143,18 @@ func RunSSA(
 	// mid-chain (clone==0) value, so reuse inside them must be detected (#60).
 	scopesCallbacks := tracer.CollectScopesCallbacks(ssaInfo.SrcFuncs)
 
+	// Collect Transaction callbacks once: their tx parameter is a fresh forkable
+	// (clone>0) handle, so it is exempt from the Phase 1b mutable-by-default
+	// treatment of *gorm.DB parameters (#60 SC103, #61).
+	transactionCallbacks := tracer.CollectTransactionCallbacks(ssaInfo.SrcFuncs)
+
 	// PASS 2: run SSA reuse analysis.
 	for _, fn := range ssaInfo.SrcFuncs {
 		if skip(fn, true) {
 			continue
 		}
 
-		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, globalReported, globalSuggestedEdits, fixGen)
+		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, transactionCallbacks, globalReported, globalSuggestedEdits, fixGen)
 		recoverPerFunction(fn, func() { chk.checkFunction(fn) })
 	}
 
@@ -229,8 +234,10 @@ type checker struct {
 	ignoreMap            directive.IgnoreMap         // Line-level ignore directives
 	pureFuncs            *directive.DirectiveFuncSet // Pure functions for analysis
 	immutableReturnFuncs *directive.DirectiveFuncSet // Immutable-return functions
+	immutableParamFuncs  *directive.DirectiveFuncSet // Immutable-param functions (params opt out of Phase 1b)
 	failedPure           map[*ssa.Function]bool      // Pure functions that failed contract validation
 	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
+	transactionCallbacks map[*ssa.Function]bool      // Transaction callbacks (tx param is forkable, immutable)
 	reported             map[token.Pos]bool          // Deduplication of reports
 	suggestedEdits       map[editKey]bool            // Global deduplication of suggested fixes
 	fixGen               *fix.Generator              // Cached fix generator for all violations
@@ -248,14 +255,16 @@ type editKey struct {
 // across parent functions and their closures.
 // The suggestedEdits map is shared to avoid duplicate fix edits.
 // The fixGen is shared to avoid recreating the generator for each violation.
-func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
+func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
 	return &checker{
 		pass:                 pass,
 		ignoreMap:            ignoreMap,
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
+		immutableParamFuncs:  immutableParamFuncs,
 		failedPure:           failedPure,
 		scopesCallbacks:      scopesCallbacks,
+		transactionCallbacks: transactionCallbacks,
 		reported:             reported,
 		suggestedEdits:       suggestedEdits,
 		fixGen:               fixGen,
@@ -264,7 +273,7 @@ func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, i
 
 // checkFunction runs SSA analysis on a single function and reports violations.
 func (c *checker) checkFunction(fn *ssa.Function) {
-	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.failedPure, c.scopesCallbacks)
+	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.immutableParamFuncs, c.failedPure, c.scopesCallbacks, c.transactionCallbacks)
 	violations := analyzer.Analyze()
 
 	// Deduplicate violations by root to avoid generating duplicate fixes.

--- a/internal/analyzer_test.go
+++ b/internal/analyzer_test.go
@@ -44,7 +44,7 @@ func TestNewAnalyzer(t *testing.T) {
 	pureFuncs := directive.NewPureFuncSet(nil, nil)
 	pureFuncs.Add(directive.FuncKey{PkgPath: "test", FuncName: "Pure"})
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(nil, nil)
-	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs, nil, nil)
+	analyzer := ssautil.NewAnalyzer(nil, pureFuncs, immutableReturnFuncs, nil, nil, nil, nil)
 
 	if analyzer == nil {
 		t.Error("Expected analyzer to be initialized")
@@ -60,7 +60,7 @@ func TestNewChecker(t *testing.T) {
 	reported := make(map[token.Pos]bool)
 	suggestedEdits := make(map[editKey]bool)
 
-	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil, nil, reported, suggestedEdits, nil)
+	chk := newChecker(nil, ignoreMap, pureFuncs, immutableReturnFuncs, nil, nil, nil, nil, reported, suggestedEdits, nil)
 
 	if chk == nil {
 		t.Error("Expected checker to be initialized")
@@ -70,7 +70,7 @@ func TestNewChecker(t *testing.T) {
 func TestAnalyzer_Analyze_NilFunction(t *testing.T) {
 	t.Parallel()
 
-	analyzer := ssautil.NewAnalyzer(nil, nil, nil, nil, nil)
+	analyzer := ssautil.NewAnalyzer(nil, nil, nil, nil, nil, nil, nil)
 
 	// Should not panic with nil function
 	violations := analyzer.Analyze()
@@ -83,7 +83,7 @@ func TestAnalyzer_Analyze_EmptyFunction(t *testing.T) {
 	t.Parallel()
 
 	fn := &ssa.Function{}
-	analyzer := ssautil.NewAnalyzer(fn, nil, nil, nil, nil)
+	analyzer := ssautil.NewAnalyzer(fn, nil, nil, nil, nil, nil, nil)
 
 	violations := analyzer.Analyze()
 	if len(violations) != 0 {

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -78,10 +78,12 @@ type Analyzer struct {
 //   - immutableReturnFuncs: Set of functions marked with //gormreuse:immutable-return directive
 //   - failedPure: Pure functions that failed contract validation (not trusted as pure)
 //   - scopesCallbacks: Scopes/Preload callbacks whose *gorm.DB param is a mutable root
-func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool) *Analyzer {
+//   - immutableParamFuncs: Functions marked //gormreuse:immutable-param (params opt out of Phase 1b)
+//   - transactionCallbacks: Transaction callbacks whose tx param is forkable (immutable)
+func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool) *Analyzer {
 	return &Analyzer{
 		fn:          fn,
-		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks),
+		rootTracer:  tracer.New(pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, transactionCallbacks),
 		cfgAnalyzer: cfg.New(),
 	}
 }

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -47,9 +47,11 @@
 //	│  *ssa.Alloc             │  Find Store instructions to this alloc     │
 //	│  *ssa.FreeVar           │  Find binding in parent's MakeClosure      │
 //	│  *ssa.FieldAddr         │  Find Store to this field                  │
-//	│  *ssa.Parameter         │  STOP - immutable source (caller's concern)│
-//	│  *ssa.Parameter (Scopes)│  ROOT - Scopes/Preload callback param is   │
-//	│                         │  mutable (receives clone==0 db, #60)       │
+//	│  *ssa.Parameter         │  ROOT - a *gorm.DB parameter is mutable by │
+//	│                         │  default (caller may pass clone==0, #61)   │
+//	│  *ssa.Parameter (exempt)│  STOP - immutable when the fn is annotated │
+//	│                         │  //gormreuse:immutable-param or is a       │
+//	│                         │  Transaction callback (forkable, clone>0)  │
 //	│  *ssa.Const (nil)       │  STOP - nil is ignored                     │
 //	│  Builtin pure call      │  STOP - returns immutable (nil root)       │
 //	│  immutable-return call  │  STOP - returns immutable (nil root)       │
@@ -97,8 +99,10 @@ import (
 type RootTracer struct {
 	pureFuncs            *directive.DirectiveFuncSet // User-defined pure functions
 	immutableReturnFuncs *directive.DirectiveFuncSet // Functions returning immutable *gorm.DB
+	immutableParamFuncs  *directive.DirectiveFuncSet // Functions whose *gorm.DB params are immutable (opt out of Phase 1b)
 	failedPure           map[*ssa.Function]bool      // Pure functions that FAILED contract validation
 	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
+	transactionCallbacks map[*ssa.Function]bool      // Transaction callbacks (tx param is forkable, immutable)
 }
 
 // New creates a new RootTracer.
@@ -112,12 +116,20 @@ type RootTracer struct {
 // *gorm.DB parameter receives a mid-chain (clone==0) value at runtime and is
 // therefore itself a mutable root — reuse inside the callback interferes (#60).
 // It may be nil.
-func New(pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks map[*ssa.Function]bool) *RootTracer {
+//
+// immutableParamFuncs lists functions annotated //gormreuse:immutable-param,
+// whose *gorm.DB parameters opt out of the Phase 1b mutable-by-default treatment
+// (issue #61). transactionCallbacks lists function literals passed to gorm's
+// Transaction, whose tx parameter is a fresh forkable (clone>0) handle and is
+// therefore immutable. Both may be nil.
+func New(pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool) *RootTracer {
 	return &RootTracer{
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
+		immutableParamFuncs:  immutableParamFuncs,
 		failedPure:           failedPure,
 		scopesCallbacks:      scopesCallbacks,
+		transactionCallbacks: transactionCallbacks,
 	}
 }
 
@@ -253,12 +265,11 @@ func (t *RootTracer) trace(v ssa.Value, visited map[ssa.Value]bool, loopInfo *cf
 	}
 	visited[v] = true
 
-	// A *gorm.DB parameter of a Scopes/Preload callback receives a mid-chain
-	// (clone==0) value at runtime, so it is itself a mutable root — unlike an
-	// ordinary parameter, which is treated as immutable (caller's concern).
-	// This must be checked BEFORE isImmutableSource, which reports parameters as
-	// immutable (issue #60).
-	if p, ok := v.(*ssa.Parameter); ok && t.isScopesCallbackParam(p) {
+	// Under Phase 1b a *gorm.DB parameter is a mutable root by default (a caller
+	// may pass a mid-chain clone==0 value that this function then branches). This
+	// must be checked BEFORE isImmutableSource, which still reports the exempt
+	// parameters (immutable-param / Transaction callback) as immutable (#61, #60).
+	if p, ok := v.(*ssa.Parameter); ok && t.isMutableParam(p) {
 		return p
 	}
 
@@ -1149,10 +1160,10 @@ func (t *RootTracer) traceAll(v ssa.Value, visited map[ssa.Value]bool, loopInfo 
 	}
 	visited[v] = true
 
-	// A Scopes/Preload callback's *gorm.DB parameter is itself a mutable root
-	// (issue #60); keep this consistent with trace()/FindMutableRoot so Phi-based
-	// pollution checks see it too.
-	if p, ok := v.(*ssa.Parameter); ok && t.isScopesCallbackParam(p) {
+	// A *gorm.DB parameter is a mutable root by default (Phase 1b, #61), except
+	// the exempt cases; keep this consistent with trace()/FindMutableRoot so
+	// Phi-based pollution checks see it too.
+	if p, ok := v.(*ssa.Parameter); ok && t.isMutableParam(p) {
 		return []ssa.Value{p}
 	}
 
@@ -1360,13 +1371,34 @@ func (t *RootTracer) traceAllFreeVar(fv *ssa.FreeVar, visited map[ssa.Value]bool
 	return nil
 }
 
-// isScopesCallbackParam reports whether p is the *gorm.DB parameter of a
-// function literal passed to gorm's Scopes/Preload (see CollectScopesCallbacks).
-func (t *RootTracer) isScopesCallbackParam(p *ssa.Parameter) bool {
-	if t.scopesCallbacks == nil || !typeutil.IsGormDB(p.Type()) {
+// isMutableParam reports whether p should be treated as a mutable root.
+//
+// Under Phase 1b (#61) a *gorm.DB parameter is a mutable root by default: a
+// caller may pass a mid-chain (clone==0) value, and branching it inside the
+// callee interferes exactly as branching a local would. Exceptions, treated as
+// immutable:
+//   - the enclosing function is annotated //gormreuse:immutable-param (the caller
+//     is responsible for passing a safe value; verified caller-side elsewhere)
+//   - p is the tx parameter of a gorm Transaction callback — a fresh, forkable
+//     (clone>0) handle, so reuse inside the callback is safe (#60 SC103)
+//
+// A Scopes/Preload callback parameter receives a clone==0 value and is ALWAYS
+// mutable; it cannot be exempted by //gormreuse:immutable-param.
+func (t *RootTracer) isMutableParam(p *ssa.Parameter) bool {
+	if !typeutil.IsGormDB(p.Type()) {
 		return false
 	}
-	return t.scopesCallbacks[p.Parent()]
+	fn := p.Parent()
+	if t.scopesCallbacks[fn] {
+		return true
+	}
+	if t.transactionCallbacks[fn] {
+		return false
+	}
+	if t.immutableParamFuncs != nil && t.immutableParamFuncs.Contains(fn) {
+		return false
+	}
+	return true
 }
 
 // IsScopesCallbackFunc reports whether fn is a Scopes/Preload callback. The
@@ -1380,7 +1412,10 @@ func (t *RootTracer) IsScopesCallbackFunc(fn *ssa.Function) bool {
 // isImmutableSource checks if a value is an immutable source (no mutable root).
 //
 // Immutable sources:
-//   - Parameter: function arguments are treated as fresh values
+//   - Parameter: reached here only for the EXEMPT parameters — a mutable
+//     *gorm.DB parameter is handled earlier by isMutableParam and never reaches
+//     this point (see trace/traceAll). Non-gorm parameters and exempt gorm
+//     parameters (immutable-param / Transaction callback) are immutable.
 //   - Const: constant values (especially nil)
 //   - Builtin pure function call: returns immutable *gorm.DB (e.g., Session())
 //   - User-defined immutable-return function: marked with //gormreuse:immutable-return
@@ -1538,28 +1573,52 @@ func ClosureCapturesGormDB(mc *ssa.MakeClosure) bool {
 // argument is a slice of it); Preload additionally boxes them in interface{}.
 func CollectScopesCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
 	set := make(map[*ssa.Function]bool)
-	visited := make(map[*ssa.Function]bool)
-	for _, fn := range funcs {
-		collectScopesCallbacks(fn, set, visited)
-	}
+	walkCalls(funcs, func(call *ssa.Call) {
+		collectScopesCallbacksFromCall(call, set)
+	})
 	return set
 }
 
-func collectScopesCallbacks(fn *ssa.Function, set, visited map[*ssa.Function]bool) {
-	if fn == nil || visited[fn] {
-		return
-	}
-	visited[fn] = true
+// CollectTransactionCallbacks returns the set of function literals passed as the
+// callback to gorm's Transaction across all given functions and their nested
+// closures.
+//
+// A Transaction callback receives a FRESH, forkable (clone>0) transaction handle,
+// so — unlike an ordinary Phase 1b parameter — its *gorm.DB parameter is NOT a
+// mutable root and reuse inside the callback is safe (verified against gorm's
+// clone semantics; see the epic's pivotal finding). It must be exempted from the
+// mutable-by-default treatment (#60 SC103).
+func CollectTransactionCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
+	set := make(map[*ssa.Function]bool)
+	walkCalls(funcs, func(call *ssa.Call) {
+		collectTransactionCallbacksFromCall(call, set)
+	})
+	return set
+}
 
-	for _, block := range fn.Blocks {
-		for _, instr := range block.Instrs {
-			if call, ok := instr.(*ssa.Call); ok {
-				collectScopesCallbacksFromCall(call, set)
+// walkCalls visits every *ssa.Call in funcs and their nested anonymous functions
+// exactly once. Shared by the Scopes/Preload and Transaction callback collectors.
+func walkCalls(funcs []*ssa.Function, visit func(*ssa.Call)) {
+	visited := make(map[*ssa.Function]bool)
+	var rec func(fn *ssa.Function)
+	rec = func(fn *ssa.Function) {
+		if fn == nil || visited[fn] {
+			return
+		}
+		visited[fn] = true
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				if call, ok := instr.(*ssa.Call); ok {
+					visit(call)
+				}
 			}
 		}
+		for _, af := range fn.AnonFuncs {
+			rec(af)
+		}
 	}
-	for _, af := range fn.AnonFuncs {
-		collectScopesCallbacks(af, set, visited)
+	for _, fn := range funcs {
+		rec(fn)
 	}
 }
 
@@ -1607,6 +1666,34 @@ func collectScopesCallbacksFromCall(call *ssa.Call, set map[*ssa.Function]bool) 
 func isScopesOrPreloadMethod(callee *ssa.Function) bool {
 	name := callee.Name()
 	if name != "Scopes" && name != "Preload" {
+		return false
+	}
+	sig := callee.Signature
+	return sig != nil && sig.Recv() != nil && typeutil.IsGormDB(sig.Recv().Type())
+}
+
+// collectTransactionCallbacksFromCall adds the callback function passed to a
+// gorm Transaction call to set.
+func collectTransactionCallbacksFromCall(call *ssa.Call, set map[*ssa.Function]bool) {
+	callee := call.Call.StaticCallee()
+	if callee == nil || !isTransactionMethod(callee) {
+		return
+	}
+	// Transaction(fc func(tx *DB) error, opts ...): with a static method callee
+	// the receiver is Args[0] and the callback fc is Args[1].
+	args := call.Call.Args
+	if len(args) < 2 {
+		return
+	}
+	if cb := callbackFuncValue(args[1]); cb != nil {
+		set[cb] = true
+	}
+}
+
+// isTransactionMethod reports whether callee is gorm's Transaction method (gated
+// on a gorm.DB receiver so a same-named user method is excluded).
+func isTransactionMethod(callee *ssa.Function) bool {
+	if callee.Name() != "Transaction" {
 		return false
 	}
 	sig := callee.Signature

--- a/internal/ssa/tracer/root_test.go
+++ b/internal/ssa/tracer/root_test.go
@@ -80,7 +80,7 @@ func gormMethod(allFuncs map[*ssa.Function]bool, name string) *ssa.Function {
 func TestIsImmutableReturningBuiltin(t *testing.T) {
 	t.Parallel()
 	fixtures, all := loadProgram(t)
-	tr := tracer.New(nil, nil, nil, nil)
+	tr := tracer.New(nil, nil, nil, nil, nil, nil)
 
 	session := gormMethod(all, "Session")
 	if session == nil {
@@ -108,7 +108,7 @@ func TestIsPureFunction(t *testing.T) {
 	t.Parallel()
 	fixtures, all := loadProgram(t)
 	// Syntax-backed pure set resolves //gormreuse:pure via each function's AST.
-	tr := tracer.New(directive.NewPureFuncSet(nil, nil), nil, nil, nil)
+	tr := tracer.New(directive.NewPureFuncSet(nil, nil), nil, nil, nil, nil, nil)
 
 	if session := gormMethod(all, "Session"); session != nil && !tr.IsPureFunction(session) {
 		t.Error("Session (immutable builtin) should count as pure")
@@ -165,7 +165,7 @@ func TestCollectScopesCallbacks(t *testing.T) {
 	}
 
 	// An ordinary helper never handed to Scopes/Preload must NOT be collected.
-	if ord := fixtures["ordinaryHelperParamStillImmutable"]; ord != nil && set[ord] {
+	if ord := fixtures["ordinaryHelperParamBranches"]; ord != nil && set[ord] {
 		t.Error("ordinary helper should not be collected as a Scopes callback")
 	}
 
@@ -187,15 +187,15 @@ func TestFindMutableRootScopesParam(t *testing.T) {
 	loops := cfg.New()
 
 	named := fixtures["namedScope"]
-	ordinary := fixtures["ordinaryHelperParamStillImmutable"]
+	ordinary := fixtures["ordinaryHelperParamBranches"]
 	if named == nil || ordinary == nil {
 		t.Fatal("required fixtures missing")
 	}
 
 	// With namedScope registered as a Scopes callback, its *gorm.DB parameter is
-	// a mutable root; the identical ordinary helper's parameter is not.
+	// a mutable root.
 	scopes := map[*ssa.Function]bool{named: true}
-	tr := tracer.New(nil, nil, nil, scopes)
+	tr := tracer.New(nil, nil, nil, nil, scopes, nil)
 
 	if !tr.IsScopesCallbackFunc(named) {
 		t.Error("namedScope should be recognized as a Scopes callback function")
@@ -212,14 +212,24 @@ func TestFindMutableRootScopesParam(t *testing.T) {
 		t.Errorf("FindAllMutableRoots should return the Scopes param, got %v", roots)
 	}
 
+	// Phase 1b (#61): an ordinary *gorm.DB parameter is now a mutable root by
+	// default, even without any Scopes registration.
 	ordParam := ordinary.Params[0]
-	if root := tr.FindMutableRoot(ordParam, loops.DetectLoops(ordinary)); root != nil {
-		t.Errorf("ordinary parameter should be immutable (nil root), got %v", root)
+	if root := tr.FindMutableRoot(ordParam, loops.DetectLoops(ordinary)); root != ordParam {
+		t.Errorf("Phase 1b: ordinary parameter should be a mutable root, got %v", root)
+	}
+	trPlain := tracer.New(nil, nil, nil, nil, nil, nil)
+	if root := trPlain.FindMutableRoot(namedParam, loops.DetectLoops(named)); root != namedParam {
+		t.Errorf("Phase 1b: unregistered parameter should be a mutable root, got %v", root)
 	}
 
-	// Without the Scopes registration, even namedScope's parameter is immutable.
-	trPlain := tracer.New(nil, nil, nil, nil)
-	if root := trPlain.FindMutableRoot(namedParam, loops.DetectLoops(named)); root != nil {
-		t.Errorf("unregistered parameter should be immutable (nil root), got %v", root)
+	// A Transaction callback's tx parameter is exempt (fresh forkable handle):
+	// registering the helper as a transaction callback makes its param immutable.
+	trTx := tracer.New(nil, nil, nil, nil, nil, map[*ssa.Function]bool{ordinary: true})
+	if root := trTx.FindMutableRoot(ordParam, loops.DetectLoops(ordinary)); root != nil {
+		t.Errorf("Transaction callback parameter should be immutable (nil root), got %v", root)
+	}
+	if roots := trTx.FindAllMutableRoots(ordParam, loops.DetectLoops(ordinary)); len(roots) != 0 {
+		t.Errorf("Transaction callback parameter should yield no roots, got %v", roots)
 	}
 }

--- a/testdata/src/converge/converge.go
+++ b/testdata/src/converge/converge.go
@@ -21,7 +21,10 @@ func simpleReuse(db *gorm.DB) {
 
 // nestedArg exposes defect 1: q is reused inside base.Or(...). The correct fix
 // makes q's root immutable; the buggy fix rebinds `base` and never addresses q,
-// so re-linting still warns.
+// so re-linting still warns. immutable-param keeps the params off the root set so
+// the only violation is the fully-fixable local q (see the package doc).
+//
+//gormreuse:immutable-param
 func nestedArg(db, base *gorm.DB) {
 	q := db.Where("base")
 	base.Or(q.Where("y"))
@@ -42,6 +45,10 @@ func multiBranchReassign(db *gorm.DB) {
 
 // localBaseReuse: a local root reused via a method whose args are other chains;
 // the fix Sessions the local's own root (not a rebind of anything nested).
+// immutable-param keeps db off the root set so the only violation is the
+// fully-fixable local base (see the package doc).
+//
+//gormreuse:immutable-param
 func localBaseReuse(db *gorm.DB) {
 	base := db.Where("start")
 	base.Or(db.Where("a"))

--- a/testdata/src/gormreuse/advanced.go
+++ b/testdata/src/gormreuse/advanced.go
@@ -166,7 +166,11 @@ func sessionBeforeFinisher(db *gorm.DB) {
 // SHOULD NOT REPORT - Reassignment
 // =============================================================================
 
-// reassignNewInstance demonstrates that reassigning a variable is safe.
+// reassignNewInstance demonstrates that reassigning a variable creates a new
+// root. The parameter is immutable-param here so the test stays focused on
+// reassignment semantics rather than Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func reassignNewInstance(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Count(new(int64))
@@ -367,22 +371,24 @@ func nestedArgsSingleUse(db *gorm.DB) {
 // =============================================================================
 
 // wrappedInRequireNoError demonstrates GORM calls wrapped in require.NoError.
-// The fix generator should NOT generate inappropriate fixes like:
+// Under Phase 1b (#61) the tx parameter is a mutable root, so branching it
+// repeatedly is a violation — but the fix generator must NOT generate an
+// inappropriate reassignment fix like:
 //
 //	tx = require.NoError(t, tx.Create(...).Error)  // WRONG!
 //
-// Instead, no reassignment fix should be generated for these cases because
-// the top-level expression is not a *gorm.DB method call.
+// (parameter roots get no auto-fix; the top-level expression is not a *gorm.DB
+// method call anyway).
 func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
-	require.NoError(t, tx.Create(nil).Error)
-	require.NoError(t, tx.Create(nil).Error)
+	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
+	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // wrappedInRequireNoErrorMixed demonstrates mixed usage patterns.
 func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
-	tx.Create(nil)
+	tx.Create(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/advanced.go.diff
+++ b/testdata/src/gormreuse/advanced.go.diff
@@ -1,6 +1,6 @@
 --- advanced.go	1970-01-01 00:00:00
 +++ advanced.go.golden	1970-01-01 00:00:00
-@@ -1,1209 +1,1209 @@
+@@ -1,1215 +1,1215 @@
  package internal
  
  import (
@@ -178,7 +178,11 @@
  // SHOULD NOT REPORT - Reassignment
  // =============================================================================
  
- // reassignNewInstance demonstrates that reassigning a variable is safe.
+ // reassignNewInstance demonstrates that reassigning a variable creates a new
+ // root. The parameter is immutable-param here so the test stays focused on
+ // reassignment semantics rather than Phase 1b parameter branching (#61).
+ //
+ //gormreuse:immutable-param
  func reassignNewInstance(db *gorm.DB) {
  	q := db.Model(&User{}).Where("active = ?", true)
  	q.Count(new(int64))
@@ -395,22 +399,24 @@
  // =============================================================================
  
  // wrappedInRequireNoError demonstrates GORM calls wrapped in require.NoError.
- // The fix generator should NOT generate inappropriate fixes like:
+ // Under Phase 1b (#61) the tx parameter is a mutable root, so branching it
+ // repeatedly is a violation — but the fix generator must NOT generate an
+ // inappropriate reassignment fix like:
  //
  //	tx = require.NoError(t, tx.Create(...).Error)  // WRONG!
  //
- // Instead, no reassignment fix should be generated for these cases because
- // the top-level expression is not a *gorm.DB method call.
+ // (parameter roots get no auto-fix; the top-level expression is not a *gorm.DB
+ // method call anyway).
  func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
  	require.NoError(t, tx.Create(nil).Error)
- 	require.NoError(t, tx.Create(nil).Error)
- 	require.NoError(t, tx.Create(nil).Error)
+ 	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
+ 	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // wrappedInRequireNoErrorMixed demonstrates mixed usage patterns.
  func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
  	require.NoError(t, tx.Create(nil).Error)
- 	tx.Create(nil)
+ 	tx.Create(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // =============================================================================

--- a/testdata/src/gormreuse/advanced.go.golden
+++ b/testdata/src/gormreuse/advanced.go.golden
@@ -166,7 +166,11 @@ func sessionBeforeFinisher(db *gorm.DB) {
 // SHOULD NOT REPORT - Reassignment
 // =============================================================================
 
-// reassignNewInstance demonstrates that reassigning a variable is safe.
+// reassignNewInstance demonstrates that reassigning a variable creates a new
+// root. The parameter is immutable-param here so the test stays focused on
+// reassignment semantics rather than Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func reassignNewInstance(db *gorm.DB) {
 	q := db.Model(&User{}).Where("active = ?", true)
 	q.Count(new(int64))
@@ -367,22 +371,24 @@ func nestedArgsSingleUse(db *gorm.DB) {
 // =============================================================================
 
 // wrappedInRequireNoError demonstrates GORM calls wrapped in require.NoError.
-// The fix generator should NOT generate inappropriate fixes like:
+// Under Phase 1b (#61) the tx parameter is a mutable root, so branching it
+// repeatedly is a violation — but the fix generator must NOT generate an
+// inappropriate reassignment fix like:
 //
 //	tx = require.NoError(t, tx.Create(...).Error)  // WRONG!
 //
-// Instead, no reassignment fix should be generated for these cases because
-// the top-level expression is not a *gorm.DB method call.
+// (parameter roots get no auto-fix; the top-level expression is not a *gorm.DB
+// method call anyway).
 func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
-	require.NoError(t, tx.Create(nil).Error)
-	require.NoError(t, tx.Create(nil).Error)
+	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
+	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // wrappedInRequireNoErrorMixed demonstrates mixed usage patterns.
 func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
-	tx.Create(nil)
+	tx.Create(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // =============================================================================

--- a/testdata/src/gormreuse/basic.go
+++ b/testdata/src/gormreuse/basic.go
@@ -71,29 +71,31 @@ func withContextAtEnd(db *gorm.DB) {
 	q.Count(new(int64)) // OK: WithContext at end makes it safe
 }
 
-// separateChains demonstrates independent chains from the same parameter.
+// separateChains demonstrates that a *gorm.DB parameter is a mutable root under
+// Phase 1b (#61): a caller may pass a mid-chain value, so branching it twice is a
+// violation.
 func separateChains(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(&[]User{})
-	db.Where("b = ?", 2).Find(&[]User{}) // OK: separate chains
+	db.Where("b = ?", 2).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// separateVariables demonstrates no reuse when using different variables.
+// separateVariables demonstrates branching a parameter into two variables.
 func separateVariables(db *gorm.DB) {
 	q1 := db.Where("a = ?", 1)
-	q2 := db.Where("b = ?", 2)
+	q2 := db.Where("b = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q1.Find(nil)
-	q2.Find(nil) // OK: different chains
+	q2.Find(nil)
 }
 
-// parameterDirectUse demonstrates that parameters are treated as immutable.
+// parameterDirectUse demonstrates that a parameter is a mutable root (Phase 1b).
 func parameterDirectUse(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(nil)
-	db.Where("b = ?", 2).Find(nil) // OK: parameter is immutable source
+	db.Where("b = ?", 2).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// parameterMultipleChains demonstrates multiple chains from parameter.
+// parameterMultipleChains demonstrates multiple chains from a parameter root.
 func parameterMultipleChains(db *gorm.DB) {
 	db.Where("x").Order("id").Find(nil)
-	db.Where("y").Limit(10).Find(nil) // OK: independent chains
+	db.Where("y").Limit(10).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/basic.go.diff
+++ b/testdata/src/gormreuse/basic.go.diff
@@ -1,6 +1,6 @@
 --- basic.go	1970-01-01 00:00:00
 +++ basic.go.golden	1970-01-01 00:00:00
-@@ -1,99 +1,99 @@
+@@ -1,101 +1,101 @@
  // Package internal contains test functions for gormreuse linter.
  package internal
  
@@ -78,29 +78,31 @@
  	q.Count(new(int64)) // OK: WithContext at end makes it safe
  }
  
- // separateChains demonstrates independent chains from the same parameter.
+ // separateChains demonstrates that a *gorm.DB parameter is a mutable root under
+ // Phase 1b (#61): a caller may pass a mid-chain value, so branching it twice is a
+ // violation.
  func separateChains(db *gorm.DB) {
  	db.Where("a = ?", 1).Find(&[]User{})
- 	db.Where("b = ?", 2).Find(&[]User{}) // OK: separate chains
+ 	db.Where("b = ?", 2).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
- // separateVariables demonstrates no reuse when using different variables.
+ // separateVariables demonstrates branching a parameter into two variables.
  func separateVariables(db *gorm.DB) {
  	q1 := db.Where("a = ?", 1)
- 	q2 := db.Where("b = ?", 2)
+ 	q2 := db.Where("b = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
  
  	q1.Find(nil)
- 	q2.Find(nil) // OK: different chains
+ 	q2.Find(nil)
  }
  
- // parameterDirectUse demonstrates that parameters are treated as immutable.
+ // parameterDirectUse demonstrates that a parameter is a mutable root (Phase 1b).
  func parameterDirectUse(db *gorm.DB) {
  	db.Where("a = ?", 1).Find(nil)
- 	db.Where("b = ?", 2).Find(nil) // OK: parameter is immutable source
+ 	db.Where("b = ?", 2).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
- // parameterMultipleChains demonstrates multiple chains from parameter.
+ // parameterMultipleChains demonstrates multiple chains from a parameter root.
  func parameterMultipleChains(db *gorm.DB) {
  	db.Where("x").Order("id").Find(nil)
- 	db.Where("y").Limit(10).Find(nil) // OK: independent chains
+ 	db.Where("y").Limit(10).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }

--- a/testdata/src/gormreuse/basic.go.golden
+++ b/testdata/src/gormreuse/basic.go.golden
@@ -71,29 +71,31 @@ func withContextAtEnd(db *gorm.DB) {
 	q.Count(new(int64)) // OK: WithContext at end makes it safe
 }
 
-// separateChains demonstrates independent chains from the same parameter.
+// separateChains demonstrates that a *gorm.DB parameter is a mutable root under
+// Phase 1b (#61): a caller may pass a mid-chain value, so branching it twice is a
+// violation.
 func separateChains(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(&[]User{})
-	db.Where("b = ?", 2).Find(&[]User{}) // OK: separate chains
+	db.Where("b = ?", 2).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// separateVariables demonstrates no reuse when using different variables.
+// separateVariables demonstrates branching a parameter into two variables.
 func separateVariables(db *gorm.DB) {
 	q1 := db.Where("a = ?", 1)
-	q2 := db.Where("b = ?", 2)
+	q2 := db.Where("b = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
 
 	q1.Find(nil)
-	q2.Find(nil) // OK: different chains
+	q2.Find(nil)
 }
 
-// parameterDirectUse demonstrates that parameters are treated as immutable.
+// parameterDirectUse demonstrates that a parameter is a mutable root (Phase 1b).
 func parameterDirectUse(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(nil)
-	db.Where("b = ?", 2).Find(nil) // OK: parameter is immutable source
+	db.Where("b = ?", 2).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// parameterMultipleChains demonstrates multiple chains from parameter.
+// parameterMultipleChains demonstrates multiple chains from a parameter root.
 func parameterMultipleChains(db *gorm.DB) {
 	db.Where("x").Order("id").Find(nil)
-	db.Where("y").Limit(10).Find(nil) // OK: independent chains
+	db.Where("y").Limit(10).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/closure_directive.go
+++ b/testdata/src/gormreuse/closure_directive.go
@@ -377,6 +377,7 @@ type structWithFuncField struct {
 }
 
 // multiAssign01: Both closures in same assignment get the directive
+//gormreuse:immutable-param
 func multiAssign01(db *gorm.DB) {
 	//gormreuse:pure
 	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
@@ -391,6 +392,7 @@ func multiAssign01(db *gorm.DB) {
 }
 
 // multiAssign02: Both variables get directive (direct assignment)
+//gormreuse:immutable-param
 func multiAssign02(db *gorm.DB) {
 	var a, c func(q *gorm.DB)
 
@@ -407,6 +409,7 @@ func multiAssign02(db *gorm.DB) {
 }
 
 // multiAssign03: Only first closure gets directive (second is inside struct literal)
+//gormreuse:immutable-param
 func multiAssign03(db *gorm.DB) {
 	//gormreuse:pure
 	a, b := func(q *gorm.DB) { _ = q }, &structWithFuncField{Fn: func(q *gorm.DB) { _ = q }}
@@ -421,6 +424,7 @@ func multiAssign03(db *gorm.DB) {
 }
 
 // multiAssign04: Three closures - first two direct, third in composite literal
+//gormreuse:immutable-param
 func multiAssign04(db *gorm.DB) {
 	//gormreuse:pure
 	a, b, c := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }, []func(*gorm.DB){func(q *gorm.DB) { _ = q }}[0]
@@ -439,6 +443,7 @@ func multiAssign04(db *gorm.DB) {
 }
 
 // multiAssign05: Separated statements - only first gets directive
+//gormreuse:immutable-param
 func multiAssign05(db *gorm.DB) {
 	//gormreuse:pure
 	a := func(q *gorm.DB) { _ = q }
@@ -454,6 +459,7 @@ func multiAssign05(db *gorm.DB) {
 }
 
 // multiAssign06: Semicolon-separated on same line - only first statement gets directive
+//gormreuse:immutable-param
 func multiAssign06(db *gorm.DB) {
 	//gormreuse:pure
 	a := func(q *gorm.DB) { _ = q }; b := func(q *gorm.DB) { _ = q }
@@ -468,6 +474,7 @@ func multiAssign06(db *gorm.DB) {
 }
 
 // multiAssign07: Multi-line assignment - all closures in same statement get directive
+//gormreuse:immutable-param
 func multiAssign07(db *gorm.DB) {
 	//gormreuse:pure
 	a, b, c := func(q *gorm.DB) { _ = q },
@@ -489,6 +496,7 @@ func multiAssign07(db *gorm.DB) {
 
 
 // multiAssign08: Multi-line assignment with comments between closures
+//gormreuse:immutable-param
 func multiAssign08(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q
@@ -517,6 +525,7 @@ func multiAssign08(db *gorm.DB) {
 
 // multiAssign09: Directive after closing brace does NOT apply to next line
 // }, //gormreuse:pure should not apply to the FuncLit on the next line
+//gormreuse:immutable-param
 func multiAssign09(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q

--- a/testdata/src/gormreuse/closure_directive.go.diff
+++ b/testdata/src/gormreuse/closure_directive.go.diff
@@ -1,6 +1,6 @@
 --- closure_directive.go	1970-01-01 00:00:00
 +++ closure_directive.go.golden	1970-01-01 00:00:00
-@@ -1,541 +1,541 @@
+@@ -1,550 +1,550 @@
  package internal
  
  import "gorm.io/gorm"
@@ -386,6 +386,7 @@
  }
  
  // multiAssign01: Both closures in same assignment get the directive
+ //gormreuse:immutable-param
  func multiAssign01(db *gorm.DB) {
  	//gormreuse:pure
  	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
@@ -400,6 +401,7 @@
  }
  
  // multiAssign02: Both variables get directive (direct assignment)
+ //gormreuse:immutable-param
  func multiAssign02(db *gorm.DB) {
  	var a, c func(q *gorm.DB)
  
@@ -416,6 +418,7 @@
  }
  
  // multiAssign03: Only first closure gets directive (second is inside struct literal)
+ //gormreuse:immutable-param
  func multiAssign03(db *gorm.DB) {
  	//gormreuse:pure
  	a, b := func(q *gorm.DB) { _ = q }, &structWithFuncField{Fn: func(q *gorm.DB) { _ = q }}
@@ -431,6 +434,7 @@
  }
  
  // multiAssign04: Three closures - first two direct, third in composite literal
+ //gormreuse:immutable-param
  func multiAssign04(db *gorm.DB) {
  	//gormreuse:pure
  	a, b, c := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }, []func(*gorm.DB){func(q *gorm.DB) { _ = q }}[0]
@@ -450,6 +454,7 @@
  }
  
  // multiAssign05: Separated statements - only first gets directive
+ //gormreuse:immutable-param
  func multiAssign05(db *gorm.DB) {
  	//gormreuse:pure
  	a := func(q *gorm.DB) { _ = q }
@@ -466,6 +471,7 @@
  }
  
  // multiAssign06: Semicolon-separated on same line - only first statement gets directive
+ //gormreuse:immutable-param
  func multiAssign06(db *gorm.DB) {
  	//gormreuse:pure
  	a := func(q *gorm.DB) { _ = q }; b := func(q *gorm.DB) { _ = q }
@@ -481,6 +487,7 @@
  }
  
  // multiAssign07: Multi-line assignment - all closures in same statement get directive
+ //gormreuse:immutable-param
  func multiAssign07(db *gorm.DB) {
  	//gormreuse:pure
  	a, b, c := func(q *gorm.DB) { _ = q },
@@ -502,6 +509,7 @@
  
  
  // multiAssign08: Multi-line assignment with comments between closures
+ //gormreuse:immutable-param
  func multiAssign08(db *gorm.DB) {
  	a, b, c := func(q *gorm.DB) { //gormreuse:pure
  		_ = q
@@ -530,6 +538,7 @@
  
  // multiAssign09: Directive after closing brace does NOT apply to next line
  // }, //gormreuse:pure should not apply to the FuncLit on the next line
+ //gormreuse:immutable-param
  func multiAssign09(db *gorm.DB) {
  	a, b, c := func(q *gorm.DB) { //gormreuse:pure
  		_ = q

--- a/testdata/src/gormreuse/closure_directive.go.golden
+++ b/testdata/src/gormreuse/closure_directive.go.golden
@@ -377,6 +377,7 @@ type structWithFuncField struct {
 }
 
 // multiAssign01: Both closures in same assignment get the directive
+//gormreuse:immutable-param
 func multiAssign01(db *gorm.DB) {
 	//gormreuse:pure
 	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
@@ -391,6 +392,7 @@ func multiAssign01(db *gorm.DB) {
 }
 
 // multiAssign02: Both variables get directive (direct assignment)
+//gormreuse:immutable-param
 func multiAssign02(db *gorm.DB) {
 	var a, c func(q *gorm.DB)
 
@@ -407,6 +409,7 @@ func multiAssign02(db *gorm.DB) {
 }
 
 // multiAssign03: Only first closure gets directive (second is inside struct literal)
+//gormreuse:immutable-param
 func multiAssign03(db *gorm.DB) {
 	//gormreuse:pure
 	a, b := func(q *gorm.DB) { _ = q }, &structWithFuncField{Fn: func(q *gorm.DB) { _ = q }}
@@ -421,6 +424,7 @@ func multiAssign03(db *gorm.DB) {
 }
 
 // multiAssign04: Three closures - first two direct, third in composite literal
+//gormreuse:immutable-param
 func multiAssign04(db *gorm.DB) {
 	//gormreuse:pure
 	a, b, c := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }, []func(*gorm.DB){func(q *gorm.DB) { _ = q }}[0]
@@ -439,6 +443,7 @@ func multiAssign04(db *gorm.DB) {
 }
 
 // multiAssign05: Separated statements - only first gets directive
+//gormreuse:immutable-param
 func multiAssign05(db *gorm.DB) {
 	//gormreuse:pure
 	a := func(q *gorm.DB) { _ = q }
@@ -454,6 +459,7 @@ func multiAssign05(db *gorm.DB) {
 }
 
 // multiAssign06: Semicolon-separated on same line - only first statement gets directive
+//gormreuse:immutable-param
 func multiAssign06(db *gorm.DB) {
 	//gormreuse:pure
 	a := func(q *gorm.DB) { _ = q }; b := func(q *gorm.DB) { _ = q }
@@ -468,6 +474,7 @@ func multiAssign06(db *gorm.DB) {
 }
 
 // multiAssign07: Multi-line assignment - all closures in same statement get directive
+//gormreuse:immutable-param
 func multiAssign07(db *gorm.DB) {
 	//gormreuse:pure
 	a, b, c := func(q *gorm.DB) { _ = q },
@@ -489,6 +496,7 @@ func multiAssign07(db *gorm.DB) {
 
 
 // multiAssign08: Multi-line assignment with comments between closures
+//gormreuse:immutable-param
 func multiAssign08(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q
@@ -517,6 +525,7 @@ func multiAssign08(db *gorm.DB) {
 
 // multiAssign09: Directive after closing brace does NOT apply to next line
 // }, //gormreuse:pure should not apply to the FuncLit on the next line
+//gormreuse:immutable-param
 func multiAssign09(db *gorm.DB) {
 	a, b, c := func(q *gorm.DB) { //gormreuse:pure
 		_ = q

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -919,17 +919,19 @@ func useDBFactory(f *DBFactory) {
 // If the function pollutes its *gorm.DB argument, it will be reported.
 // =============================================================================
 
-// PIR101: pure,immutable-return but pollutes argument
+// PIR101: pure,immutable-return but pollutes argument. immutable-param keeps the
+// test focused on the pure contract rather than Phase 1b parameter branching.
 //
-//gormreuse:pure,immutable-return
+//gormreuse:pure,immutable-return,immutable-param
 func badPureImmutable(db *gorm.DB) *gorm.DB {
 	db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
 	return db.Session(&gorm.Session{})
 }
 
-// PIR102: pure,immutable-return but passes to non-pure function
+// PIR102: pure,immutable-return but passes to non-pure function. immutable-param
+// keeps the test focused on the pure contract, not Phase 1b parameter branching.
 //
-//gormreuse:pure,immutable-return
+//gormreuse:pure,immutable-return,immutable-param
 func badPureImmutablePassesNonPure(db *gorm.DB) *gorm.DB {
 	nonPureHelper(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureHelper`
 	return db.Session(&gorm.Session{})
@@ -943,7 +945,7 @@ func badPureImmutablePassesNonPure(db *gorm.DB) *gorm.DB {
 // This function pollutes its argument but that's allowed without pure directive.
 // The return value is still treated as immutable.
 //
-//gormreuse:immutable-return
+//gormreuse:immutable-return,immutable-param
 func immutableOnlyPollutes(db *gorm.DB) *gorm.DB {
 	db.Where("pollute") // No error - not marked as pure
 	return db.Session(&gorm.Session{})
@@ -1135,8 +1137,9 @@ func multiAssignPureValidSibling(db *gorm.DB) {
 }
 
 // blockCommentPureBad: block-comment directive form is now recognized, so the
-// pure contract is enforced (previously a silent no-op).
-/*gormreuse:pure*/
+// pure contract is enforced (previously a silent no-op). immutable-param keeps
+// the test focused on the pure contract, not Phase 1b parameter branching.
+/*gormreuse:pure,immutable-param*/
 func blockCommentPureBad(db *gorm.DB) *gorm.DB {
 	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
 	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1182 +1,1182 @@
+@@ -1,1185 +1,1185 @@
  package internal
  
  import (
@@ -925,17 +925,19 @@
  // If the function pollutes its *gorm.DB argument, it will be reported.
  // =============================================================================
  
- // PIR101: pure,immutable-return but pollutes argument
+ // PIR101: pure,immutable-return but pollutes argument. immutable-param keeps the
+ // test focused on the pure contract rather than Phase 1b parameter branching.
  //
- //gormreuse:pure,immutable-return
+ //gormreuse:pure,immutable-return,immutable-param
  func badPureImmutable(db *gorm.DB) *gorm.DB {
  	db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
  	return db.Session(&gorm.Session{})
  }
  
- // PIR102: pure,immutable-return but passes to non-pure function
+ // PIR102: pure,immutable-return but passes to non-pure function. immutable-param
+ // keeps the test focused on the pure contract, not Phase 1b parameter branching.
  //
- //gormreuse:pure,immutable-return
+ //gormreuse:pure,immutable-return,immutable-param
  func badPureImmutablePassesNonPure(db *gorm.DB) *gorm.DB {
  	nonPureHelper(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureHelper`
  	return db.Session(&gorm.Session{})
@@ -949,7 +951,7 @@
  // This function pollutes its argument but that's allowed without pure directive.
  // The return value is still treated as immutable.
  //
- //gormreuse:immutable-return
+ //gormreuse:immutable-return,immutable-param
  func immutableOnlyPollutes(db *gorm.DB) *gorm.DB {
  	db.Where("pollute") // No error - not marked as pure
  	return db.Session(&gorm.Session{})
@@ -1141,8 +1143,9 @@
  }
  
  // blockCommentPureBad: block-comment directive form is now recognized, so the
- // pure contract is enforced (previously a silent no-op).
- /*gormreuse:pure*/
+ // pure contract is enforced (previously a silent no-op). immutable-param keeps
+ // the test focused on the pure contract, not Phase 1b parameter branching.
+ /*gormreuse:pure,immutable-param*/
  func blockCommentPureBad(db *gorm.DB) *gorm.DB {
  	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
  	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -919,17 +919,19 @@ func useDBFactory(f *DBFactory) {
 // If the function pollutes its *gorm.DB argument, it will be reported.
 // =============================================================================
 
-// PIR101: pure,immutable-return but pollutes argument
+// PIR101: pure,immutable-return but pollutes argument. immutable-param keeps the
+// test focused on the pure contract rather than Phase 1b parameter branching.
 //
-//gormreuse:pure,immutable-return
+//gormreuse:pure,immutable-return,immutable-param
 func badPureImmutable(db *gorm.DB) *gorm.DB {
 	db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`
 	return db.Session(&gorm.Session{})
 }
 
-// PIR102: pure,immutable-return but passes to non-pure function
+// PIR102: pure,immutable-return but passes to non-pure function. immutable-param
+// keeps the test focused on the pure contract, not Phase 1b parameter branching.
 //
-//gormreuse:pure,immutable-return
+//gormreuse:pure,immutable-return,immutable-param
 func badPureImmutablePassesNonPure(db *gorm.DB) *gorm.DB {
 	nonPureHelper(db) // want `pure function passes \*gorm\.DB argument to non-pure function nonPureHelper`
 	return db.Session(&gorm.Session{})
@@ -943,7 +945,7 @@ func badPureImmutablePassesNonPure(db *gorm.DB) *gorm.DB {
 // This function pollutes its argument but that's allowed without pure directive.
 // The return value is still treated as immutable.
 //
-//gormreuse:immutable-return
+//gormreuse:immutable-return,immutable-param
 func immutableOnlyPollutes(db *gorm.DB) *gorm.DB {
 	db.Where("pollute") // No error - not marked as pure
 	return db.Session(&gorm.Session{})
@@ -1135,8 +1137,9 @@ func multiAssignPureValidSibling(db *gorm.DB) {
 }
 
 // blockCommentPureBad: block-comment directive form is now recognized, so the
-// pure contract is enforced (previously a silent no-op).
-/*gormreuse:pure*/
+// pure contract is enforced (previously a silent no-op). immutable-param keeps
+// the test focused on the pure contract, not Phase 1b parameter branching.
+/*gormreuse:pure,immutable-param*/
 func blockCommentPureBad(db *gorm.DB) *gorm.DB {
 	db.Find(nil)         // want `pure function pollutes \*gorm\.DB argument by calling Find`
 	return db.Where("x") // want `pure function pollutes \*gorm\.DB argument by calling Where`

--- a/testdata/src/gormreuse/evil.go
+++ b/testdata/src/gormreuse/evil.go
@@ -252,6 +252,7 @@ func loopWithSession(db *gorm.DB, items []string) {
 }
 
 // loopNewChainEachIteration demonstrates creating new chain in each iteration.
+//gormreuse:immutable-param
 func loopNewChainEachIteration(db *gorm.DB, items []string) {
 	for _, item := range items {
 		q := db.Where("item = ?", item)
@@ -2201,6 +2202,7 @@ func iifeArgumentReturnsChain(db *gorm.DB) {
 }
 
 // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
+//gormreuse:immutable-param
 func iifeArgumentAndFreeVarMixed(db *gorm.DB) {
 	q1 := db.Where("q1", 1)
 	q2 := db.Where("q2", 2)
@@ -2323,6 +2325,7 @@ func beginChainedBecomesMutable(db *gorm.DB) {
 
 // reassignInLoop demonstrates reassignment inside a loop.
 // Each iteration creates a new mutable instance.
+//gormreuse:immutable-param
 func reassignInLoop(db *gorm.DB, items []string) {
 	var q *gorm.DB
 	for _, item := range items {
@@ -2334,6 +2337,7 @@ func reassignInLoop(db *gorm.DB, items []string) {
 
 // reassignInLoopSafe demonstrates safe reassignment pattern in loop.
 // Reassignment before each use prevents pollution carry-over.
+//gormreuse:immutable-param
 func reassignInLoopSafe(db *gorm.DB, items []string) {
 	var q *gorm.DB
 	for _, item := range items {
@@ -2358,6 +2362,7 @@ func reassignConditionalPartial(db *gorm.DB, flag bool) {
 
 // reassignConditionalBoth demonstrates reassignment in both branches.
 // Both branches reassign - should be safe.
+//gormreuse:immutable-param
 func reassignConditionalBoth(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2383,6 +2388,7 @@ func reassignAfterPollutionSameValue(db *gorm.DB) {
 
 // reassignShadowing demonstrates variable shadowing vs reassignment.
 // Inner q shadows outer q - they are different variables.
+//gormreuse:immutable-param
 func reassignShadowing(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes outer q
@@ -2409,6 +2415,7 @@ func reassignInClosure(db *gorm.DB) {
 }
 
 // reassignFromHelper demonstrates reassignment from helper function.
+//gormreuse:immutable-param
 func reassignFromHelper(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2423,6 +2430,7 @@ func helperReturnsDB(db *gorm.DB) *gorm.DB {
 }
 
 // reassignNilThenUse demonstrates reassigning to nil then using.
+//gormreuse:immutable-param
 func reassignNilThenUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2434,6 +2442,7 @@ func reassignNilThenUse(db *gorm.DB) {
 }
 
 // reassignChainExtension demonstrates extending a chain after reassignment.
+//gormreuse:immutable-param
 func reassignChainExtension(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2445,6 +2454,7 @@ func reassignChainExtension(db *gorm.DB) {
 }
 
 // reassignMultipleTimes demonstrates multiple reassignments.
+//gormreuse:immutable-param
 func reassignMultipleTimes(db *gorm.DB) {
 	q := db.Where("a = ?", 1)
 	q.Find(nil) // Pollutes first q
@@ -2478,6 +2488,7 @@ func reassignInSwitch(db *gorm.DB, mode int) {
 }
 
 // reassignInSwitchAll demonstrates reassignment in all switch branches.
+//gormreuse:immutable-param
 func reassignInSwitchAll(db *gorm.DB, mode int) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2495,6 +2506,7 @@ func reassignInSwitchAll(db *gorm.DB, mode int) {
 }
 
 // reassignFromMethodValue demonstrates reassignment via method value result.
+//gormreuse:immutable-param
 func reassignFromMethodValue(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2507,6 +2519,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 
 // reassignDeferredUse demonstrates reassignment with deferred use.
 // The defer evaluates q immediately - Count pollutes, then defer uses polluted q.
+//gormreuse:immutable-param
 func reassignDeferredUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 
@@ -2956,6 +2969,7 @@ type conditionalFieldAssignHolderForTest struct {
 // conditionalFieldAssignOnePolluted demonstrates conditional field assignment
 // where one branch assigns a polluted value.
 // The linter should detect this because q1 (polluted) may be used via h.db.
+//gormreuse:immutable-param
 func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
 	q2 := db.Where("b")
@@ -2977,6 +2991,7 @@ func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 // traceFieldStore which returns the first Store found.
 // [BUG DETECTOR] If this test passes but conditionalFieldAssignOnePolluted fails,
 // or vice versa, there's an ordering bug in traceFieldStore.
+//gormreuse:immutable-param
 func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
 	q2 := db.Where("b")
@@ -2995,6 +3010,7 @@ func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 
 // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
 // where both branches assign polluted values.
+//gormreuse:immutable-param
 func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
 	q2 := db.Where("b")

--- a/testdata/src/gormreuse/evil.go.diff
+++ b/testdata/src/gormreuse/evil.go.diff
@@ -1,6 +1,6 @@
 --- evil.go	1970-01-01 00:00:00
 +++ evil.go.golden	1970-01-01 00:00:00
-@@ -1,3182 +1,3182 @@
+@@ -1,3198 +1,3198 @@
  package internal
  
  import "gorm.io/gorm"
@@ -269,6 +269,7 @@
  }
  
  // loopNewChainEachIteration demonstrates creating new chain in each iteration.
+ //gormreuse:immutable-param
  func loopNewChainEachIteration(db *gorm.DB, items []string) {
  	for _, item := range items {
  		q := db.Where("item = ?", item)
@@ -2308,6 +2309,7 @@
  }
  
  // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
+ //gormreuse:immutable-param
  func iifeArgumentAndFreeVarMixed(db *gorm.DB) {
 -	q1 := db.Where("q1", 1)
 -	q2 := db.Where("q2", 2)
@@ -2442,6 +2444,7 @@
  
  // reassignInLoop demonstrates reassignment inside a loop.
  // Each iteration creates a new mutable instance.
+ //gormreuse:immutable-param
  func reassignInLoop(db *gorm.DB, items []string) {
  	var q *gorm.DB
  	for _, item := range items {
@@ -2454,6 +2457,7 @@
  
  // reassignInLoopSafe demonstrates safe reassignment pattern in loop.
  // Reassignment before each use prevents pollution carry-over.
+ //gormreuse:immutable-param
  func reassignInLoopSafe(db *gorm.DB, items []string) {
  	var q *gorm.DB
  	for _, item := range items {
@@ -2478,6 +2482,7 @@
  
  // reassignConditionalBoth demonstrates reassignment in both branches.
  // Both branches reassign - should be safe.
+ //gormreuse:immutable-param
  func reassignConditionalBoth(db *gorm.DB, flag bool) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2504,6 +2509,7 @@
  
  // reassignShadowing demonstrates variable shadowing vs reassignment.
  // Inner q shadows outer q - they are different variables.
+ //gormreuse:immutable-param
  func reassignShadowing(db *gorm.DB) {
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
@@ -2533,6 +2539,7 @@
  }
  
  // reassignFromHelper demonstrates reassignment from helper function.
+ //gormreuse:immutable-param
  func reassignFromHelper(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2548,6 +2555,7 @@
  }
  
  // reassignNilThenUse demonstrates reassigning to nil then using.
+ //gormreuse:immutable-param
  func reassignNilThenUse(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2559,6 +2567,7 @@
  }
  
  // reassignChainExtension demonstrates extending a chain after reassignment.
+ //gormreuse:immutable-param
  func reassignChainExtension(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2571,6 +2580,7 @@
  }
  
  // reassignMultipleTimes demonstrates multiple reassignments.
+ //gormreuse:immutable-param
  func reassignMultipleTimes(db *gorm.DB) {
  	q := db.Where("a = ?", 1)
  	q.Find(nil) // Pollutes first q
@@ -2604,6 +2614,7 @@
  }
  
  // reassignInSwitchAll demonstrates reassignment in all switch branches.
+ //gormreuse:immutable-param
  func reassignInSwitchAll(db *gorm.DB, mode int) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2621,6 +2632,7 @@
  }
  
  // reassignFromMethodValue demonstrates reassignment via method value result.
+ //gormreuse:immutable-param
  func reassignFromMethodValue(db *gorm.DB) {
  	q := db.Where("x = ?", 1)
  	q.Find(nil) // Pollutes q
@@ -2633,6 +2645,7 @@
  
  // reassignDeferredUse demonstrates reassignment with deferred use.
  // The defer evaluates q immediately - Count pollutes, then defer uses polluted q.
+ //gormreuse:immutable-param
  func reassignDeferredUse(db *gorm.DB) {
 -	q := db.Where("x = ?", 1)
 +	q := db.Where("x = ?", 1).Session(&gorm.Session{})
@@ -3128,6 +3141,7 @@
  // conditionalFieldAssignOnePolluted demonstrates conditional field assignment
  // where one branch assigns a polluted value.
  // The linter should detect this because q1 (polluted) may be used via h.db.
+ //gormreuse:immutable-param
  func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 -	q1 := db.Where("a")
 +	q1 := db.Where("a").Session(&gorm.Session{})
@@ -3150,6 +3164,7 @@
  // traceFieldStore which returns the first Store found.
  // [BUG DETECTOR] If this test passes but conditionalFieldAssignOnePolluted fails,
  // or vice versa, there's an ordering bug in traceFieldStore.
+ //gormreuse:immutable-param
  func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
  	q1 := db.Where("a")
 -	q2 := db.Where("b")
@@ -3169,6 +3184,7 @@
  
  // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
  // where both branches assign polluted values.
+ //gormreuse:immutable-param
  func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
  	q1 := db.Where("a")
 -	q2 := db.Where("b")

--- a/testdata/src/gormreuse/evil.go.golden
+++ b/testdata/src/gormreuse/evil.go.golden
@@ -252,6 +252,7 @@ func loopWithSession(db *gorm.DB, items []string) {
 }
 
 // loopNewChainEachIteration demonstrates creating new chain in each iteration.
+//gormreuse:immutable-param
 func loopNewChainEachIteration(db *gorm.DB, items []string) {
 	for _, item := range items {
 		q := db.Where("item = ?", item)
@@ -2201,6 +2202,7 @@ func iifeArgumentReturnsChain(db *gorm.DB) {
 }
 
 // iifeArgumentAndFreeVarMixed demonstrates IIFE with both argument and FreeVar.
+//gormreuse:immutable-param
 func iifeArgumentAndFreeVarMixed(db *gorm.DB) {
 	q1 := db.Where("q1", 1).Session(&gorm.Session{})
 	q2 := db.Where("q2", 2).Session(&gorm.Session{})
@@ -2323,6 +2325,7 @@ func beginChainedBecomesMutable(db *gorm.DB) {
 
 // reassignInLoop demonstrates reassignment inside a loop.
 // Each iteration creates a new mutable instance.
+//gormreuse:immutable-param
 func reassignInLoop(db *gorm.DB, items []string) {
 	var q *gorm.DB
 	for _, item := range items {
@@ -2334,6 +2337,7 @@ func reassignInLoop(db *gorm.DB, items []string) {
 
 // reassignInLoopSafe demonstrates safe reassignment pattern in loop.
 // Reassignment before each use prevents pollution carry-over.
+//gormreuse:immutable-param
 func reassignInLoopSafe(db *gorm.DB, items []string) {
 	var q *gorm.DB
 	for _, item := range items {
@@ -2358,6 +2362,7 @@ func reassignConditionalPartial(db *gorm.DB, flag bool) {
 
 // reassignConditionalBoth demonstrates reassignment in both branches.
 // Both branches reassign - should be safe.
+//gormreuse:immutable-param
 func reassignConditionalBoth(db *gorm.DB, flag bool) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2383,6 +2388,7 @@ func reassignAfterPollutionSameValue(db *gorm.DB) {
 
 // reassignShadowing demonstrates variable shadowing vs reassignment.
 // Inner q shadows outer q - they are different variables.
+//gormreuse:immutable-param
 func reassignShadowing(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 	q.Find(nil) // Pollutes outer q
@@ -2409,6 +2415,7 @@ func reassignInClosure(db *gorm.DB) {
 }
 
 // reassignFromHelper demonstrates reassignment from helper function.
+//gormreuse:immutable-param
 func reassignFromHelper(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2423,6 +2430,7 @@ func helperReturnsDB(db *gorm.DB) *gorm.DB {
 }
 
 // reassignNilThenUse demonstrates reassigning to nil then using.
+//gormreuse:immutable-param
 func reassignNilThenUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2434,6 +2442,7 @@ func reassignNilThenUse(db *gorm.DB) {
 }
 
 // reassignChainExtension demonstrates extending a chain after reassignment.
+//gormreuse:immutable-param
 func reassignChainExtension(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2445,6 +2454,7 @@ func reassignChainExtension(db *gorm.DB) {
 }
 
 // reassignMultipleTimes demonstrates multiple reassignments.
+//gormreuse:immutable-param
 func reassignMultipleTimes(db *gorm.DB) {
 	q := db.Where("a = ?", 1)
 	q.Find(nil) // Pollutes first q
@@ -2478,6 +2488,7 @@ func reassignInSwitch(db *gorm.DB, mode int) {
 }
 
 // reassignInSwitchAll demonstrates reassignment in all switch branches.
+//gormreuse:immutable-param
 func reassignInSwitchAll(db *gorm.DB, mode int) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2495,6 +2506,7 @@ func reassignInSwitchAll(db *gorm.DB, mode int) {
 }
 
 // reassignFromMethodValue demonstrates reassignment via method value result.
+//gormreuse:immutable-param
 func reassignFromMethodValue(db *gorm.DB) {
 	q := db.Where("x = ?", 1)
 	q.Find(nil) // Pollutes q
@@ -2507,6 +2519,7 @@ func reassignFromMethodValue(db *gorm.DB) {
 
 // reassignDeferredUse demonstrates reassignment with deferred use.
 // The defer evaluates q immediately - Count pollutes, then defer uses polluted q.
+//gormreuse:immutable-param
 func reassignDeferredUse(db *gorm.DB) {
 	q := db.Where("x = ?", 1).Session(&gorm.Session{})
 
@@ -2956,6 +2969,7 @@ type conditionalFieldAssignHolderForTest struct {
 // conditionalFieldAssignOnePolluted demonstrates conditional field assignment
 // where one branch assigns a polluted value.
 // The linter should detect this because q1 (polluted) may be used via h.db.
+//gormreuse:immutable-param
 func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 	q1 := db.Where("a").Session(&gorm.Session{})
 	q2 := db.Where("b")
@@ -2977,6 +2991,7 @@ func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) {
 // traceFieldStore which returns the first Store found.
 // [BUG DETECTOR] If this test passes but conditionalFieldAssignOnePolluted fails,
 // or vice versa, there's an ordering bug in traceFieldStore.
+//gormreuse:immutable-param
 func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
 	q2 := db.Where("b").Session(&gorm.Session{})
@@ -2995,6 +3010,7 @@ func conditionalFieldAssignOnePollutedReverse(db *gorm.DB, cond bool) {
 
 // conditionalFieldAssignBothPolluted demonstrates conditional field assignment
 // where both branches assign polluted values.
+//gormreuse:immutable-param
 func conditionalFieldAssignBothPolluted(db *gorm.DB, cond bool) {
 	q1 := db.Where("a")
 	q2 := db.Where("b").Session(&gorm.Session{})

--- a/testdata/src/gormreuse/interface_patterns.go
+++ b/testdata/src/gormreuse/interface_patterns.go
@@ -72,6 +72,7 @@ func variadicInterfaceArgs(db *gorm.DB) {
 }
 
 // variadicInterfaceArgsMultiple: Multiple args to variadic
+//gormreuse:immutable-param
 func variadicInterfaceArgsMultiple(db *gorm.DB) {
 	q1 := db.Where("x")
 	q2 := db.Where("y")
@@ -84,6 +85,7 @@ func variadicInterfaceArgsMultiple(db *gorm.DB) {
 }
 
 // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
+//gormreuse:immutable-param
 func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 	q1 := db.Where("x")
 	q2 := db.Where("y")
@@ -171,6 +173,7 @@ func gormOrMethodChain(db *gorm.DB) {
 }
 
 // gormOrMethodFresh: Fresh query passed to Or (no reuse)
+//gormreuse:immutable-param
 func gormOrMethodFresh(db *gorm.DB) {
 	base := db.Where("base")
 
@@ -196,6 +199,7 @@ func interfaceSliceLiteral(db *gorm.DB) {
 }
 
 // interfaceSliceMultiple: Multiple *gorm.DB in slice
+//gormreuse:immutable-param
 func interfaceSliceMultiple(db *gorm.DB) {
 	q1 := db.Where("x")
 	q2 := db.Where("y")

--- a/testdata/src/gormreuse/interface_patterns.go.diff
+++ b/testdata/src/gormreuse/interface_patterns.go.diff
@@ -1,6 +1,6 @@
 --- interface_patterns.go	1970-01-01 00:00:00
 +++ interface_patterns.go.golden	1970-01-01 00:00:00
-@@ -1,379 +1,379 @@
+@@ -1,383 +1,383 @@
  package internal
  
  import "gorm.io/gorm"
@@ -76,6 +76,7 @@
  }
  
  // variadicInterfaceArgsMultiple: Multiple args to variadic
+ //gormreuse:immutable-param
  func variadicInterfaceArgsMultiple(db *gorm.DB) {
 -	q1 := db.Where("x")
 -	q2 := db.Where("y")
@@ -90,6 +91,7 @@
  }
  
  // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
+ //gormreuse:immutable-param
  func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 -	q1 := db.Where("x")
 +	q1 := db.Where("x").Session(&gorm.Session{})
@@ -183,6 +185,7 @@
  }
  
  // gormOrMethodFresh: Fresh query passed to Or (no reuse)
+ //gormreuse:immutable-param
  func gormOrMethodFresh(db *gorm.DB) {
  	base := db.Where("base")
  
@@ -210,6 +213,7 @@
  }
  
  // interfaceSliceMultiple: Multiple *gorm.DB in slice
+ //gormreuse:immutable-param
  func interfaceSliceMultiple(db *gorm.DB) {
 -	q1 := db.Where("x")
 -	q2 := db.Where("y")

--- a/testdata/src/gormreuse/interface_patterns.go.golden
+++ b/testdata/src/gormreuse/interface_patterns.go.golden
@@ -72,6 +72,7 @@ func variadicInterfaceArgs(db *gorm.DB) {
 }
 
 // variadicInterfaceArgsMultiple: Multiple args to variadic
+//gormreuse:immutable-param
 func variadicInterfaceArgsMultiple(db *gorm.DB) {
 	q1 := db.Where("x").Session(&gorm.Session{})
 	q2 := db.Where("y").Session(&gorm.Session{})
@@ -84,6 +85,7 @@ func variadicInterfaceArgsMultiple(db *gorm.DB) {
 }
 
 // variadicInterfaceArgsOnlyOne: Only one of multiple is passed
+//gormreuse:immutable-param
 func variadicInterfaceArgsOnlyOne(db *gorm.DB) {
 	q1 := db.Where("x").Session(&gorm.Session{})
 	q2 := db.Where("y")
@@ -171,6 +173,7 @@ func gormOrMethodChain(db *gorm.DB) {
 }
 
 // gormOrMethodFresh: Fresh query passed to Or (no reuse)
+//gormreuse:immutable-param
 func gormOrMethodFresh(db *gorm.DB) {
 	base := db.Where("base")
 
@@ -196,6 +199,7 @@ func interfaceSliceLiteral(db *gorm.DB) {
 }
 
 // interfaceSliceMultiple: Multiple *gorm.DB in slice
+//gormreuse:immutable-param
 func interfaceSliceMultiple(db *gorm.DB) {
 	q1 := db.Where("x").Session(&gorm.Session{})
 	q2 := db.Where("y").Session(&gorm.Session{})

--- a/testdata/src/gormreuse/nested_chaos.go
+++ b/testdata/src/gormreuse/nested_chaos.go
@@ -796,7 +796,10 @@ func chaosInterwovenVariables(db *gorm.DB, a, b, c bool) {
 	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// chaosVariableSwap demonstrates variable swapping patterns.
+// chaosVariableSwap demonstrates variable swapping patterns. immutable-param
+// keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func chaosVariableSwap(db *gorm.DB, a, b bool) {
 	q1 := db.Where("q1_base")
 	q2 := db.Where("q2_base")
@@ -833,7 +836,10 @@ func chaosVariableSwapConditional(db *gorm.DB, swap bool) {
 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// chaosVariableSwapChain demonstrates swapping with chaining.
+// chaosVariableSwapChain demonstrates swapping with chaining. immutable-param
+// keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func chaosVariableSwapChain(db *gorm.DB) {
 	q1 := db.Where("q1")
 	q2 := db.Where("q2")
@@ -905,6 +911,9 @@ func chaosMultipleSwaps(db *gorm.DB, a, b, c bool) {
 }
 
 // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
+// immutable-param keeps the test focused on the swap, not parameter branching.
+//
+//gormreuse:immutable-param
 func chaosModernSwapSyntax(db *gorm.DB, a bool) {
 	q1 := db.Where("q1")
 	q2 := db.Where("q2")

--- a/testdata/src/gormreuse/nested_chaos.go.diff
+++ b/testdata/src/gormreuse/nested_chaos.go.diff
@@ -1,6 +1,6 @@
 --- nested_chaos.go	1970-01-01 00:00:00
 +++ nested_chaos.go.golden	1970-01-01 00:00:00
-@@ -1,1205 +1,1205 @@
+@@ -1,1214 +1,1214 @@
  package internal
  
  import "gorm.io/gorm"
@@ -857,7 +857,10 @@
  	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
- // chaosVariableSwap demonstrates variable swapping patterns.
+ // chaosVariableSwap demonstrates variable swapping patterns. immutable-param
+ // keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+ //
+ //gormreuse:immutable-param
  func chaosVariableSwap(db *gorm.DB, a, b bool) {
 -	q1 := db.Where("q1_base")
 -	q2 := db.Where("q2_base")
@@ -896,7 +899,10 @@
  	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
- // chaosVariableSwapChain demonstrates swapping with chaining.
+ // chaosVariableSwapChain demonstrates swapping with chaining. immutable-param
+ // keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+ //
+ //gormreuse:immutable-param
  func chaosVariableSwapChain(db *gorm.DB) {
  	q1 := db.Where("q1")
  	q2 := db.Where("q2")
@@ -972,6 +978,9 @@
  }
  
  // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
+ // immutable-param keeps the test focused on the swap, not parameter branching.
+ //
+ //gormreuse:immutable-param
  func chaosModernSwapSyntax(db *gorm.DB, a bool) {
 -	q1 := db.Where("q1")
 -	q2 := db.Where("q2")

--- a/testdata/src/gormreuse/nested_chaos.go.golden
+++ b/testdata/src/gormreuse/nested_chaos.go.golden
@@ -796,7 +796,10 @@ func chaosInterwovenVariables(db *gorm.DB, a, b, c bool) {
 	q2.Last(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// chaosVariableSwap demonstrates variable swapping patterns.
+// chaosVariableSwap demonstrates variable swapping patterns. immutable-param
+// keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func chaosVariableSwap(db *gorm.DB, a, b bool) {
 	q1 := db.Where("q1_base").Session(&gorm.Session{})
 	q2 := db.Where("q2_base").Session(&gorm.Session{})
@@ -833,7 +836,10 @@ func chaosVariableSwapConditional(db *gorm.DB, swap bool) {
 	q2.Count(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
-// chaosVariableSwapChain demonstrates swapping with chaining.
+// chaosVariableSwapChain demonstrates swapping with chaining. immutable-param
+// keeps the test focused on the swap, not Phase 1b parameter branching (#61).
+//
+//gormreuse:immutable-param
 func chaosVariableSwapChain(db *gorm.DB) {
 	q1 := db.Where("q1")
 	q2 := db.Where("q2")
@@ -905,6 +911,9 @@ func chaosMultipleSwaps(db *gorm.DB, a, b, c bool) {
 }
 
 // chaosModernSwapSyntax demonstrates modern Go swap syntax (a, b = b, a).
+// immutable-param keeps the test focused on the swap, not parameter branching.
+//
+//gormreuse:immutable-param
 func chaosModernSwapSyntax(db *gorm.DB, a bool) {
 	q1 := db.Where("q1").Session(&gorm.Session{})
 	q2 := db.Where("q2").Session(&gorm.Session{})

--- a/testdata/src/gormreuse/scopes_callback.go
+++ b/testdata/src/gormreuse/scopes_callback.go
@@ -75,9 +75,10 @@ func transactionCallbackNoReport(db *gorm.DB) {
 	})
 }
 
-// SC104: An ordinary (non-Scopes) func(*gorm.DB) *gorm.DB helper still treats
-// its parameter as immutable — Phase 1a does NOT broaden to all parameters.
-func ordinaryHelperParamStillImmutable(tx *gorm.DB) *gorm.DB {
+// SC104: Under Phase 1b (#61) an ordinary func(*gorm.DB) *gorm.DB helper's
+// parameter is a mutable root — a caller may pass a mid-chain value, so branching
+// it twice interferes. (Contrast with immutable-param-annotated helpers below.)
+func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
-	return tx.Where("b") // OK: ordinary parameter is immutable (caller's concern)
+	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -75,9 +75,10 @@ func transactionCallbackNoReport(db *gorm.DB) {
 	})
 }
 
-// SC104: An ordinary (non-Scopes) func(*gorm.DB) *gorm.DB helper still treats
-// its parameter as immutable — Phase 1a does NOT broaden to all parameters.
-func ordinaryHelperParamStillImmutable(tx *gorm.DB) *gorm.DB {
+// SC104: Under Phase 1b (#61) an ordinary func(*gorm.DB) *gorm.DB helper's
+// parameter is a mutable root — a caller may pass a mid-chain value, so branching
+// it twice interferes. (Contrast with immutable-param-annotated helpers below.)
+func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
-	return tx.Where("b") // OK: ordinary parameter is immutable (caller's concern)
+	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }


### PR DESCRIPTION
## Phase 1b, Stage 2a — the breaking flip (#61)

Makes `*gorm.DB` **parameters mutable roots by default**. A caller may pass a mid-chain (`clone==0`) value, so branching a parameter interferes exactly as branching a local would. Stage 1 (#106) recognized the escape directive inertly; the tracer now actually consults it.

### The decision rule (what changed)

A `*gorm.DB` **parameter** is now a **mutable root** ⇒ **branching it ≥2×** (2nd branch reachable from the 1st) **reports**. Exceptions stay silent:

| Case | Root? | Reports on 2nd branch? |
|---|---|---|
| ordinary `*gorm.DB` param | **mutable (new)** | **yes** |
| param of `//gormreuse:immutable-param` fn | immutable | no |
| `tx` of `Transaction(func(tx){…})` callback | immutable (`clone>0`) | no |
| Scopes/Preload callback param | mutable | yes (immutable-param **ignored**) |
| param used in a **single** chain | mutable, 1 branch | no |

Local-root detection is unchanged. Parameter roots still get **no auto-fix** (no def-site to isolate), so a newly-mutable param reports without a misleading rewrite.

---

# Report-vs-silent, with snippets (review aid)

## ① NOW REPORTS — 7 new true positives (`// want` added)

**`basic.go`** — a parameter branched twice:
```go
func separateChains(db *gorm.DB) {
	db.Where("a = ?", 1).Find(&[]User{})
	db.Where("b = ?", 2).Find(&[]User{}) // ▶ REPORTS: 2nd branch from db
}

func separateVariables(db *gorm.DB) {
	q1 := db.Where("a = ?", 1)
	q2 := db.Where("b = ?", 2) // ▶ REPORTS: 2nd branch from db (at the q2 assignment)
	q1.Find(nil)
	q2.Find(nil)
}

func parameterDirectUse(db *gorm.DB) {
	db.Where("a = ?", 1).Find(nil)
	db.Where("b = ?", 2).Find(nil) // ▶ REPORTS
}

func parameterMultipleChains(db *gorm.DB) {
	db.Where("x").Order("id").Find(nil)
	db.Where("y").Limit(10).Find(nil) // ▶ REPORTS
}
```

**`scopes_callback.go`** — renamed¹ helper whose premise 1b removes:
```go
func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
	tx.Where("a").Find(nil)
	return tx.Where("b") // ▶ REPORTS: 2nd branch from tx
}
```
¹ was `ordinaryHelperParamStillImmutable`; tracer unit-test reference updated.

**`advanced.go`** — the #71 fix-generator guard; now fires **and** must produce **no** bogus fix:
```go
func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
	require.NoError(t, tx.Create(nil).Error)
	require.NoError(t, tx.Create(nil).Error) // ▶ REPORTS: 2nd branch (NO `tx = require.NoError(...)` fix)
	require.NoError(t, tx.Create(nil).Error) // ▶ REPORTS: 3rd branch
}

func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
	require.NoError(t, tx.Create(nil).Error)
	tx.Create(nil) // ▶ REPORTS: 2nd branch
}
```
Verified in `advanced.go.golden`: both are byte-identical to source (param root ⇒ no fix).

## ② STAYS SILENT — structural carve-out (no directive needed)

**`scopes_callback.go`** — the one case that is silent purely from the new `Transaction` detection:
```go
func transactionCallbackNoReport(db *gorm.DB) {
	_ = db.Transaction(func(tx *gorm.DB) error {
		tx.Where("a").Find(nil)
		tx.Where("b").Find(nil) // ○ SILENT: tx is a Transaction callback = fresh forkable handle (clone>0)
		return nil
	})
}
```
Plus: any `func(db *gorm.DB)` that chains `db` **once** is 1 branch, never a report (untouched).

## ③ STAYS SILENT — suppressed with `//gormreuse:immutable-param` (scaffolding)

These branch a param ≥2× only as **setup** for testing something else. The annotation takes the param off the root set so the test stays focused; **every pre-existing `// want` is preserved.**

**`closure_directive.go` — `multiAssign01`…`09`** (testing `//gormreuse:pure` placement across a multi-assignment). Representative:
```go
//gormreuse:immutable-param            // ← added: db no longer a root
func multiAssign01(db *gorm.DB) {
	//gormreuse:pure
	a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }

	q := db.Where("base")
	a(q)
	q.Find(nil)            // OK - a is pure
	q2 := db.Where("base2") // ← without the annotation this is a 2nd branch from db (noise)
	b(q2)
	q2.Find(nil)           // OK - b is pure  ← this test's real subject, still verified
}
```
`02`–`09` are the same shape with different directive-placement variants (some keep an existing closure-impurity `// want` on `q2`/`q3`, which still fires).

**`evil.go`** (16 fns — reassignment / loop / field-assign / iife). Representatives:
```go
//gormreuse:immutable-param
func reassignMultipleTimes(db *gorm.DB) {  // subject: reassignment creates fresh roots
	q := db.Where("a = ?", 1); q.Find(nil)
	q = db.Where("b = ?", 2); q.Find(nil)  // ← each db.Where would be a fresh param-branch (noise)
	q = db.Where("c = ?", 3); q.Find(nil)
	q = db.Where("d = ?", 4); q.Count(nil) // OK - new instance
}

//gormreuse:immutable-param
func loopNewChainEachIteration(db *gorm.DB, items []string) { // subject: loop makes fresh q each iter
	for _, item := range items {
		q := db.Where("item = ?", item)
		q.Find(nil) // OK: new q each iteration
	}
}

//gormreuse:immutable-param
func conditionalFieldAssignOnePolluted(db *gorm.DB, cond bool) { // subject: field-assign phi pollution
	q1 := db.Where("a")
	q2 := db.Where("b")  // ← 2nd param-branch (noise); the real want is below
	q1.Find(nil)
	h := &conditionalFieldAssignHolderForTest{}
	if cond { h.db = q1 } else { h.db = q2 }
	h.db.Count(nil) // want: reused  ← preserved (phi of polluted q1 / clean q2)
}

//gormreuse:immutable-param
func iifeArgumentAndFreeVarMixed(db *gorm.DB) { // subject: IIFE arg + FreeVar ordering
	q1 := db.Where("q1", 1)
	q2 := db.Where("q2", 2) // ← 2nd param-branch (noise)
	_ = func(inner *gorm.DB) *gorm.DB {
		_ = q2.Where("freevar").Find(nil)
		return inner.Where("arg", 1)
	}(q1).Find(nil)
	q1.Count(nil) // want: reused  ← preserved
	q2.Count(nil) // want: reused  ← preserved
}
```
Full list: `reassignInLoop`, `reassignInLoopSafe`, `reassignConditionalBoth`, `reassignShadowing`, `reassignFromHelper`, `reassignNilThenUse`, `reassignChainExtension`, `reassignMultipleTimes`, `reassignInSwitchAll`, `reassignFromMethodValue`, `reassignDeferredUse`, `loopNewChainEachIteration`, `iifeArgumentAndFreeVarMixed`, `conditionalFieldAssignOnePolluted`, `…Reverse`, `…BothPolluted`.

**`interface_patterns.go`** (interface-arg / slice-storage pollution). Representatives:
```go
//gormreuse:immutable-param
func variadicInterfaceArgsMultiple(db *gorm.DB) {
	q1 := db.Where("x")
	q2 := db.Where("y")     // ← 2nd param-branch (noise)
	acceptVariadic(q1, q2)  // pollutes both
	q1.Find(nil) // want: reused  ← preserved
	q2.Find(nil) // want: reused  ← preserved
}

//gormreuse:immutable-param
func gormOrMethodFresh(db *gorm.DB) {
	base := db.Where("base")
	base.Or(db.Where("x")) // ← the inner db.Where is a 2nd param-branch (noise)
	base.Find(nil) // want: reused (base reused)  ← preserved
}
```
Also: `variadicInterfaceArgsOnlyOne`, `interfaceSliceMultiple`.

**`nested_chaos.go`** (variable-swap tracking). Representative:
```go
//gormreuse:immutable-param
func chaosVariableSwap(db *gorm.DB, a, b bool) {
	q1 := db.Where("q1_base")
	q2 := db.Where("q2_base") // ← 2nd param-branch (noise)
	q1.Find(nil); q2.Count(nil)
	q3 := q1; q1 = q2; q2 = q3 // swap
	q1.First(nil) // want: reused  ← preserved (swap propagates pollution)
	q2.Last(nil)  // want: reused  ← preserved
}
```
Also: `chaosVariableSwapChain`, `chaosModernSwapSyntax`.

**`advanced.go`**:
```go
//gormreuse:immutable-param
func reassignNewInstance(db *gorm.DB) { // subject: reassignment = new root
	q := db.Model(&User{}).Where("active = ?", true)
	q.Count(new(int64))
	q = db.Where("name = ?", "test") // ← without annotation, a 2nd branch from db
	q.Find(&[]User{})                // OK
}
```

## ④ STAYS SILENT — combined directive (`directive_validation.go`, locked decision)

`immutable-param` is **appended** to the existing directive; the contract `// want`s are unaffected, only the 1b param-branch noise is removed:
```go
//gormreuse:pure,immutable-return,immutable-param   // ← was pure,immutable-return
func badPureImmutable(db *gorm.DB) *gorm.DB {
	db.Where("x") // want `pure function pollutes ... by calling Where`  ← preserved
	return db.Session(&gorm.Session{}) // ← was newly REPORTING as 2nd branch; now silent
}
```
Also: `badPureImmutablePassesNonPure` (PIR102, same combo), `immutableOnlyPollutes` (PIR201, `immutable-return,immutable-param`), `blockCommentPureBad` (`/*gormreuse:pure,immutable-param*/`).

## ⑤ Convergence harness (`converge.go`)

Annotated so the harness keeps its documented **"no parameter roots"** invariant — the only remaining violation is the fully-fixable **local** root, so apply-fix→re-lint still converges to zero:
```go
//gormreuse:immutable-param
func nestedArg(db, base *gorm.DB) {
	q := db.Where("base")
	base.Or(q.Where("y")) // base/db param-branches now silent...
	base.Or(q.Where("z")) // want: reused (local q) ← the only violation; fully fixable
}

//gormreuse:immutable-param
func localBaseReuse(db *gorm.DB) {
	base := db.Where("start")
	base.Or(db.Where("a")) // inner db.Where param-branches now silent...
	base.Or(db.Where("b")) // want: reused (local base) ← the only violation; fully fixable
}
```

## ⑥ Reviewer notes / edge cases
```go
// nested_chaos.go — NOT annotated, and needs no annotation:
func chaosVariableSwapConditional(db *gorm.DB, swap bool) {
	q1 := db.Where("q1_base")
	q2 := db.Where("q2_base") // ○ SILENT: same shape as chaosVariableSwap, but current
	                          //   detection surfaces no new diagnostic here (verified: passes
	                          //   with AND without the annotation). Left untouched = minimal diff,
	                          //   NOT a masked false-negative of the flip.
	q1.Find(nil)
	if swap { q1, q2 = q2, q1 }
	q1.Count(nil) // want: reused  ← preserved
	q2.Count(nil) // want: reused  ← preserved
}
```

---

## Implementation
```go
// tracer/root.go — the whole behavioral pivot:
func (t *RootTracer) isMutableParam(p *ssa.Parameter) bool {
	if !typeutil.IsGormDB(p.Type()) { return false }
	fn := p.Parent()
	if t.scopesCallbacks[fn]      { return true }  // Scopes/Preload: always mutable
	if t.transactionCallbacks[fn] { return false } // Transaction tx: forkable, immutable
	if t.immutableParamFuncs != nil && t.immutableParamFuncs.Contains(fn) { return false } // opt-out
	return true // Phase 1b: mutable by default
}
```
- `isMutableParam` replaces `isScopesCallbackParam` at both param early-returns in `trace()`/`traceAll()`.
- `New`/`RootTracer` gain `immutableParamFuncs` + `transactionCallbacks`; `CollectTransactionCallbacks` mirrors `CollectScopesCallbacks` (shared `walkCalls`).
- Threaded `RunSSA → newChecker → NewAnalyzer → tracer.New` (now 6/7-arg).
- `tracer/root_test`: ordinary param is now a mutable root; added Transaction-callback exemption coverage. goldens/diffs regenerated.

## Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` **0 issues** ✅ · coverage **91.7%** (new fns ~100%, baseline 89.8%) ✅

## Follow-ups (staged, per the #61 plan)
- **2b** caller-side contract verification (report passing a mutable value into an `immutable-param` fn)
- **2c** `immutable-param` suggested-fix for param roots (+ extend converge harness)
- **2d** README migration guide + clone-semantics table

Part of #59. #61 stays open through 2b–2d.
