### PR TITLE
feat: Connection/FindInBatches callbacks are immutable (Phase 2 Part A, #62)

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -142,7 +142,7 @@ func RunSSA(
 	// Collect Transaction callbacks once: their tx parameter is a fresh forkable
 	// (clone>0) handle, so it is exempt from the Phase 1b mutable-by-default
 	// treatment of *gorm.DB parameters (#60 SC103, #61).
-	transactionCallbacks := tracer.CollectTransactionCallbacks(ssaInfo.SrcFuncs)
+	immutableCallbacks := tracer.CollectImmutableCallbacks(ssaInfo.SrcFuncs)
 
 	// Share a single fix generator across all violations (it caches AST
 	// inspectors). It needs scopesCallbacks to withhold the immutable-param fix on
@@ -155,7 +155,7 @@ func RunSSA(
 	// contract check (stage 2b, passed into the checker below) and, by its
 	// complement, redundant-directive detection (a directive whose function does
 	// NOT reuse a param suppresses nothing).
-	needsImmutableParam := computeNeedsImmutableParam(ssaInfo, immutableParamFuncs, pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, transactionCallbacks, skip)
+	needsImmutableParam := computeNeedsImmutableParam(ssaInfo, immutableParamFuncs, pureFuncs, immutableReturnFuncs, failedPure, scopesCallbacks, immutableCallbacks, skip)
 
 	// PASS 2: run SSA reuse analysis.
 	for _, fn := range ssaInfo.SrcFuncs {
@@ -163,7 +163,7 @@ func RunSSA(
 			continue
 		}
 
-		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, transactionCallbacks, needsImmutableParam, globalReported, globalSuggestedEdits, fixGen)
+		chk := newChecker(pass, ignoreMaps[pass.Fset.Position(fn.Pos()).Filename], pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, immutableCallbacks, needsImmutableParam, globalReported, globalSuggestedEdits, fixGen)
 		recoverPerFunction(fn, func() { chk.checkFunction(fn) })
 	}
 
@@ -211,7 +211,7 @@ func RunSSA(
 func computeNeedsImmutableParam(
 	ssaInfo *buildssa.SSA,
 	immutableParamFuncs, pureFuncs, immutableReturnFuncs *directive.DirectiveFuncSet,
-	failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool,
+	failedPure, scopesCallbacks, immutableCallbacks map[*ssa.Function]bool,
 	skip func(*ssa.Function, bool) bool,
 ) map[*ssa.Function]bool {
 	needs := make(map[*ssa.Function]bool)
@@ -230,7 +230,7 @@ func computeNeedsImmutableParam(
 		}
 		recoverPerFunction(fn, func() {
 			// Counterfactual: analyze fn with its parameters treated as mutable.
-			cf := ssautil.NewAnalyzer(fn, pureFuncs, immutableReturnFuncs, nil, failedPure, scopesCallbacks, transactionCallbacks, nil)
+			cf := ssautil.NewAnalyzer(fn, pureFuncs, immutableReturnFuncs, nil, failedPure, scopesCallbacks, immutableCallbacks, nil)
 			for _, v := range cf.Analyze() {
 				if p, ok := v.Root.(*ssa.Parameter); ok && p.Parent() == fn {
 					needs[fn] = true
@@ -348,7 +348,7 @@ type checker struct {
 	immutableParamFuncs  *directive.DirectiveFuncSet // Immutable-param functions (params opt out of Phase 1b)
 	failedPure           map[*ssa.Function]bool      // Pure functions that failed contract validation
 	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
-	transactionCallbacks map[*ssa.Function]bool      // Transaction callbacks (tx param is forkable, immutable)
+	immutableCallbacks   map[*ssa.Function]bool      // Transaction/Connection/FindInBatches callbacks (fresh tx)
 	needsImmutableParam  map[*ssa.Function]bool      // immutable-param fns that branch a param (2b caller check)
 	reported             map[token.Pos]bool          // Deduplication of reports
 	suggestedEdits       map[editKey]bool            // Global deduplication of suggested fixes
@@ -367,7 +367,7 @@ type editKey struct {
 // across parent functions and their closures.
 // The suggestedEdits map is shared to avoid duplicate fix edits.
 // The fixGen is shared to avoid recreating the generator for each violation.
-func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks, needsImmutableParam map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
+func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, immutableCallbacks, needsImmutableParam map[*ssa.Function]bool, reported map[token.Pos]bool, suggestedEdits map[editKey]bool, fixGen *fix.Generator) *checker {
 	return &checker{
 		pass:                 pass,
 		ignoreMap:            ignoreMap,
@@ -376,7 +376,7 @@ func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, i
 		immutableParamFuncs:  immutableParamFuncs,
 		failedPure:           failedPure,
 		scopesCallbacks:      scopesCallbacks,
-		transactionCallbacks: transactionCallbacks,
+		immutableCallbacks:   immutableCallbacks,
 		needsImmutableParam:  needsImmutableParam,
 		reported:             reported,
 		suggestedEdits:       suggestedEdits,
@@ -386,7 +386,7 @@ func newChecker(pass *analysis.Pass, ignoreMap directive.IgnoreMap, pureFuncs, i
 
 // checkFunction runs SSA analysis on a single function and reports violations.
 func (c *checker) checkFunction(fn *ssa.Function) {
-	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.immutableParamFuncs, c.failedPure, c.scopesCallbacks, c.transactionCallbacks, c.needsImmutableParam)
+	analyzer := ssautil.NewAnalyzer(fn, c.pureFuncs, c.immutableReturnFuncs, c.immutableParamFuncs, c.failedPure, c.scopesCallbacks, c.immutableCallbacks, c.needsImmutableParam)
 	violations := analyzer.Analyze()
 
 	// Deduplicate violations by root to avoid generating duplicate fixes.

--- a/internal/ssa/analyzer.go
+++ b/internal/ssa/analyzer.go
@@ -80,13 +80,13 @@ type Analyzer struct {
 //   - failedPure: Pure functions that failed contract validation (not trusted as pure)
 //   - scopesCallbacks: Scopes/Preload callbacks whose *gorm.DB param is a mutable root
 //   - immutableParamFuncs: Functions marked //gormreuse:immutable-param (params opt out of Phase 1b)
-//   - transactionCallbacks: Transaction callbacks whose tx param is forkable (immutable)
+//   - immutableCallbacks: Transaction callbacks whose tx param is forkable (immutable)
 //   - needsImmutableParam: immutable-param functions that actually branch a param, so a caller
 //     passing a mutable value to them violates the contract (Phase 1b stage 2b)
-func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks, needsImmutableParam map[*ssa.Function]bool) *Analyzer {
+func NewAnalyzer(fn *ssa.Function, pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, immutableCallbacks, needsImmutableParam map[*ssa.Function]bool) *Analyzer {
 	return &Analyzer{
 		fn:                  fn,
-		rootTracer:          tracer.New(pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, transactionCallbacks),
+		rootTracer:          tracer.New(pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, immutableCallbacks),
 		cfgAnalyzer:         cfg.New(),
 		needsImmutableParam: needsImmutableParam,
 	}

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -102,7 +102,7 @@ type RootTracer struct {
 	immutableParamFuncs  *directive.DirectiveFuncSet // Functions whose *gorm.DB params are immutable (opt out of Phase 1b)
 	failedPure           map[*ssa.Function]bool      // Pure functions that FAILED contract validation
 	scopesCallbacks      map[*ssa.Function]bool      // Scopes/Preload callbacks (params are mutable roots)
-	transactionCallbacks map[*ssa.Function]bool      // Transaction callbacks (tx param is forkable, immutable)
+	immutableCallbacks   map[*ssa.Function]bool      // Transaction/Connection/FindInBatches callbacks (fresh tx)
 }
 
 // New creates a new RootTracer.
@@ -119,17 +119,17 @@ type RootTracer struct {
 //
 // immutableParamFuncs lists functions annotated //gormreuse:immutable-param,
 // whose *gorm.DB parameters opt out of the Phase 1b mutable-by-default treatment
-// (issue #61). transactionCallbacks lists function literals passed to gorm's
-// Transaction, whose tx parameter is a fresh forkable (clone>0) handle and is
-// therefore immutable. Both may be nil.
-func New(pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, transactionCallbacks map[*ssa.Function]bool) *RootTracer {
+// (issue #61). immutableCallbacks lists function literals passed to gorm's
+// Transaction/Connection/FindInBatches, whose tx parameter is a fresh forkable
+// (clone>0) handle and is therefore immutable. Both may be nil.
+func New(pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet, failedPure, scopesCallbacks, immutableCallbacks map[*ssa.Function]bool) *RootTracer {
 	return &RootTracer{
 		pureFuncs:            pureFuncs,
 		immutableReturnFuncs: immutableReturnFuncs,
 		immutableParamFuncs:  immutableParamFuncs,
 		failedPure:           failedPure,
 		scopesCallbacks:      scopesCallbacks,
-		transactionCallbacks: transactionCallbacks,
+		immutableCallbacks:   immutableCallbacks,
 	}
 }
 
@@ -1379,8 +1379,9 @@ func (t *RootTracer) traceAllFreeVar(fv *ssa.FreeVar, visited map[ssa.Value]bool
 // immutable:
 //   - the enclosing function is annotated //gormreuse:immutable-param (the caller
 //     is responsible for passing a safe value; verified caller-side elsewhere)
-//   - p is the tx parameter of a gorm Transaction callback — a fresh, forkable
-//     (clone>0) handle, so reuse inside the callback is safe (#60 SC103)
+//   - p is the tx parameter of a gorm Transaction/Connection/FindInBatches
+//     callback — a fresh, forkable (clone>0) handle, so reuse inside the callback
+//     is safe (#60 SC103, #62)
 //
 // A Scopes/Preload callback parameter receives a clone==0 value and is ALWAYS
 // mutable; it cannot be exempted by //gormreuse:immutable-param.
@@ -1392,7 +1393,7 @@ func (t *RootTracer) isMutableParam(p *ssa.Parameter) bool {
 	if t.scopesCallbacks[fn] {
 		return true
 	}
-	if t.transactionCallbacks[fn] {
+	if t.immutableCallbacks[fn] {
 		return false
 	}
 	if t.immutableParamFuncs != nil && t.immutableParamFuncs.Contains(fn) {
@@ -1579,19 +1580,20 @@ func CollectScopesCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
 	return set
 }
 
-// CollectTransactionCallbacks returns the set of function literals passed as the
-// callback to gorm's Transaction across all given functions and their nested
-// closures.
+// CollectImmutableCallbacks returns the set of function literals passed as the
+// callback to gorm's Transaction, Connection, or FindInBatches across all given
+// functions and their nested closures.
 //
-// A Transaction callback receives a FRESH, forkable (clone>0) transaction handle,
-// so — unlike an ordinary Phase 1b parameter — its *gorm.DB parameter is NOT a
-// mutable root and reuse inside the callback is safe (verified against gorm's
-// clone semantics; see the epic's pivotal finding). It must be exempted from the
-// mutable-by-default treatment (#60 SC103).
-func CollectTransactionCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
+// Each of these methods hands the callback a FRESH, forkable (clone>0) handle
+// (they route through Session()/Begin at runtime), so — unlike an ordinary Phase
+// 1b parameter — the callback's *gorm.DB parameter is NOT a mutable root and
+// reuse inside the callback is safe (verified against gorm's clone semantics; see
+// the epic's pivotal finding). It must be exempted from the mutable-by-default
+// treatment (#60 SC103, #62).
+func CollectImmutableCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
 	set := make(map[*ssa.Function]bool)
 	walkCalls(funcs, func(call *ssa.Call) {
-		collectTransactionCallbacksFromCall(call, set)
+		collectImmutableCallbacksFromCall(call, set)
 	})
 	return set
 }
@@ -1672,28 +1674,32 @@ func isScopesOrPreloadMethod(callee *ssa.Function) bool {
 	return sig != nil && sig.Recv() != nil && typeutil.IsGormDB(sig.Recv().Type())
 }
 
-// collectTransactionCallbacksFromCall adds the callback function passed to a
-// gorm Transaction call to set.
-func collectTransactionCallbacksFromCall(call *ssa.Call, set map[*ssa.Function]bool) {
+// collectImmutableCallbacksFromCall adds the callback function passed to a gorm
+// Transaction/Connection/FindInBatches call to set. The callback sits at a
+// different argument position per method (Transaction/Connection: first
+// argument; FindInBatches: third), so scan for the func-typed argument whose
+// signature takes a *gorm.DB rather than hard-coding an index.
+func collectImmutableCallbacksFromCall(call *ssa.Call, set map[*ssa.Function]bool) {
 	callee := call.Call.StaticCallee()
-	if callee == nil || !isTransactionMethod(callee) {
+	if callee == nil || !isImmutableCallbackMethod(callee) {
 		return
 	}
-	// Transaction(fc func(tx *DB) error, opts ...): with a static method callee
-	// the receiver is Args[0] and the callback fc is Args[1].
-	args := call.Call.Args
-	if len(args) < 2 {
-		return
-	}
-	if cb := callbackFuncValue(args[1]); cb != nil {
-		set[cb] = true
+	for _, arg := range call.Call.Args {
+		cb := callbackFuncValue(arg)
+		if cb != nil && cb.Signature != nil && directive.HasGormDBParameter(cb.Signature) {
+			set[cb] = true
+		}
 	}
 }
 
-// isTransactionMethod reports whether callee is gorm's Transaction method (gated
-// on a gorm.DB receiver so a same-named user method is excluded).
-func isTransactionMethod(callee *ssa.Function) bool {
-	if callee.Name() != "Transaction" {
+// isImmutableCallbackMethod reports whether callee is a gorm method that hands a
+// fresh (clone>0) *gorm.DB to a callback — Transaction, Connection, or
+// FindInBatches — gated on a gorm.DB receiver so a same-named user method is
+// excluded.
+func isImmutableCallbackMethod(callee *ssa.Function) bool {
+	switch callee.Name() {
+	case "Transaction", "Connection", "FindInBatches":
+	default:
 		return false
 	}
 	sig := callee.Signature

--- a/testdata/src/gorm.io/gorm/gorm.go
+++ b/testdata/src/gorm.io/gorm/gorm.go
@@ -185,6 +185,14 @@ func (db *DB) Rollback() *DB { return db }
 // Transaction executes in transaction.
 func (db *DB) Transaction(fc func(tx *DB) error, opts ...interface{}) error { return nil }
 
+// Connection executes with a dedicated connection; fc receives a fresh handle.
+func (db *DB) Connection(fc func(tx *DB) error) error { return nil }
+
+// FindInBatches finds records in batches; fc receives a fresh handle per batch.
+func (db *DB) FindInBatches(dest interface{}, batchSize int, fc func(tx *DB, batch int) error) *DB {
+	return db
+}
+
 // SavePoint creates save point.
 func (db *DB) SavePoint(name string) *DB { return db }
 

--- a/testdata/src/gormreuse/scopes_callback.go
+++ b/testdata/src/gormreuse/scopes_callback.go
@@ -82,3 +82,23 @@ func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
 	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
+
+// SC105: A Connection callback also receives a fresh (clone>0) handle, so reuse
+// inside it is safe (#62).
+func connectionCallbackNoReport(db *gorm.DB) {
+	_ = db.Connection(func(tx *gorm.DB) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+		return nil
+	})
+}
+
+// SC106: A FindInBatches callback (the tx argument, third parameter of the
+// method) likewise receives a fresh handle per batch (#62).
+func findInBatchesCallbackNoReport(db *gorm.DB) {
+	_ = db.FindInBatches(nil, 100, func(tx *gorm.DB, batch int) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+		return nil
+	})
+}

--- a/testdata/src/gormreuse/scopes_callback.go.diff
+++ b/testdata/src/gormreuse/scopes_callback.go.diff
@@ -1,6 +1,6 @@
 --- scopes_callback.go	1970-01-01 00:00:00
 +++ scopes_callback.go.golden	1970-01-01 00:00:00
-@@ -1,84 +1,85 @@
+@@ -1,104 +1,105 @@
  package internal
  
  import "gorm.io/gorm"
@@ -85,4 +85,24 @@
  func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
  	tx.Where("a").Find(nil)
  	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
+ }
+ 
+ // SC105: A Connection callback also receives a fresh (clone>0) handle, so reuse
+ // inside it is safe (#62).
+ func connectionCallbackNoReport(db *gorm.DB) {
+ 	_ = db.Connection(func(tx *gorm.DB) error {
+ 		tx.Where("a").Find(nil)
+ 		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+ 		return nil
+ 	})
+ }
+ 
+ // SC106: A FindInBatches callback (the tx argument, third parameter of the
+ // method) likewise receives a fresh handle per batch (#62).
+ func findInBatchesCallbackNoReport(db *gorm.DB) {
+ 	_ = db.FindInBatches(nil, 100, func(tx *gorm.DB, batch int) error {
+ 		tx.Where("a").Find(nil)
+ 		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+ 		return nil
+ 	})
  }

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -83,3 +83,23 @@ func ordinaryHelperParamBranches(tx *gorm.DB) *gorm.DB {
 	tx.Where("a").Find(nil)
 	return tx.Where("b") // want `\*gorm\.DB reused: second branch from mutable root`
 }
+
+// SC105: A Connection callback also receives a fresh (clone>0) handle, so reuse
+// inside it is safe (#62).
+func connectionCallbackNoReport(db *gorm.DB) {
+	_ = db.Connection(func(tx *gorm.DB) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+		return nil
+	})
+}
+
+// SC106: A FindInBatches callback (the tx argument, third parameter of the
+// method) likewise receives a fresh handle per batch (#62).
+func findInBatchesCallbackNoReport(db *gorm.DB) {
+	_ = db.FindInBatches(nil, 100, func(tx *gorm.DB, batch int) error {
+		tx.Where("a").Find(nil)
+		tx.Where("b").Find(nil) // OK: tx is a fresh handle
+		return nil
+	})
+}


### PR DESCRIPTION
## Phase 2 (Part A) — Connection/FindInBatches callbacks are immutable (#62)

gorm's `Connection` and `FindInBatches` — like `Transaction` — hand their callback a **fresh, forkable (`clone>0`)** `*gorm.DB` (they route through `Session()`/`Begin` at runtime), so reuse inside the callback is safe. Previously only `Transaction` callbacks were exempt; the other two would false-positive under Phase 1b.

```go
db.Connection(func(tx *gorm.DB) error {
    tx.Where("a").Find(nil)
    tx.Where("b").Find(nil) // now OK — tx is a fresh handle (was: reused)
    return nil
})

db.FindInBatches(&users, 100, func(tx *gorm.DB, batch int) error {
    tx.Where("a").Find(nil)
    tx.Where("b").Find(nil) // now OK
    return nil
})
```

### Changes
- `isImmutableCallbackMethod` recognizes `Transaction`/`Connection`/`FindInBatches`; `collectImmutableCallbacksFromCall` scans for the func-typed arg taking a `*gorm.DB` (callback position differs per method — 1st for Transaction/Connection, 3rd for FindInBatches) rather than a hard-coded index.
- Renamed `transactionCallbacks` → `immutableCallbacks` (collector, tracer field, analyzer threading) — it now covers three methods, and Part B's user `//gormreuse:immutable-input` callbacks will join the same set.
- gorm stub gains `Connection`/`FindInBatches`; fixtures `SC105`/`SC106` assert the callbacks are clean.

### Acceptance (from #62)
- [x] `db.Transaction(func(tx){ tx.Find(nil); tx.Count(nil) })` clean — already held (2a); Connection/FindInBatches now match.

### Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` 0 issues ✅ · collector 100% covered ✅

Part of **#62 (Part A)**. The `//gormreuse:immutable-input(name)` directive (body contract 2.3/2.4, callback exemption 2.2, U1-U3 unused) follows in a second PR that closes #62.
