### PR TITLE
feat: parameter-root immutable-param fix + migration docs (Phase 1b stage 2c/2d, #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,14 +250,29 @@ db.Scopes(func(tx *gorm.DB) *gorm.DB {
 })
 ```
 
-This applies **only** to callbacks actually handed to `Scopes`/`Preload`. An ordinary parameter of a plain helper is still treated as immutable (the caller's responsibility) and needs no migration:
+#### Parameters are mutable
+
+A [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) **parameter** is a mutable root: a caller may pass a mid-chain value, so branching a parameter interferes exactly as branching a local would.
 
 ```go
 func helper(tx *gorm.DB) *gorm.DB {
-    tx.Where("a").Find(&users) // OK - ordinary parameter is treated as immutable
-    return tx.Where("b")
+    tx.Where("a").Find(&users) // first branch from tx - OK
+    return tx.Where("b")       // VIOLATION: second branch from tx
 }
 ```
+
+To opt a helper out — declaring that the caller is responsible for passing an isolated value — annotate it with [`//gormreuse:immutable-param`](#gormreuseimmutable-param).
+
+Reuse safety is determined by GORM's internal `clone` field: a handle with `clone > 0` forks a **fresh** `Statement` on the next chain call (safe to reuse), while a mid-chain handle (`clone == 0`) shares its `Statement`. A parameter's `clone` value is statically unknowable, so it is treated conservatively as mutable.
+
+| Source | `clone` | Reusable? |
+| --- | --- | --- |
+| [`gorm.Open`](https://pkg.go.dev/gorm.io/gorm#Open), [`Session`](https://pkg.go.dev/gorm.io/gorm#DB.Session), [`WithContext`](https://pkg.go.dev/gorm.io/gorm#DB.WithContext), [`Debug`](https://pkg.go.dev/gorm.io/gorm#DB.Debug) | `> 0` | ✅ forks a fresh Statement |
+| [`Begin`](https://pkg.go.dev/gorm.io/gorm#DB.Begin) result, [`Transaction`](https://pkg.go.dev/gorm.io/gorm#DB.Transaction) callback `tx` | `> 0` | ✅ fresh transaction handle |
+| Mid-chain ([`Where`](https://pkg.go.dev/gorm.io/gorm#DB.Where), [`Order`](https://pkg.go.dev/gorm.io/gorm#DB.Order), …) | `== 0` | ❌ shares Statement |
+| A [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) **parameter** | unknown | ❌ treated as mutable |
+
+Transaction callbacks (`tx` in `db.Transaction(func(tx *gorm.DB) error {...})`) are exempt — their `tx` is a fresh forkable handle.
 
 #### Safe: Variable reassignment
 
@@ -293,7 +308,7 @@ q.Find(&users)             // OK - first branch from whichever root
 
 ## Directives
 
-- Directives can be combined with commas: `//gormreuse:pure,immutable-return`
+- Directives can be combined with commas: `//gormreuse:pure,immutable-return`, `//gormreuse:pure,immutable-param`
 - Trailing comments use `//`: `//gormreuse:ignore // reason here`
 
 ### `//gormreuse:ignore`
@@ -392,6 +407,31 @@ func useIt() {
 > [!TIP]
 > Use this directive for DB connection helpers that return a fresh, immutable [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) instance. This allows callers to reuse the returned value freely without worrying about pollution.
 
+### `//gormreuse:immutable-param`
+
+Opt a function's [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) **parameters** out of the default mutable treatment — they are treated as immutable inside the function, so the caller becomes responsible for passing an isolated value:
+
+```go
+//gormreuse:immutable-param
+func applyFilters(tx *gorm.DB) {
+    tx.Where("a").Find(&users) // OK - tx is treated as immutable here
+    tx.Where("b").Find(&more)  // OK
+}
+```
+
+> [!WARNING]
+> **Caller-side contract.** When the function actually branches such a parameter, passing a *mutable* [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) at a call site is reported — the callee's internal branching would interfere because the value is not isolated:
+> ```go
+> func caller(root *gorm.DB) {
+>     q := root.Session(&gorm.Session{}).Where("x") // mutable
+>     applyFilters(q) // VIOLATION: mutable *gorm.DB passed to immutable-param parameter
+> }
+> ```
+> Fix by passing an isolated value (`root.Session(&gorm.Session{})`), or make the caller `//gormreuse:immutable-param` too so the contract propagates.
+
+> [!TIP]
+> Combine with `//gormreuse:pure` when a helper both leaves its argument unpolluted and expects an isolated value. A **redundant** `//gormreuse:immutable-param` — one whose parameter is never reused, so it suppresses nothing — is reported so you can drop it.
+
 ### `//gormreuse:pure,immutable-return`
 
 The recommended pattern for DB connection helpers - combines both guarantees:
@@ -413,7 +453,7 @@ func useIt(db *gorm.DB) {
 ```
 
 > [!WARNING]
-> Unused `//gormreuse:pure` and `//gormreuse:immutable-return` directives are reported as warnings. This helps identify misplaced or stale directives. For combined directives like `//gormreuse:pure,immutable-return`, if either part is used, no unused warning is reported.
+> Unused `//gormreuse:pure`, `//gormreuse:immutable-return`, and `//gormreuse:immutable-param` directives are reported as warnings (a directive whose signature doesn't fit — e.g. `immutable-param` on a function with no [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) parameter). A **redundant** `//gormreuse:immutable-param` (signature-valid but its parameter is never reused) is reported too. For combined directives like `//gormreuse:pure,immutable-return`, if either part is used, no unused warning is reported.
 
 ## Documentation
 

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -85,10 +85,6 @@ func RunSSA(
 	// across different violations that suggest the same edit.
 	globalSuggestedEdits := make(map[editKey]bool)
 
-	// Share a single fix generator to avoid recreating it for each violation.
-	// The generator caches AST inspectors internally, so sharing it improves performance.
-	fixGen := fix.New(pass)
-
 	// skip reports whether a function is in an excluded file or wholly ignored.
 	// When markUsed is true it also records the function-level ignore directive
 	// as used; that side effect must happen exactly once per function, so only
@@ -147,6 +143,11 @@ func RunSSA(
 	// (clone>0) handle, so it is exempt from the Phase 1b mutable-by-default
 	// treatment of *gorm.DB parameters (#60 SC103, #61).
 	transactionCallbacks := tracer.CollectTransactionCallbacks(ssaInfo.SrcFuncs)
+
+	// Share a single fix generator across all violations (it caches AST
+	// inspectors). It needs scopesCallbacks to withhold the immutable-param fix on
+	// Scopes/Preload callbacks, whose parameters cannot be exempted (stage 2c).
+	fixGen := fix.New(pass, scopesCallbacks)
 
 	// Determine which //gormreuse:immutable-param functions actually rely on
 	// immutability — they would reuse a *gorm.DB parameter if it were treated as

--- a/internal/fix/generator.go
+++ b/internal/fix/generator.go
@@ -52,14 +52,17 @@ import (
 
 // Generator generates SuggestedFix for a violation.
 type Generator struct {
-	pass       *analysis.Pass
-	fset       *token.FileSet
-	files      map[*token.File]*ast.File          // token.File -> ast.File mapping
-	inspectors map[*ast.File]*inspector.Inspector // cached inspectors per file
+	pass            *analysis.Pass
+	fset            *token.FileSet
+	files           map[*token.File]*ast.File          // token.File -> ast.File mapping
+	inspectors      map[*ast.File]*inspector.Inspector // cached inspectors per file
+	scopesCallbacks map[*ssa.Function]bool             // Scopes/Preload callbacks (no immutable-param fix)
 }
 
-// New creates a new fix Generator.
-func New(pass *analysis.Pass) *Generator {
+// New creates a new fix Generator. scopesCallbacks lists Scopes/Preload callback
+// functions, whose *gorm.DB parameters cannot be made immutable-param, so the
+// parameter-root fix is withheld for them (stage 2c); it may be nil.
+func New(pass *analysis.Pass, scopesCallbacks map[*ssa.Function]bool) *Generator {
 	// Build token.File -> ast.File mapping
 	files := make(map[*token.File]*ast.File)
 	for _, f := range pass.Files {
@@ -70,10 +73,11 @@ func New(pass *analysis.Pass) *Generator {
 	}
 
 	return &Generator{
-		pass:       pass,
-		fset:       pass.Fset,
-		files:      files,
-		inspectors: make(map[*ast.File]*inspector.Inspector),
+		pass:            pass,
+		fset:            pass.Fset,
+		files:           files,
+		inspectors:      make(map[*ast.File]*inspector.Inspector),
+		scopesCallbacks: scopesCallbacks,
 	}
 }
 
@@ -95,14 +99,13 @@ func (g *Generator) Generate(v pollution.Violation) []analysis.SuggestedFix {
 		return nil // Cannot fix without root information
 	}
 
-	// A parameter root (e.g. a Scopes/Preload callback's *gorm.DB, issue #60)
-	// has no definition site to make immutable — the generator's "insert
-	// Session() at the root" model does not apply, and forcing an edit produces
-	// a misleading fix on an unrelated expression. Report the violation without
-	// an auto-fix instead. (Isolating a reused parameter requires a manual
-	// Session() at the branch, which the user must place.)
-	if _, ok := root.(*ssa.Parameter); ok {
-		return nil
+	// A parameter root has no definition site to Session(), so the "insert
+	// Session() at the root" model does not apply. Instead, suggest declaring the
+	// enclosing function //gormreuse:immutable-param — the parameter is then
+	// treated as immutable and the caller becomes responsible for passing an
+	// isolated value (verified caller-side, stage 2b/2c).
+	if p, ok := root.(*ssa.Parameter); ok {
+		return g.generateImmutableParamFix(p)
 	}
 
 	allUses := v.AllUses
@@ -176,6 +179,40 @@ func (g *Generator) Generate(v pollution.Violation) []analysis.SuggestedFix {
 			TextEdits: edits,
 		},
 	}
+}
+
+// generateImmutableParamFix suggests annotating the enclosing function with
+// //gormreuse:immutable-param when a *gorm.DB PARAMETER is the reused root
+// (Phase 1b). This declares the parameter immutable; the caller then owns
+// passing an isolated value (verified caller-side, stage 2b).
+//
+// No fix is offered when:
+//   - the function is a Scopes/Preload callback — immutable-param is rejected
+//     there (the parameter genuinely receives a mid-chain value), so annotating
+//     would not converge; the user must Session() inside the callback.
+//   - the enclosing function is not a named declaration (a closure/func literal) —
+//     directive placement on literals is left to the user.
+func (g *Generator) generateImmutableParamFix(p *ssa.Parameter) []analysis.SuggestedFix {
+	fn := p.Parent()
+	if fn == nil || g.scopesCallbacks[fn] {
+		return nil
+	}
+	fd, ok := fn.Syntax().(*ast.FuncDecl)
+	if !ok {
+		return nil
+	}
+	// Insert the directive on its own line immediately before `func` (after any
+	// doc comment). FuncDecl.Pos() is the `func` keyword, so this is the
+	// recognized next-line placement and needs no indentation for top-level decls.
+	pos := fd.Pos()
+	return []analysis.SuggestedFix{{
+		Message: "Declare //gormreuse:immutable-param (caller must pass an isolated *gorm.DB)",
+		TextEdits: []analysis.TextEdit{{
+			Pos:     pos,
+			End:     pos,
+			NewText: []byte("//gormreuse:immutable-param\n"),
+		}},
+	}}
 }
 
 // findNonFinisherUses finds uses that are non-finisher expression statements.

--- a/testdata/src/converge/converge.go
+++ b/testdata/src/converge/converge.go
@@ -1,8 +1,8 @@
 // Package converge holds self-contained, fully-fixable reuse scenarios for the
 // convergence harness (#71): applying the suggested fix and re-linting the
-// result must report nothing. Unlike the gormreuse fixtures, every violation
-// here is expected to be fully resolved by its fix — no parameter roots, no
-// documented limitations.
+// result must report nothing. Every violation here is expected to be fully
+// resolved by its fix — either a Session() on a local root, or (Phase 1b stage
+// 2c) a //gormreuse:immutable-param annotation on a parameter root.
 package converge
 
 import "gorm.io/gorm"
@@ -62,4 +62,12 @@ func reassignChain(db *gorm.DB) {
 	q = q.Where("a")
 	q.Find(&User{})
 	q.Count(new(int64)) // want `\*gorm\.DB reused: second branch from mutable root`
+}
+
+// paramReuse: a *gorm.DB parameter branched twice (Phase 1b stage 2c). The fix
+// annotates the function //gormreuse:immutable-param; re-linting is then clean
+// (the parameter is immutable and there is no local caller to check).
+func paramReuse(db *gorm.DB) {
+	db.Where("a").Find(&User{})
+	db.Where("b").Find(&User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }

--- a/testdata/src/gormreuse/advanced.go.diff
+++ b/testdata/src/gormreuse/advanced.go.diff
@@ -1,6 +1,6 @@
 --- advanced.go	1970-01-01 00:00:00
 +++ advanced.go.golden	1970-01-01 00:00:00
-@@ -1,1215 +1,1215 @@
+@@ -1,1215 +1,1217 @@
  package internal
  
  import (
@@ -407,6 +407,7 @@
  //
  // (parameter roots get no auto-fix; the top-level expression is not a *gorm.DB
  // method call anyway).
++//gormreuse:immutable-param
  func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
  	require.NoError(t, tx.Create(nil).Error)
  	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
@@ -414,6 +415,7 @@
  }
  
  // wrappedInRequireNoErrorMixed demonstrates mixed usage patterns.
++//gormreuse:immutable-param
  func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
  	require.NoError(t, tx.Create(nil).Error)
  	tx.Create(nil) // want `\*gorm\.DB reused: second branch from mutable root`

--- a/testdata/src/gormreuse/advanced.go.golden
+++ b/testdata/src/gormreuse/advanced.go.golden
@@ -379,6 +379,7 @@ func nestedArgsSingleUse(db *gorm.DB) {
 //
 // (parameter roots get no auto-fix; the top-level expression is not a *gorm.DB
 // method call anyway).
+//gormreuse:immutable-param
 func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
 	require.NoError(t, tx.Create(nil).Error) // want `\*gorm\.DB reused: second branch from mutable root`
@@ -386,6 +387,7 @@ func wrappedInRequireNoError(tx *gorm.DB, t require.TestingT) {
 }
 
 // wrappedInRequireNoErrorMixed demonstrates mixed usage patterns.
+//gormreuse:immutable-param
 func wrappedInRequireNoErrorMixed(tx *gorm.DB, t require.TestingT) {
 	require.NoError(t, tx.Create(nil).Error)
 	tx.Create(nil) // want `\*gorm\.DB reused: second branch from mutable root`

--- a/testdata/src/gormreuse/basic.go.diff
+++ b/testdata/src/gormreuse/basic.go.diff
@@ -1,6 +1,6 @@
 --- basic.go	1970-01-01 00:00:00
 +++ basic.go.golden	1970-01-01 00:00:00
-@@ -1,101 +1,101 @@
+@@ -1,101 +1,105 @@
  // Package internal contains test functions for gormreuse linter.
  package internal
  
@@ -81,12 +81,14 @@
  // separateChains demonstrates that a *gorm.DB parameter is a mutable root under
  // Phase 1b (#61): a caller may pass a mid-chain value, so branching it twice is a
  // violation.
++//gormreuse:immutable-param
  func separateChains(db *gorm.DB) {
  	db.Where("a = ?", 1).Find(&[]User{})
  	db.Where("b = ?", 2).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // separateVariables demonstrates branching a parameter into two variables.
++//gormreuse:immutable-param
  func separateVariables(db *gorm.DB) {
  	q1 := db.Where("a = ?", 1)
  	q2 := db.Where("b = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
@@ -96,12 +98,14 @@
  }
  
  // parameterDirectUse demonstrates that a parameter is a mutable root (Phase 1b).
++//gormreuse:immutable-param
  func parameterDirectUse(db *gorm.DB) {
  	db.Where("a = ?", 1).Find(nil)
  	db.Where("b = ?", 2).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
  }
  
  // parameterMultipleChains demonstrates multiple chains from a parameter root.
++//gormreuse:immutable-param
  func parameterMultipleChains(db *gorm.DB) {
  	db.Where("x").Order("id").Find(nil)
  	db.Where("y").Limit(10).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`

--- a/testdata/src/gormreuse/basic.go.golden
+++ b/testdata/src/gormreuse/basic.go.golden
@@ -74,12 +74,14 @@ func withContextAtEnd(db *gorm.DB) {
 // separateChains demonstrates that a *gorm.DB parameter is a mutable root under
 // Phase 1b (#61): a caller may pass a mid-chain value, so branching it twice is a
 // violation.
+//gormreuse:immutable-param
 func separateChains(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(&[]User{})
 	db.Where("b = ?", 2).Find(&[]User{}) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // separateVariables demonstrates branching a parameter into two variables.
+//gormreuse:immutable-param
 func separateVariables(db *gorm.DB) {
 	q1 := db.Where("a = ?", 1)
 	q2 := db.Where("b = ?", 2) // want `\*gorm\.DB reused: second branch from mutable root`
@@ -89,12 +91,14 @@ func separateVariables(db *gorm.DB) {
 }
 
 // parameterDirectUse demonstrates that a parameter is a mutable root (Phase 1b).
+//gormreuse:immutable-param
 func parameterDirectUse(db *gorm.DB) {
 	db.Where("a = ?", 1).Find(nil)
 	db.Where("b = ?", 2).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`
 }
 
 // parameterMultipleChains demonstrates multiple chains from a parameter root.
+//gormreuse:immutable-param
 func parameterMultipleChains(db *gorm.DB) {
 	db.Where("x").Order("id").Find(nil)
 	db.Where("y").Limit(10).Find(nil) // want `\*gorm\.DB reused: second branch from mutable root`

--- a/testdata/src/gormreuse/scopes_callback.go.diff
+++ b/testdata/src/gormreuse/scopes_callback.go.diff
@@ -1,0 +1,88 @@
+--- scopes_callback.go	1970-01-01 00:00:00
++++ scopes_callback.go.golden	1970-01-01 00:00:00
+@@ -1,84 +1,85 @@
+ package internal
+ 
+ import "gorm.io/gorm"
+ 
+ // =============================================================================
+ // Scopes/Preload callback parameters are MUTABLE roots (#60, Phase 1a)
+ //
+ // GORM passes the mid-chain (clone==0) *gorm.DB into Scopes/Preload callbacks,
+ // so reusing that parameter inside the callback interferes at runtime — exactly
+ // like reusing any other mutable *gorm.DB. This is the narrow, uncontroversial
+ // half of #56 Phase 1: only callbacks actually handed to Scopes/Preload are
+ // affected, not every func(*gorm.DB) *gorm.DB (that is Phase 1b).
+ // =============================================================================
+ 
+ // =============================================================================
+ // SHOULD REPORT
+ // =============================================================================
+ 
+ // SC001: Reuse of the Scopes callback parameter (two branches from tx).
+ func scopesCallbackReuse(db *gorm.DB) {
+ 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+ 		tx.Where("a").Find(nil) // first branch from tx
+ 		return tx.Where("b")    // want `\*gorm\.DB reused: second branch from mutable root`
+ 	})
+ }
+ 
+ // SC002: Reuse of a Preload scope callback parameter (a scope func rides in
+ // Preload's variadic args and receives the same mid-chain value).
+ func preloadCallbackReuse(db *gorm.DB) {
+ 	db.Preload("Orders", func(tx *gorm.DB) *gorm.DB {
+ 		tx.Where("a").Find(nil)
+ 		return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
+ 	})
+ }
+ 
+ // SC003: A named function passed to Scopes is analyzed as an ordinary source
+ // function; its *gorm.DB parameter is a mutable root too.
+ func namedScope(tx *gorm.DB) *gorm.DB {
+ 	tx.Where("a").Find(nil)
+ 	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
+ }
+ 
+ func useNamedScope(db *gorm.DB) {
+ 	db.Scopes(namedScope)
+ }
+ 
+ // =============================================================================
+ // SHOULD NOT REPORT
+ // =============================================================================
+ 
+ // SC101: Single use of the Scopes callback parameter is fine (one branch).
+ func scopesCallbackSingleUse(db *gorm.DB) {
+ 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+ 		return tx.Where("a") // OK: single branch from tx
+ 	})
+ }
+ 
+ // SC102: Session() inside the callback isolates before branching.
+ func scopesCallbackSessionIsolated(db *gorm.DB) {
+ 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
+ 		s := tx.Session(&gorm.Session{})
+ 		s.Where("a").Find(nil)
+ 		return s.Where("b") // OK: s is immutable (Session isolates)
+ 	})
+ }
+ 
+ // SC103: A Transaction callback receives a FRESH (forkable, clone>0) tx, not a
+ // mid-chain value, so reuse inside it is safe and must NOT be reported. Only
+ // Scopes/Preload callbacks get the mutable-root treatment.
+ func transactionCallbackNoReport(db *gorm.DB) {
+ 	_ = db.Transaction(func(tx *gorm.DB) error {
+ 		tx.Where("a").Find(nil)
+ 		tx.Where("b").Find(nil) // OK: tx is a fresh session, not a Scopes callback
+ 		return nil
+ 	})
+ }
+ 
+ // SC104: Under Phase 1b (#61) an ordinary func(*gorm.DB) *gorm.DB helper's
+ // parameter is a mutable root — a caller may pass a mid-chain value, so branching
+ // it twice interferes. (Contrast with immutable-param-annotated helpers below.)
++//gormreuse:immutable-param
+ func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
+ 	tx.Where("a").Find(nil)
+ 	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
+ }

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -78,6 +78,7 @@ func transactionCallbackNoReport(db *gorm.DB) {
 // SC104: Under Phase 1b (#61) an ordinary func(*gorm.DB) *gorm.DB helper's
 // parameter is a mutable root — a caller may pass a mid-chain value, so branching
 // it twice interferes. (Contrast with immutable-param-annotated helpers below.)
+//gormreuse:immutable-param
 func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
 	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`


### PR DESCRIPTION
## Phase 1b stage 2c + 2d — parameter-root suggested fix & spec docs (#61)

Finishes the #61 stage-2 train. Depends on 2a (params mutable), 2b (caller-side contract), and #108 (redundant detection), all already on `main`.

### 2c — suggested fix for parameter-root reuse

A `*gorm.DB` **parameter** has no definition site to `Session()`, so param-root reuse previously produced **no** fix. It now suggests declaring the enclosing function `//gormreuse:immutable-param` (inserted on its own line before `func`); the parameter becomes immutable and the caller owns passing an isolated value (verified by 2b).

```go
//gormreuse:immutable-param   // ← inserted by the fix
func separateChains(db *gorm.DB) {
	db.Where("a = ?", 1).Find(&[]User{})
	db.Where("b = ?", 2).Find(&[]User{}) // was: reused (no fix); now fixed by the annotation
}
```

Withheld where it would not help:
- **Scopes/Preload callbacks** — immutable-param is rejected there (the param genuinely receives a mid-chain value), so annotating wouldn't converge. `fix.New` now takes `scopesCallbacks` to detect them. *(verified: `scopes_callback.go.golden` inserts the directive only on the ordinary helper, not on any Scopes callback.)*
- **Closures / func literals** — directive placement on literals is left to the user.

**Convergence guarded**: `converge.paramReuse` applies the fix and re-lints clean through `TestFixesConverge` (apply → re-lint → 0 diagnostics). Goldens regenerated for the positive parameter-root fixtures (`basic`, `advanced`, `scopes_callback`); the #107-annotated scaffolding is unaffected (its params are already immutable).

### 2d — README (current spec, not a migration guide)

- **Corrected** the now-false “ordinary parameter is immutable … needs no migration” claim — documents that a `*gorm.DB` parameter is a mutable root.
- Added a **clone-semantics table** as plain spec (explains why parameters are mutable):

  | Source | `clone` | Reusable? |
  | --- | --- | --- |
  | `gorm.Open`, `Session`, `WithContext`, `Debug` | `> 0` | ✅ forks a fresh Statement |
  | `Begin` result, `Transaction` callback `tx` | `> 0` | ✅ fresh transaction handle |
  | Mid-chain (`Where`, `Order`, …) | `== 0` | ❌ shares Statement |
  | a `*gorm.DB` **parameter** | unknown | ❌ treated as mutable |

- New **`//gormreuse:immutable-param`** directive section: caller-side contract + redundant reporting.

### Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` **0 issues** ✅ · new fn coverage 87.5% ✅

### #61 status after this
Stage 2 (2a→2d) complete. #61 can close once merged. Remaining epic #59 work: **#62 (Phase 2)**, **#63 (Phase 3)**.
