### PR TITLE
feat: //gormreuse:immutable-input(name) directive (Phase 2 Part B, #62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ The linter detects when a mutable `*gorm.DB` branches into multiple code paths:
 - `//gormreuse:pure` - Mark function/method/closure as not polluting its `*gorm.DB` argument
 - `//gormreuse:immutable-return` - Mark function/method/closure as returning immutable `*gorm.DB` (like Session/WithContext)
 - `//gormreuse:immutable-param` - Opt a function's `*gorm.DB` parameters out of the Phase 1b mutable-by-default treatment: they are treated as immutable inside the function (the caller is responsible for passing an isolated value). **Caller-side contract**: when the function actually branches such a parameter, passing a mutable `*gorm.DB` at a call site is reported (isolate with `.Session(&gorm.Session{})` first, or make the caller `immutable-param` too so the contract propagates).
+- `//gormreuse:immutable-input(name)` - Declare that the function passes an **immutable** `*gorm.DB` to its callback parameter `name` (a user-defined equivalent of gorm's `Transaction`/`Connection`/`FindInBatches`). The named callback's `*gorm.DB` parameter is then treated as immutable, so reuse inside the callback is allowed. **Body contract**: if the function actually passes a mutable value to the callback, it is reported. Reported unused when `name` isn't a parameter, isn't a function type, or the callback has no `*gorm.DB` parameter.
+
+Also: gorm's built-in `Transaction`, `Connection`, and `FindInBatches` are known to pass a fresh (immutable) handle to their callbacks, so reuse inside those callbacks is always allowed.
 
 Directives can be combined with commas: `//gormreuse:pure,immutable-return`
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Reuse safety is determined by GORM's internal `clone` field: a handle with `clon
 | Mid-chain ([`Where`](https://pkg.go.dev/gorm.io/gorm#DB.Where), [`Order`](https://pkg.go.dev/gorm.io/gorm#DB.Order), …) | `== 0` | ❌ shares Statement |
 | A [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) **parameter** | unknown | ❌ treated as mutable |
 
-Transaction callbacks (`tx` in `db.Transaction(func(tx *gorm.DB) error {...})`) are exempt — their `tx` is a fresh forkable handle.
+Transaction/Connection/FindInBatches callbacks (e.g. `tx` in `db.Transaction(func(tx *gorm.DB) error {...})`) are exempt — their `tx` is a fresh forkable handle. Declare your own such helpers with [`//gormreuse:immutable-input(name)`](#gormreuseimmutable-inputname).
 
 #### Safe: Variable reassignment
 
@@ -431,6 +431,39 @@ func applyFilters(tx *gorm.DB) {
 
 > [!TIP]
 > Combine with `//gormreuse:pure` when a helper both leaves its argument unpolluted and expects an isolated value. A **redundant** `//gormreuse:immutable-param` — one whose parameter is never reused, so it suppresses nothing — is reported so you can drop it.
+
+### `//gormreuse:immutable-input(name)`
+
+Declare that the function passes an **immutable** [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) to its callback parameter `name` — a user-defined equivalent of gorm's [`Transaction`](https://pkg.go.dev/gorm.io/gorm#DB.Transaction)/[`Connection`](https://pkg.go.dev/gorm.io/gorm#DB.Connection)/[`FindInBatches`](https://pkg.go.dev/gorm.io/gorm#DB.FindInBatches). The named callback's `*gorm.DB` parameter is then treated as immutable, so reuse inside the callback is allowed:
+
+```go
+//gormreuse:immutable-input(cb)
+func withFreshDB(cb func(*gorm.DB) error, db *gorm.DB) error {
+    return cb(db.Session(&gorm.Session{})) // hands the callback an isolated value
+}
+
+func useIt(db *gorm.DB) {
+    _ = withFreshDB(func(q *gorm.DB) error {
+        q.Find(&users)
+        q.Count(&count) // OK — q is declared immutable input
+        return nil
+    }, db)
+}
+```
+
+> [!WARNING]
+> **Body contract.** If the function actually hands the callback a mutable value, it is reported:
+> ```go
+> //gormreuse:immutable-input(cb)
+> func bad(cb func(*gorm.DB) error, db *gorm.DB) error {
+>     q := db.Where("x")
+>     return cb(q) // VIOLATION: immutable-input(cb) declared but mutable *gorm.DB passed to callback
+> }
+> ```
+> The directive is reported **unused** when `name` isn't a parameter, isn't a function type, or the callback has no [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) parameter.
+
+> [!NOTE]
+> gorm's built-in [`Transaction`](https://pkg.go.dev/gorm.io/gorm#DB.Transaction), [`Connection`](https://pkg.go.dev/gorm.io/gorm#DB.Connection), and [`FindInBatches`](https://pkg.go.dev/gorm.io/gorm#DB.FindInBatches) already pass a fresh handle to their callbacks, so reuse inside those callbacks needs no directive.
 
 ### `//gormreuse:pure,immutable-return`
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -77,6 +77,7 @@ func run(pass *analysis.Pass) (any, error) {
 	pureFuncs := directive.NewPureFuncSet(pass.Fset, pass.TypesInfo)
 	immutableReturnFuncs := directive.NewImmutableReturnFuncSet(pass.Fset, pass.TypesInfo)
 	immutableParamFuncs := directive.NewImmutableParamFuncSet(pass.Fset, pass.TypesInfo)
+	immutableInputSet := directive.NewImmutableInputSet(pass.Fset, pass.TypesInfo)
 
 	pkgPath := pass.Pkg.Path()
 	for _, file := range pass.Files {
@@ -104,10 +105,12 @@ func run(pass *analysis.Pass) (any, error) {
 		for key := range directive.BuildImmutableParamFunctionSet(file, pkgPath) {
 			immutableParamFuncs.Add(key)
 		}
+		// Build immutable-input(name) callback declarations for this file
+		immutableInputSet.AddFile(file, pkgPath)
 	}
 
 	// Run SSA-based analysis
-	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, immutableParamFuncs, skipFiles)
+	internal.RunSSA(pass, ssaInfo, ignoreMaps, funcIgnores, pureFuncs, immutableReturnFuncs, immutableParamFuncs, immutableInputSet, skipFiles)
 
 	return nil, nil
 }

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -73,6 +73,7 @@ func RunSSA(
 	ignoreMaps map[string]directive.IgnoreMap,
 	funcIgnores map[string]map[token.Pos]directive.FunctionIgnoreEntry,
 	pureFuncs, immutableReturnFuncs, immutableParamFuncs *directive.DirectiveFuncSet,
+	immutableInputSet *directive.ImmutableInputSet,
 	skipFiles map[string]bool,
 ) {
 	// Share a single reported map across all functions to deduplicate
@@ -139,10 +140,33 @@ func RunSSA(
 	// mid-chain (clone==0) value, so reuse inside them must be detected (#60).
 	scopesCallbacks := tracer.CollectScopesCallbacks(ssaInfo.SrcFuncs)
 
-	// Collect Transaction callbacks once: their tx parameter is a fresh forkable
-	// (clone>0) handle, so it is exempt from the Phase 1b mutable-by-default
-	// treatment of *gorm.DB parameters (#60 SC103, #61).
+	// Collect immutable callbacks once: gorm's Transaction/Connection/FindInBatches
+	// hand their callback a fresh forkable (clone>0) handle, and a user function
+	// declared //gormreuse:immutable-input(cb) promises the same for cb. Their
+	// callback's tx parameter is therefore exempt from the Phase 1b
+	// mutable-by-default treatment (#60 SC103, #61, #62 case 2.2).
 	immutableCallbacks := tracer.CollectImmutableCallbacks(ssaInfo.SrcFuncs)
+	tracer.CollectImmutableInputCallbacks(ssaInfo.SrcFuncs, immutableInputSet, immutableCallbacks)
+
+	// Enforce the body-side immutable-input contract (#62 cases 2.3/2.4) and
+	// report unused immutable-input directives (U1-U3). Uses a tracer with the
+	// full context so FindMutableRoot classifies immutable sources correctly.
+	inputTracer := tracer.New(pureFuncs, immutableReturnFuncs, immutableParamFuncs, failedPure, scopesCallbacks, immutableCallbacks)
+	for _, fn := range ssaInfo.SrcFuncs {
+		if skip(fn, false) {
+			continue
+		}
+		recoverPerFunction(fn, func() {
+			for _, v := range purity.ValidateImmutableInputs(fn, immutableInputSet, inputTracer) {
+				pass.Reportf(v.Pos, "%s", v.Message)
+			}
+		})
+	}
+	if immutableInputSet != nil {
+		for _, u := range immutableInputSet.GetUnused() {
+			pass.Reportf(u.Pos, "%s", u.Reason)
+		}
+	}
 
 	// Share a single fix generator across all violations (it caches AST
 	// inspectors). It needs scopesCallbacks to withhold the immutable-param fix on

--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -111,3 +111,37 @@ func IsImmutableReturnDirective(text string) bool { return hasDirective(text, "i
 // (clone>0) *gorm.DB arguments, so the parameter can be reused safely. It is the
 // escape hatch for the default-mutable parameter treatment (Phase 1b, #61).
 func IsImmutableParamDirective(text string) bool { return hasDirective(text, "immutable-param") }
+
+// ExtractImmutableInputParams returns the callback parameter names declared by
+// //gormreuse:immutable-input(name) directives in a comment. A comment may carry
+// several (comma-combinable with other directives), so it returns a slice; nil if
+// none. It accepts both line and block comment forms and ignores a trailing "//"
+// comment, mirroring hasDirective (#62).
+func ExtractImmutableInputParams(text string) []string {
+	if strings.HasPrefix(text, "/*") {
+		text = strings.TrimSuffix(strings.TrimPrefix(text, "/*"), "*/")
+	} else {
+		text = strings.TrimPrefix(text, "//")
+	}
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, directivePrefix) {
+		return nil
+	}
+	text = strings.TrimPrefix(text, directivePrefix)
+	if idx := strings.Index(text, "//"); idx != -1 {
+		text = text[:idx]
+	}
+
+	var params []string
+	for _, part := range strings.Split(text, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.HasPrefix(part, "immutable-input(") || !strings.HasSuffix(part, ")") {
+			continue
+		}
+		name := strings.TrimSpace(part[len("immutable-input(") : len(part)-1])
+		if name != "" {
+			params = append(params, name)
+		}
+	}
+	return params
+}

--- a/internal/directive/immutable_input.go
+++ b/internal/directive/immutable_input.go
@@ -1,0 +1,204 @@
+package directive
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// =============================================================================
+// //gormreuse:immutable-input(name) Directive
+// =============================================================================
+//
+// This directive declares that a callback parameter (named name) of a function
+// receives an immutable *gorm.DB — the function is a user-defined equivalent of
+// gorm's Transaction/Connection/FindInBatches. Inside such a callback, the
+// *gorm.DB parameter can be reused without triggering Phase 1b reuse detection,
+// and the declaring function's body must hand the callback an immutable value.
+
+// ImmutableInputCallback identifies a single callback parameter that receives an
+// immutable *gorm.DB.
+type ImmutableInputCallback struct {
+	ParamIdx  int    // Index of the callback parameter (counting from the first non-receiver parameter)
+	ParamName string // The name as written in immutable-input(name) — kept for diagnostics
+}
+
+// ImmutableInputUnused describes a directive whose target is not a usable
+// callback. It corresponds to the U1–U3 cases in issue #56/#62.
+type ImmutableInputUnused struct {
+	Pos    token.Pos // Position of the directive comment
+	Reason string    // Human-readable reason for reporting
+}
+
+// ImmutableInputSet stores all //gormreuse:immutable-input(name) directives found
+// in the analyzed source, keyed by the enclosing function.
+type ImmutableInputSet struct {
+	known  map[FuncKey][]ImmutableInputCallback
+	unused []ImmutableInputUnused
+
+	fset      *token.FileSet
+	typesInfo *types.Info
+}
+
+// NewImmutableInputSet creates an empty set tied to the pass's FileSet and
+// TypesInfo.
+func NewImmutableInputSet(fset *token.FileSet, typesInfo *types.Info) *ImmutableInputSet {
+	return &ImmutableInputSet{
+		known:     make(map[FuncKey][]ImmutableInputCallback),
+		fset:      fset,
+		typesInfo: typesInfo,
+	}
+}
+
+// AddFile scans an AST file for `//gormreuse:immutable-input(name)` directives,
+// validates each against the surrounding function's signature, and either
+// registers a usable callback or records an unused-directive diagnostic.
+func (s *ImmutableInputSet) AddFile(file *ast.File, pkgPath string) {
+	if s == nil || file == nil {
+		return
+	}
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Doc == nil {
+			continue
+		}
+		refs := s.extractParamsFromComments(fd.Doc.List)
+		if len(refs) == 0 {
+			continue
+		}
+		key := s.buildFuncKey(fd, pkgPath)
+		s.processDirectiveTargets(fd, refs, key)
+	}
+}
+
+type paramRef struct {
+	commentPos token.Pos
+	name       string
+}
+
+// extractParamsFromComments collects (commentPos, paramName) tuples for every
+// immutable-input(name) directive in the comment list.
+func (s *ImmutableInputSet) extractParamsFromComments(list []*ast.Comment) []paramRef {
+	var refs []paramRef
+	for _, c := range list {
+		for _, name := range ExtractImmutableInputParams(c.Text) {
+			refs = append(refs, paramRef{commentPos: c.Pos(), name: name})
+		}
+	}
+	return refs
+}
+
+// processDirectiveTargets validates each (commentPos, paramName) against the
+// function's signature, registering usable callbacks in s.known and pushing
+// unused-diagnostic entries into s.unused otherwise.
+func (s *ImmutableInputSet) processDirectiveTargets(fd *ast.FuncDecl, refs []paramRef, key FuncKey) {
+	for _, ref := range refs {
+		idx, paramType := s.lookupParam(fd, ref.name)
+		if idx < 0 {
+			s.unused = append(s.unused, ImmutableInputUnused{
+				Pos:    ref.commentPos,
+				Reason: fmt.Sprintf("unused gormreuse:immutable-input directive: parameter %q not found", ref.name),
+			})
+			continue
+		}
+		funcSig := asFunctionSignature(paramType)
+		if funcSig == nil {
+			s.unused = append(s.unused, ImmutableInputUnused{
+				Pos:    ref.commentPos,
+				Reason: fmt.Sprintf("unused gormreuse:immutable-input directive: parameter %q is not a function type", ref.name),
+			})
+			continue
+		}
+		if !hasGormDBParameter(funcSig) {
+			s.unused = append(s.unused, ImmutableInputUnused{
+				Pos:    ref.commentPos,
+				Reason: fmt.Sprintf("unused gormreuse:immutable-input directive: callback %q has no *gorm.DB parameter", ref.name),
+			})
+			continue
+		}
+		s.known[key] = append(s.known[key], ImmutableInputCallback{ParamIdx: idx, ParamName: ref.name})
+	}
+}
+
+// lookupParam finds a parameter by name in the function declaration and returns
+// (index counting from the first non-receiver parameter, recorded type). Returns
+// idx=-1 if not found.
+func (s *ImmutableInputSet) lookupParam(fd *ast.FuncDecl, name string) (int, types.Type) {
+	if fd.Type == nil || fd.Type.Params == nil {
+		return -1, nil
+	}
+	idx := 0
+	for _, field := range fd.Type.Params.List {
+		// A field with no names still occupies one parameter position but cannot
+		// match any name.
+		if len(field.Names) == 0 {
+			idx++
+			continue
+		}
+		for _, ident := range field.Names {
+			if ident.Name == name {
+				var t types.Type
+				if s.typesInfo != nil {
+					t = s.typesInfo.TypeOf(field.Type)
+				}
+				return idx, t
+			}
+			idx++
+		}
+	}
+	return -1, nil
+}
+
+// asFunctionSignature returns the *types.Signature for a parameter that is itself
+// a function, or nil if it isn't (or if type info is unavailable — an honest U2
+// in that degraded case rather than a misleading U3).
+func asFunctionSignature(t types.Type) *types.Signature {
+	if t == nil {
+		return nil
+	}
+	sig, _ := t.Underlying().(*types.Signature)
+	return sig
+}
+
+// buildFuncKey produces a FuncKey for a function declaration matching what the
+// tracer/analyzer use for SSA functions.
+func (s *ImmutableInputSet) buildFuncKey(fd *ast.FuncDecl, pkgPath string) FuncKey {
+	key := FuncKey{PkgPath: pkgPath, FuncName: fd.Name.Name}
+	if fd.Recv != nil && len(fd.Recv.List) > 0 {
+		key.ReceiverType = stripPointer(exprToString(fd.Recv.List[0].Type))
+	}
+	return key
+}
+
+// Callbacks returns the registered immutable-input callbacks for fn, used to
+// exempt callback arguments (case 2.2) and to validate the declaring function's
+// body contract (cases 2.3/2.4).
+func (s *ImmutableInputSet) Callbacks(fn *ssa.Function) []ImmutableInputCallback {
+	if s == nil || fn == nil {
+		return nil
+	}
+	key := FuncKey{FuncName: fn.Name()}
+	if fn.Pkg != nil && fn.Pkg.Pkg != nil {
+		key.PkgPath = fn.Pkg.Pkg.Path()
+	}
+	if sig := fn.Signature; sig != nil && sig.Recv() != nil {
+		key.ReceiverType = formatReceiverType(sig.Recv().Type())
+	}
+	out := make([]ImmutableInputCallback, len(s.known[key]))
+	copy(out, s.known[key])
+	return out
+}
+
+// GetUnused returns the diagnostics for directives that don't apply to any usable
+// callback (U1–U3). U4 is the success path: nothing to report.
+func (s *ImmutableInputSet) GetUnused() []ImmutableInputUnused {
+	if s == nil {
+		return nil
+	}
+	out := make([]ImmutableInputUnused, len(s.unused))
+	copy(out, s.unused)
+	return out
+}

--- a/internal/directive/immutable_input_test.go
+++ b/internal/directive/immutable_input_test.go
@@ -1,0 +1,129 @@
+package directive
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+// parseFileWithTypes parses src as a single Go file in package "demo" and runs
+// go/types over it so the resulting *ast.File / *types.Info combo can drive
+// ImmutableInputSet.AddFile in tests.
+func parseFileWithTypes(t *testing.T, src string) (*token.FileSet, *ast.File, *types.Info) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "demo.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	conf := &types.Config{Importer: importer.Default()}
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
+		Uses:  make(map[*ast.Ident]types.Object),
+	}
+	if _, err := conf.Check("demo", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("type check: %v", err)
+	}
+	return fset, file, info
+}
+
+func TestImmutableInputSet_NilSafety(t *testing.T) {
+	t.Parallel()
+
+	var nilSet *ImmutableInputSet
+	// Every accessor must tolerate a nil receiver — the analyzer passes a nil set
+	// when directive bookkeeping isn't applicable.
+	nilSet.AddFile(nil, "demo")
+	if got := nilSet.Callbacks(nil); got != nil {
+		t.Errorf("Callbacks(nil) = %v, want nil", got)
+	}
+	if got := nilSet.GetUnused(); got != nil {
+		t.Errorf("GetUnused() = %v, want nil", got)
+	}
+}
+
+func TestImmutableInputSet_AddFile_NoDirectives(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\nfunc plain(cb func()) {}\n"
+	fset, file, info := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, info)
+	s.AddFile(file, "demo")
+	if got := len(s.GetUnused()); got != 0 {
+		t.Errorf("GetUnused() with no directives = %d, want 0", got)
+	}
+}
+
+func TestImmutableInputSet_AddFile_ParamNotFound(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\n//gormreuse:immutable-input(missing)\nfunc noSuchParam(cb func()) {}\n"
+	fset, file, info := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, info)
+	s.AddFile(file, "demo")
+	assertOneUnused(t, s, `parameter "missing" not found`)
+}
+
+func TestImmutableInputSet_AddFile_ParamNotFunctionType(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\n//gormreuse:immutable-input(x)\nfunc notFn(x int) {}\n"
+	fset, file, info := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, info)
+	s.AddFile(file, "demo")
+	assertOneUnused(t, s, `parameter "x" is not a function type`)
+}
+
+// U3: the named parameter is a function type, but its signature has no *gorm.DB
+// argument, so the directive can never apply.
+func TestImmutableInputSet_AddFile_CallbackHasNoGormDB(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\n//gormreuse:immutable-input(cb)\nfunc cbNoGormDB(cb func(int) int) {}\n"
+	fset, file, info := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, info)
+	s.AddFile(file, "demo")
+	assertOneUnused(t, s, "no *gorm.DB parameter")
+}
+
+// Covers the lookupParam branch where a field has no Names slice — it still
+// consumes a position but cannot match any name — and confirms the index is
+// advanced so a later parameter still resolves.
+func TestImmutableInputSet_AddFile_AnonymousParam(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\n//gormreuse:immutable-input(missing)\nfunc anon(int, cb func()) {}\n"
+	fset, file, info := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, info)
+	s.AddFile(file, "demo")
+	assertOneUnused(t, s, `parameter "missing" not found`)
+}
+
+// With no type info, lookupParam returns a nil type, so asFunctionSignature(nil)
+// takes its nil branch and the directive is honestly reported as U2 rather than
+// synthesising a misleading U3.
+func TestImmutableInputSet_AddFile_NilTypesInfo(t *testing.T) {
+	t.Parallel()
+
+	const src = "package demo\n\n//gormreuse:immutable-input(cb)\nfunc noTypeInfo(cb func()) {}\n"
+	fset, file, _ := parseFileWithTypes(t, src)
+	s := NewImmutableInputSet(fset, nil) // no TypesInfo
+	s.AddFile(file, "demo")
+	assertOneUnused(t, s, `parameter "cb" is not a function type`)
+}
+
+func assertOneUnused(t *testing.T, s *ImmutableInputSet, want string) {
+	t.Helper()
+	unused := s.GetUnused()
+	if len(unused) != 1 {
+		t.Fatalf("len(GetUnused()) = %d, want 1; entries=%+v", len(unused), unused)
+	}
+	if got := unused[0].Reason; !strings.Contains(got, want) {
+		t.Errorf("Reason = %q, want substring %q", got, want)
+	}
+}

