### PR TITLE
feat: detect redundant //gormreuse:immutable-param directives (#61)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ a, b := func(q *gorm.DB) { _ = q }, func(q *gorm.DB) { _ = q }
 > - Unused `//gormreuse:ignore` - line/function-level ignores that suppress no violations
 > - Unused `//gormreuse:pure` - directives that don't match any function
 > - Unused `//gormreuse:immutable-return` - directives that don't match any function
+> - Unused `//gormreuse:immutable-param` - directives that don't match any function (no `*gorm.DB` parameter)
+> - **Redundant** `//gormreuse:immutable-param` - directive is signature-valid but has no effect: the parameter is never reused, so even treated as mutable it would produce no violation to suppress. Reported at the function declaration. Skipped when combined with `//gormreuse:pure` (a valid pure function cannot branch its parameter, so immutable-param is redundant there by construction). This is callee-side only, matching Phase 1b stage 2a.
 > - For combined directives (`//gormreuse:pure,immutable-return`), if either part is used, no unused warning is reported
 
 ## Architecture

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -158,6 +158,10 @@ func RunSSA(
 		recoverPerFunction(fn, func() { chk.checkFunction(fn) })
 	}
 
+	// Report immutable-param directives that are signature-valid but have no
+	// effect (no *gorm.DB parameter is reused).
+	reportRedundantImmutableParam(pass, ssaInfo, immutableParamFuncs, pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, transactionCallbacks, skip)
+
 	// Report unused ignore directives
 	for _, ignoreMap := range ignoreMaps {
 		if ignoreMap == nil {
@@ -169,6 +173,70 @@ func RunSSA(
 	}
 
 	reportUnusedDirectiveFuncs(pass, pureFuncs, immutableReturnFuncs, immutableParamFuncs)
+}
+
+// reportRedundantImmutableParam flags //gormreuse:immutable-param directives that
+// are signature-valid (the function has a *gorm.DB parameter) yet have no effect:
+// even if the parameter were treated as mutable, it would never be reused, so the
+// directive suppresses nothing.
+//
+// This is checked with a counterfactual analysis: re-run the function with its
+// parameters treated as mutable (immutableParamFuncs = nil) and see whether any
+// resulting violation is rooted at one of the function's own parameters. If none
+// is, removing the directive would change no diagnostic and it is redundant.
+//
+// Scope note: Phase 1b stage 2a makes immutable-param a purely callee-side
+// contract, so "changes no diagnostic" need only consider the function's own
+// body. When stage 2b adds caller-side verification, a directive also becomes
+// "used" if a caller relies on it; this check must then also consult call sites.
+//
+// Signature-invalid directives (no *gorm.DB parameter) are NOT handled here —
+// they are already reported as unused by reportUnusedDirectiveFuncs; the
+// HasGormDBParameter guard below skips them to avoid a double report.
+//
+// Functions also marked //gormreuse:pure are skipped: a valid pure function
+// cannot branch its parameter at all (branching is pollution, which the pure
+// contract forbids), so immutable-param is redundant there by construction.
+// Flagging it would fire on every pure,immutable-param combination and
+// contradict the decision to allow that combination freely (#61).
+func reportRedundantImmutableParam(
+	pass *analysis.Pass,
+	ssaInfo *buildssa.SSA,
+	immutableParamFuncs, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet,
+	failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool,
+	skip func(*ssa.Function, bool) bool,
+) {
+	if immutableParamFuncs == nil {
+		return
+	}
+	for _, fn := range ssaInfo.SrcFuncs {
+		if skip(fn, false) {
+			continue
+		}
+		if !immutableParamFuncs.Contains(fn) {
+			continue
+		}
+		if fn.Signature == nil || !directive.HasGormDBParameter(fn.Signature) {
+			continue // signature-invalid: handled by reportUnusedDirectiveFuncs
+		}
+		if pureFuncs != nil && pureFuncs.Contains(fn) {
+			continue // pure ⇒ param never branched ⇒ immutable-param redundant by construction
+		}
+		redundant := true
+		recoverPerFunction(fn, func() {
+			// Counterfactual: analyze fn with its parameters mutable.
+			cf := ssautil.NewAnalyzer(fn, pureFuncs, immutableReturnFuncs, nil, failedPure, scopesCallbacks, transactionCallbacks)
+			for _, v := range cf.Analyze() {
+				if p, ok := v.Root.(*ssa.Parameter); ok && p.Parent() == fn {
+					redundant = false
+					break
+				}
+			}
+		})
+		if redundant {
+			pass.Reportf(fn.Pos(), "redundant gormreuse:immutable-param directive: no *gorm.DB parameter is reused")
+		}
+	}
 }
 
 // reportUnusedDirectiveFuncs reports pure / immutable-return / immutable-param

--- a/internal/directive/signature.go
+++ b/internal/directive/signature.go
@@ -6,6 +6,13 @@ import "go/types"
 // Signature Validation
 // =============================================================================
 
+// HasGormDBParameter reports whether a function signature has any parameter
+// containing *gorm.DB. It is the same predicate that decides whether a
+// //gormreuse:immutable-param directive has a valid signature, exported so
+// callers (e.g. redundant-directive detection) can distinguish a signature-valid
+// annotation from a signature-invalid one.
+func HasGormDBParameter(sig *types.Signature) bool { return hasGormDBParameter(sig) }
+
 // hasGormDBParameter checks if a function signature has any parameter
 // containing *gorm.DB (directly or in struct fields).
 func hasGormDBParameter(sig *types.Signature) bool {

--- a/testdata/src/gormreuse/directive_validation.go
+++ b/testdata/src/gormreuse/directive_validation.go
@@ -1162,8 +1162,9 @@ func blockCommentPureGood(db *gorm.DB) *gorm.DB {
 // =============================================================================
 
 // IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
-// reported unused). Reuse of db is clean today because parameters are still
-// immutable; this annotation is what will keep it clean once Phase 1b flips.
+// reported unused) AND necessary — db is branched twice, so without the directive
+// Phase 1b would flag the second branch. The directive suppresses that, so it is
+// NOT reported redundant (contrast IPARAM004/005).
 //
 //gormreuse:immutable-param
 func immutableParamValid(db *gorm.DB) {
@@ -1182,4 +1183,23 @@ func immutableParamNoGormArg(x int) int { return x }
 //gormreuse:pure,immutable-param
 func pureAndImmutableParam(db *gorm.DB) {
 	_ = db
+}
+
+// IPARAM004: signature-valid immutable-param that is REDUNDANT — the parameter is
+// branched at most once, so even treated as mutable it would never be reused, and
+// the directive suppresses nothing. Reported (distinct from the signature-invalid
+// "unused" case).
+//
+//gormreuse:immutable-param
+func immutableParamRedundant(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+	db.Where("only-one-branch").Find(nil)
+}
+
+// IPARAM005: signature-valid immutable-param on a parameter used but not branched
+// (single chain via a local) is also redundant.
+//
+//gormreuse:immutable-param
+func immutableParamRedundantLocal(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+	q := db.Where("x")
+	q.Find(nil)
 }

--- a/testdata/src/gormreuse/directive_validation.go.diff
+++ b/testdata/src/gormreuse/directive_validation.go.diff
@@ -1,6 +1,6 @@
 --- directive_validation.go	1970-01-01 00:00:00
 +++ directive_validation.go.golden	1970-01-01 00:00:00
-@@ -1,1185 +1,1185 @@
+@@ -1,1205 +1,1205 @@
  package internal
  
  import (
@@ -1168,8 +1168,9 @@
  // =============================================================================
  
  // IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
- // reported unused). Reuse of db is clean today because parameters are still
- // immutable; this annotation is what will keep it clean once Phase 1b flips.
+ // reported unused) AND necessary — db is branched twice, so without the directive
+ // Phase 1b would flag the second branch. The directive suppresses that, so it is
+ // NOT reported redundant (contrast IPARAM004/005).
  //
  //gormreuse:immutable-param
  func immutableParamValid(db *gorm.DB) {
@@ -1188,4 +1189,23 @@
  //gormreuse:pure,immutable-param
  func pureAndImmutableParam(db *gorm.DB) {
  	_ = db
+ }
+ 
+ // IPARAM004: signature-valid immutable-param that is REDUNDANT — the parameter is
+ // branched at most once, so even treated as mutable it would never be reused, and
+ // the directive suppresses nothing. Reported (distinct from the signature-invalid
+ // "unused" case).
+ //
+ //gormreuse:immutable-param
+ func immutableParamRedundant(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+ 	db.Where("only-one-branch").Find(nil)
+ }
+ 
+ // IPARAM005: signature-valid immutable-param on a parameter used but not branched
+ // (single chain via a local) is also redundant.
+ //
+ //gormreuse:immutable-param
+ func immutableParamRedundantLocal(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+ 	q := db.Where("x")
+ 	q.Find(nil)
  }

--- a/testdata/src/gormreuse/directive_validation.go.golden
+++ b/testdata/src/gormreuse/directive_validation.go.golden
@@ -1162,8 +1162,9 @@ func blockCommentPureGood(db *gorm.DB) *gorm.DB {
 // =============================================================================
 
 // IPARAM001: immutable-param on a *gorm.DB-parameter function is valid (not
-// reported unused). Reuse of db is clean today because parameters are still
-// immutable; this annotation is what will keep it clean once Phase 1b flips.
+// reported unused) AND necessary — db is branched twice, so without the directive
+// Phase 1b would flag the second branch. The directive suppresses that, so it is
+// NOT reported redundant (contrast IPARAM004/005).
 //
 //gormreuse:immutable-param
 func immutableParamValid(db *gorm.DB) {
@@ -1182,4 +1183,23 @@ func immutableParamNoGormArg(x int) int { return x }
 //gormreuse:pure,immutable-param
 func pureAndImmutableParam(db *gorm.DB) {
 	_ = db
+}
+
+// IPARAM004: signature-valid immutable-param that is REDUNDANT — the parameter is
+// branched at most once, so even treated as mutable it would never be reused, and
+// the directive suppresses nothing. Reported (distinct from the signature-invalid
+// "unused" case).
+//
+//gormreuse:immutable-param
+func immutableParamRedundant(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+	db.Where("only-one-branch").Find(nil)
+}
+
+// IPARAM005: signature-valid immutable-param on a parameter used but not branched
+// (single chain via a local) is also redundant.
+//
+//gormreuse:immutable-param
+func immutableParamRedundantLocal(db *gorm.DB) { // want `redundant gormreuse:immutable-param directive: no \*gorm\.DB parameter is reused`
+	q := db.Where("x")
+	q.Find(nil)
 }


### PR DESCRIPTION
## Detect redundant `//gormreuse:immutable-param` (#61 follow-up)

Extends the directive's diagnostics from **signature-invalid** ("unused") to also cover **signature-valid-but-ineffective** ("redundant"): the directive is on a `*gorm.DB`-parameter function, but the parameter is never reused, so even treated as mutable it would produce no violation — the directive suppresses nothing.

### Report vs silent (with snippets)

**▶ REPORTS — redundant** (param branched ≤1×, so immutable-param does nothing):
```go
//gormreuse:immutable-param
func immutableParamRedundant(db *gorm.DB) { // ▶ "redundant gormreuse:immutable-param directive: no *gorm.DB parameter is reused"
	db.Where("only-one-branch").Find(nil)   // db branched once → nothing to suppress
}

//gormreuse:immutable-param
func immutableParamRedundantLocal(db *gorm.DB) { // ▶ REPORTS
	q := db.Where("x") // single chain via a local
	q.Find(nil)
}
```

**○ SILENT — necessary** (param branched ≥2×, directive genuinely suppresses a violation):
```go
//gormreuse:immutable-param
func immutableParamValid(db *gorm.DB) {
	db.Where("a").Find(nil)
	db.Where("b").Find(nil) // ○ without the directive Phase 1b flags this 2nd branch → directive is necessary
}
```

**○ SILENT — combined with `pure`** (skipped by design):
```go
//gormreuse:pure,immutable-param
func pureAndImmutableParam(db *gorm.DB) { _ = db } // ○ SILENT
// A valid pure fn cannot branch its param (branching = pollution the pure contract forbids),
// so immutable-param is redundant there by construction. Flagging every pure,immutable-param
// combo would be noise and contradict "combine freely" (#61), so pure-annotated fns are skipped.
```

**○ SILENT — signature-invalid** stays on the existing "unused" path (not double-reported):
```go
//gormreuse:immutable-param // "unused gormreuse:immutable-param directive"  ← existing path, not "redundant"
func noGorm(x int) int { return x }
```

### How it's detected
A counterfactual analysis: re-run the function with its parameters treated as mutable (`immutableParamFuncs=nil`) and check whether any violation is rooted at one of the function's **own** parameters. None ⇒ redundant. Cheap (annotated functions are few), precise, single extra per-function analysis wrapped in the existing panic guard.

```go
// internal/analyzer.go
cf := ssautil.NewAnalyzer(fn, pureFuncs, immutableReturnFuncs, nil /*params mutable*/, failedPure, scopesCallbacks, transactionCallbacks)
for _, v := range cf.Analyze() {
	if p, ok := v.Root.(*ssa.Parameter); ok && p.Parent() == fn { redundant = false; break }
}
```

### Scope / forward-compat
**Callee-side only**, matching Phase 1b stage 2a (immutable-param has no caller-side effect yet). When **stage 2b** adds caller-side verification, a directive relied upon by a caller becomes "used" too, so this check will be extended to also consult call sites. Documented in the code + CLAUDE.md.

### Changes
- `directive.HasGormDBParameter` exported for the signature-valid guard (mirrors the directive's own validity predicate — no drift).
- Fixtures `IPARAM004`/`IPARAM005` (redundant → reported); `IPARAM001` clarified as the necessary contrast; `IPARAM003` (`pure,immutable-param`) confirms the pure-skip. Goldens regenerated.
- CLAUDE.md documents the redundant-directive warning.

### Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` **0 issues** ✅ · new fns 95–100% ✅

Part of #59 / #61.