--- a/internal/ssa/purity/immutable_input.go
+++ b/internal/ssa/purity/immutable_input.go
@@ -1,0 +1,84 @@
+package purity
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/mpyw/gormreuse/internal/directive"
+	"github.com/mpyw/gormreuse/internal/ssa/tracer"
+	"github.com/mpyw/gormreuse/internal/typeutil"
+)
+
+// ValidateImmutableInputs enforces the body-side contract of
+// //gormreuse:immutable-input(name): whenever the declaring function calls the
+// named callback parameter, every *gorm.DB argument must be an immutable source
+// (a Session()/WithContext()/Debug()/Begin result, an immutable-return user
+// function result, an immutable-param'd value, or nil). Passing a mutable
+// (clone==0) value violates the declaration.
+//
+// Issue #56/#62 cases 2.3 (declaration violated) and 2.4 (correct usage).
+//
+// rt must be a tracer configured with the pass's full context so FindMutableRoot
+// classifies immutable sources correctly.
+func ValidateImmutableInputs(fn *ssa.Function, set *directive.ImmutableInputSet, rt *tracer.RootTracer) []Violation {
+	if fn == nil || set == nil || rt == nil {
+		return nil
+	}
+	callbacks := set.Callbacks(fn)
+	if len(callbacks) == 0 {
+		return nil
+	}
+
+	// Resolve declared callback param indices to actual SSA Parameters.
+	// ssa.Function.Params lists the receiver first for methods, while
+	// ImmutableInputCallback.ParamIdx counts from the first non-receiver
+	// parameter, so shift by one when the function has a receiver.
+	hasReceiver := fn.Signature != nil && fn.Signature.Recv() != nil
+	cbParams := make(map[*ssa.Parameter]string, len(callbacks))
+	for _, cb := range callbacks {
+		idx := cb.ParamIdx
+		if hasReceiver {
+			idx++
+		}
+		if idx < 0 || idx >= len(fn.Params) {
+			continue
+		}
+		cbParams[fn.Params[idx]] = cb.ParamName
+	}
+	if len(cbParams) == 0 {
+		return nil
+	}
+
+	var violations []Violation
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			call, ok := instr.(*ssa.Call)
+			if !ok {
+				continue
+			}
+			calleeParam, ok := call.Call.Value.(*ssa.Parameter)
+			if !ok {
+				continue
+			}
+			name, watched := cbParams[calleeParam]
+			if !watched {
+				continue
+			}
+			for _, arg := range call.Call.Args {
+				if !typeutil.IsGormDB(arg.Type()) {
+					continue
+				}
+				if rt.FindMutableRoot(arg, nil) == nil {
+					continue // immutable source — fine
+				}
+				violations = append(violations, Violation{
+					Pos:     call.Pos(),
+					Message: fmt.Sprintf("immutable-input(%s) declared but mutable *gorm.DB passed to callback", name),
+				})
+				break // one diagnostic per call site
+			}
+		}
+	}
+	return violations
+}

--- a/internal/ssa/tracer/root.go
+++ b/internal/ssa/tracer/root.go
@@ -1598,6 +1598,43 @@ func CollectImmutableCallbacks(funcs []*ssa.Function) map[*ssa.Function]bool {
 	return set
 }
 
+// CollectImmutableInputCallbacks adds, to into, every closure passed as the
+// callback argument declared by a //gormreuse:immutable-input(name) function.
+// Such a callback receives an immutable *gorm.DB (the declaring function promised
+// to hand it one), so — like a Transaction callback — its *gorm.DB parameter is
+// exempt from the Phase 1b mutable-by-default treatment (#62 case 2.2).
+func CollectImmutableInputCallbacks(funcs []*ssa.Function, set *directive.ImmutableInputSet, into map[*ssa.Function]bool) {
+	if set == nil || into == nil {
+		return
+	}
+	walkCalls(funcs, func(call *ssa.Call) {
+		callee := call.Call.StaticCallee()
+		if callee == nil {
+			return
+		}
+		cbs := set.Callbacks(callee)
+		if len(cbs) == 0 {
+			return
+		}
+		// A method call carries its receiver as Args[0]; ParamIdx counts from the
+		// first non-receiver parameter, so shift when the callee has a receiver.
+		shift := 0
+		if callee.Signature != nil && callee.Signature.Recv() != nil {
+			shift = 1
+		}
+		args := call.Call.Args
+		for _, cb := range cbs {
+			idx := cb.ParamIdx + shift
+			if idx < 0 || idx >= len(args) {
+				continue
+			}
+			if fn := callbackFuncValue(args[idx]); fn != nil {
+				into[fn] = true
+			}
+		}
+	})
+}
+
 // walkCalls visits every *ssa.Call in funcs and their nested anonymous functions
 // exactly once. Shared by the Scopes/Preload and Transaction callback collectors.
 func walkCalls(funcs []*ssa.Function, visit func(*ssa.Call)) {

--- a/testdata/src/gormreuse/immutable_input.go
+++ b/testdata/src/gormreuse/immutable_input.go
@@ -1,0 +1,138 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// User-defined //gormreuse:immutable-input(name) Directive
+// Issue #56 cases 2.1–2.4 + U1–U4.
+// =============================================================================
+
+// =============================================================================
+// 2.1 — Builtin Transaction (already covered, kept for completeness)
+// =============================================================================
+
+// transactionCallbackUserDefined demonstrates that the existing builtin
+// constraint still works after the user-defined wiring landed.
+func transactionCallbackUserDefined(db *gorm.DB) {
+	db = db.Session(&gorm.Session{}) // make parameter immutable
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		tx.Find(nil)
+		tx.Count(nil) // OK — tx is immutable input
+		return nil
+	})
+}
+
+// =============================================================================
+// 2.2 — User-defined immutable-input on a free function
+// =============================================================================
+
+// withFreshDB declares that its callback receives an immutable *gorm.DB.
+// The implementation respects this by handing fresh through Session().
+//
+//gormreuse:immutable-input(cb)
+func withFreshDB(cb func(*gorm.DB) error, db *gorm.DB) error {
+	fresh := db.Session(&gorm.Session{})
+	return cb(fresh) // OK: passes immutable
+}
+
+// useWithFreshDBOK demonstrates that callbacks of immutable-input
+// declarations may reuse their parameter.
+func useWithFreshDBOK(db *gorm.DB) {
+	db = db.Session(&gorm.Session{})
+	_ = withFreshDB(func(q *gorm.DB) error {
+		q.Find(nil)
+		q.Count(nil) // OK — q is declared immutable
+		return nil
+	}, db)
+}
+
+// =============================================================================
+// 2.3 — immutable-input declared but body passes a mutable value
+// =============================================================================
+
+// badImmutableInput violates its own immutable-input(cb) contract by
+// handing the callback a mutable value derived from db.
+//
+//gormreuse:immutable-input(cb)
+func badImmutableInput(cb func(*gorm.DB) error, db *gorm.DB) error {
+	q := db.Where("x")                                                           // q is mutable
+	return cb(q) // want `immutable-input\(cb\) declared but mutable \*gorm\.DB passed to callback`
+}
+
+// =============================================================================
+// 2.4 — immutable-input declared and body passes an immutable value
+// =============================================================================
+
+// goodImmutableInput correctly hands an immutable value to its callback.
+//
+//gormreuse:immutable-input(cb)
+func goodImmutableInput(cb func(*gorm.DB) error, db *gorm.DB) error {
+	fresh := db.Session(&gorm.Session{})
+	return cb(fresh)
+}
+
+// =============================================================================
+// U1–U4 — Unused directive detection
+// =============================================================================
+
+// U1: parameter named `nonexistent` doesn't exist in the signature.
+//
+//gormreuse:immutable-input(nonexistent) // want `unused gormreuse:immutable-input directive: parameter "nonexistent" not found`
+func noSuchParam(cb func(*gorm.DB)) {
+	_ = cb
+}
+
+// U2: parameter `x` is not a function type.
+//
+//gormreuse:immutable-input(x) // want `unused gormreuse:immutable-input directive: parameter "x" is not a function type`
+func notFuncType(x int) {
+	_ = x
+}
+
+// U3: callback `cb` has no *gorm.DB parameter.
+//
+//gormreuse:immutable-input(cb) // want `unused gormreuse:immutable-input directive: callback "cb" has no \*gorm\.DB parameter`
+func callbackNoGormDBParam(cb func(int) int) {
+	_ = cb
+}
+
+// U4: valid declaration — no diagnostic.
+//
+//gormreuse:immutable-input(cb)
+func validImmutableInput(cb func(*gorm.DB) error) error {
+	return cb(nil)
+}
+
+// =============================================================================
+// 2.5 — immutable-input on a METHOD (receiver-shifted parameter index)
+// =============================================================================
+
+type immutableInputRepo struct{ db *gorm.DB }
+
+// withFreshMethod declares immutable-input(cb) on a method; cb is the first
+// non-receiver parameter, so the index must be shifted past the receiver.
+//
+//gormreuse:immutable-input(cb)
+func (r *immutableInputRepo) withFreshMethod(cb func(*gorm.DB) error) error {
+	fresh := r.db.Session(&gorm.Session{})
+	return cb(fresh) // OK: passes immutable
+}
+
+// badMethod violates its own method-level immutable-input(cb) contract.
+//
+//gormreuse:immutable-input(cb)
+func (r *immutableInputRepo) badMethod(cb func(*gorm.DB) error, db *gorm.DB) error {
+	q := db.Where("x")
+	return cb(q) // want `immutable-input\(cb\) declared but mutable \*gorm\.DB passed to callback`
+}
+
+// useWithFreshMethod passes a closure to the method; its *gorm.DB parameter is
+// treated as immutable input, so reuse inside it is OK (callback exemption with
+// a receiver-shifted argument index).
+func useWithFreshMethod(r *immutableInputRepo) {
+	_ = r.withFreshMethod(func(q *gorm.DB) error {
+		q.Find(nil)
+		q.Count(nil) // OK — q is declared immutable input
+		return nil
+	})
+}

--- a/testdata/src/gormreuse/immutable_input.go.golden
+++ b/testdata/src/gormreuse/immutable_input.go.golden
@@ -1,0 +1,138 @@
+package internal
+
+import "gorm.io/gorm"
+
+// =============================================================================
+// User-defined //gormreuse:immutable-input(name) Directive
+// Issue #56 cases 2.1–2.4 + U1–U4.
+// =============================================================================
+
+// =============================================================================
+// 2.1 — Builtin Transaction (already covered, kept for completeness)
+// =============================================================================
+
+// transactionCallbackUserDefined demonstrates that the existing builtin
+// constraint still works after the user-defined wiring landed.
+func transactionCallbackUserDefined(db *gorm.DB) {
+	db = db.Session(&gorm.Session{}) // make parameter immutable
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		tx.Find(nil)
+		tx.Count(nil) // OK — tx is immutable input
+		return nil
+	})
+}
+
+// =============================================================================
+// 2.2 — User-defined immutable-input on a free function
+// =============================================================================
+
+// withFreshDB declares that its callback receives an immutable *gorm.DB.
+// The implementation respects this by handing fresh through Session().
+//
+//gormreuse:immutable-input(cb)
+func withFreshDB(cb func(*gorm.DB) error, db *gorm.DB) error {
+	fresh := db.Session(&gorm.Session{})
+	return cb(fresh) // OK: passes immutable
+}
+
+// useWithFreshDBOK demonstrates that callbacks of immutable-input
+// declarations may reuse their parameter.
+func useWithFreshDBOK(db *gorm.DB) {
+	db = db.Session(&gorm.Session{})
+	_ = withFreshDB(func(q *gorm.DB) error {
+		q.Find(nil)
+		q.Count(nil) // OK — q is declared immutable
+		return nil
+	}, db)
+}
+
+// =============================================================================
+// 2.3 — immutable-input declared but body passes a mutable value
+// =============================================================================
+
+// badImmutableInput violates its own immutable-input(cb) contract by
+// handing the callback a mutable value derived from db.
+//
+//gormreuse:immutable-input(cb)
+func badImmutableInput(cb func(*gorm.DB) error, db *gorm.DB) error {
+	q := db.Where("x")                                                           // q is mutable
+	return cb(q) // want `immutable-input\(cb\) declared but mutable \*gorm\.DB passed to callback`
+}
+
+// =============================================================================
+// 2.4 — immutable-input declared and body passes an immutable value
+// =============================================================================
+
+// goodImmutableInput correctly hands an immutable value to its callback.
+//
+//gormreuse:immutable-input(cb)
+func goodImmutableInput(cb func(*gorm.DB) error, db *gorm.DB) error {
+	fresh := db.Session(&gorm.Session{})
+	return cb(fresh)
+}
+
+// =============================================================================
+// U1–U4 — Unused directive detection
+// =============================================================================
+
+// U1: parameter named `nonexistent` doesn't exist in the signature.
+//
+//gormreuse:immutable-input(nonexistent) // want `unused gormreuse:immutable-input directive: parameter "nonexistent" not found`
+func noSuchParam(cb func(*gorm.DB)) {
+	_ = cb
+}
+
+// U2: parameter `x` is not a function type.
+//
+//gormreuse:immutable-input(x) // want `unused gormreuse:immutable-input directive: parameter "x" is not a function type`
+func notFuncType(x int) {
+	_ = x
+}
+
+// U3: callback `cb` has no *gorm.DB parameter.
+//
+//gormreuse:immutable-input(cb) // want `unused gormreuse:immutable-input directive: callback "cb" has no \*gorm\.DB parameter`
+func callbackNoGormDBParam(cb func(int) int) {
+	_ = cb
+}
+
+// U4: valid declaration — no diagnostic.
+//
+//gormreuse:immutable-input(cb)
+func validImmutableInput(cb func(*gorm.DB) error) error {
+	return cb(nil)
+}
+
+// =============================================================================
+// 2.5 — immutable-input on a METHOD (receiver-shifted parameter index)
+// =============================================================================
+
+type immutableInputRepo struct{ db *gorm.DB }
+
+// withFreshMethod declares immutable-input(cb) on a method; cb is the first
+// non-receiver parameter, so the index must be shifted past the receiver.
+//
+//gormreuse:immutable-input(cb)
+func (r *immutableInputRepo) withFreshMethod(cb func(*gorm.DB) error) error {
+	fresh := r.db.Session(&gorm.Session{})
+	return cb(fresh) // OK: passes immutable
+}
+
+// badMethod violates its own method-level immutable-input(cb) contract.
+//
+//gormreuse:immutable-input(cb)
+func (r *immutableInputRepo) badMethod(cb func(*gorm.DB) error, db *gorm.DB) error {
+	q := db.Where("x")
+	return cb(q) // want `immutable-input\(cb\) declared but mutable \*gorm\.DB passed to callback`
+}
+
+// useWithFreshMethod passes a closure to the method; its *gorm.DB parameter is
+// treated as immutable input, so reuse inside it is OK (callback exemption with
+// a receiver-shifted argument index).
+func useWithFreshMethod(r *immutableInputRepo) {
+	_ = r.withFreshMethod(func(q *gorm.DB) error {
+		q.Find(nil)
+		q.Count(nil) // OK — q is declared immutable input
+		return nil
+	})
+}


### PR DESCRIPTION
## Phase 2 (Part B) — `//gormreuse:immutable-input(name)` directive (#62)

Lets users declare their own Transaction-like helpers. A function annotated `//gormreuse:immutable-input(cb)` promises to pass an **immutable** `*gorm.DB` to its callback parameter `cb`. Builds on Part A (#110), which taught the linter the `Transaction`/`Connection`/`FindInBatches` builtins.

### Callback exemption (case 2.2)
A closure passed as the declared callback arg has its `*gorm.DB` parameter treated as immutable — same set as the builtins:
```go
//gormreuse:immutable-input(cb)
func withFreshDB(cb func(*gorm.DB) error, db *gorm.DB) error {
    return cb(db.Session(&gorm.Session{}))
}

withFreshDB(func(q *gorm.DB) error {
    q.Find(&users)
    q.Count(&count) // OK — q is declared immutable input
    return nil
}, db)
```

### Body contract (cases 2.3/2.4)
Passing a mutable value to the callback is reported:
```go
//gormreuse:immutable-input(cb)
func bad(cb func(*gorm.DB) error, db *gorm.DB) error {
    q := db.Where("x")
    return cb(q) // ▶ immutable-input(cb) declared but mutable *gorm.DB passed to callback
}
```

### Unused detection (U1-U3)
Reported at the directive when `name` isn't a parameter / isn't a function type / the callback has no `*gorm.DB` parameter. U4 (valid) is clean.

### Implementation
- `internal/directive/immutable_input.go` — `ImmutableInputSet` (parses via new `directive.ExtractImmutableInputParams`, validates each name against the signature). Ported/adapted from the closed PR #57 reference.
- `internal/ssa/purity/immutable_input.go` — body-contract validator.
- `tracer.CollectImmutableInputCallbacks` feeds callback exemptions into the shared `immutableCallbacks` set (receiver-shift aware).
- Wired through the public analyzer (set built from `pass.Files`/`TypesInfo`) into `RunSSA`.
- Fixtures `immutable_input.go` (cases 2.1-2.5 incl. a **method** for the receiver-shifted index, U1-U4); directive unit tests for the U1-U3 / nil-receiver / anonymous-param / nil-TypesInfo branches. No suggested fixes (0-byte `.diff`, intentional — matches the #57 note).
- README + CLAUDE.md document the directive and the builtin callbacks.

### Acceptance criteria (#62)
- [x] `db.Transaction(func(tx){ tx.Find(nil); tx.Count(nil) })` clean (Part A / 2a)
- [x] `//gormreuse:immutable-input(cb)` body-contract violation reported
- [x] U1-U3 diagnostics work; U4 clean
- [x] New files covered (directive fns ~100%; remaining gaps are defensive nil/bounds guards)

### Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` 0 issues ✅

**Closes #62.** With Part A (#110) this completes Phase 2; remaining epic #59 work is **#63 (Phase 3)**.
