### PR TITLE
feat: temporary Scopes-callback Session/WithContext/Debug warning (Phase 3, #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,23 @@ func useIt(db *gorm.DB) {
 > [!WARNING]
 > Unused `//gormreuse:pure`, `//gormreuse:immutable-return`, and `//gormreuse:immutable-param` directives are reported as warnings (a directive whose signature doesn't fit — e.g. `immutable-param` on a function with no [`*gorm.DB`](https://pkg.go.dev/gorm.io/gorm#DB) parameter). A **redundant** `//gormreuse:immutable-param` (signature-valid but its parameter is never reused) is reported too. For combined directives like `//gormreuse:pure,immutable-return`, if either part is used, no unused warning is reported.
 
+## Temporary rule: `Session`/`WithContext`/`Debug` inside `Scopes` callbacks
+
+> [!WARNING]
+> This is a **temporary** rule working around an upstream GORM bug.
+
+Calling [`Session`](https://pkg.go.dev/gorm.io/gorm#DB.Session), [`WithContext`](https://pkg.go.dev/gorm.io/gorm#DB.WithContext), or [`Debug`](https://pkg.go.dev/gorm.io/gorm#DB.Debug) inside a [`Scopes`](https://pkg.go.dev/gorm.io/gorm#DB.Scopes) callback corrupts GORM's `InstanceSet`/`InstanceGet` bookkeeping and leaks transactions ([go-gorm/gorm#7592](https://github.com/go-gorm/gorm/issues/7592), fix attempt [#7593](https://github.com/go-gorm/gorm/pull/7593)):
+
+```go
+db.Scopes(func(q *gorm.DB) *gorm.DB {
+    return q.Session(&gorm.Session{}).Where("x") // WARNING: Session() in Scopes callback causes transaction leak
+})
+```
+
+[`Preload`](https://pkg.go.dev/gorm.io/gorm#DB.Preload) callbacks are **unaffected** (Preload builds a fresh DB), so the same code inside a Preload callback is not flagged.
+
+**Removal condition**: once the upstream fix ships in a supported GORM release, this rule is deleted by removing `internal/scopes_session_warning.go` and its single call site in `RunSSA` — the file documents this in-line. Re-check go-gorm/gorm#7592 on each GORM version bump.
+
 ## Documentation
 
 - [CLAUDE.md](./CLAUDE.md) - AI assistant guidance for development

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -168,6 +168,18 @@ func RunSSA(
 		}
 	}
 
+	// TEMPORARY (GORM bug go-gorm/gorm#7592): warn on Session/WithContext/Debug
+	// inside Scopes callbacks. Deletable by removing scopes_session_warning.go and
+	// this loop once the upstream fix ships in a supported release — see that file.
+	for _, fn := range ssaInfo.SrcFuncs {
+		if skip(fn, false) {
+			continue
+		}
+		for _, w := range validateScopesCallback(fn) {
+			pass.Reportf(w.Pos, "%s", w.Message)
+		}
+	}
+
 	// Share a single fix generator across all violations (it caches AST
 	// inspectors). It needs scopesCallbacks to withhold the immutable-param fix on
 	// Scopes/Preload callbacks, whose parameters cannot be exempted (stage 2c).

--- a/internal/scopes_session_warning.go
+++ b/internal/scopes_session_warning.go
@@ -1,0 +1,203 @@
+package internal
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/mpyw/gormreuse/internal/typeutil"
+)
+
+// =============================================================================
+// Scopes Session() Warning (TEMPORARY — GORM bug workaround)
+// =============================================================================
+//
+// GORM has a bug where calling Session()/WithContext()/Debug() inside a
+// Scopes callback corrupts the InstanceSet/InstanceGet bookkeeping and
+// causes transaction leaks:
+//
+//   - Issue: https://github.com/go-gorm/gorm/issues/7592
+//   - Patch: https://github.com/go-gorm/gorm/pull/7593
+//
+// **Removal condition**: once the upstream fix ships in a tagged GORM
+// release and gormreuse drops support for older versions, delete this
+// entire file and the call site in RunSSA. The remaining detection
+// (Scopes callback parameter reuse) is handled by Phase 1 alone.
+//
+// Why this lives in its own file: it is independent of pollution
+// tracking, has a known sunset, and would otherwise pollute the
+// general orchestration code in analyzer.go.
+
+// scopesWarning represents a warning about Session()-family calls
+// inside a Scopes callback.
+type scopesWarning struct {
+	Pos     token.Pos
+	Message string
+}
+
+// validateScopesCallback checks whether fn is a Scopes callback and warns
+// about Session()/WithContext()/Debug() calls inside it. These three are
+// the methods that touch the broken InstanceSet/InstanceGet path.
+func validateScopesCallback(fn *ssa.Function) []scopesWarning {
+	parent := fn.Parent()
+	if parent == nil {
+		return nil
+	}
+	if !isScopesCallback(fn, parent) {
+		return nil
+	}
+
+	var warnings []scopesWarning
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			call, ok := instr.(*ssa.Call)
+			if !ok {
+				continue
+			}
+			// Only flag the GORM bug when these names are actually
+			// methods on *gorm.DB; an unrelated package's Session() or
+			// Debug() shouldn't trigger the warning.
+			if !isGormDBMethodCall(call) {
+				continue
+			}
+			switch getMethodName(call) {
+			case "Session":
+				warnings = append(warnings, scopesWarning{
+					Pos:     call.Pos(),
+					Message: "Session() in Scopes callback causes transaction leak (GORM bug)",
+				})
+			case "WithContext":
+				warnings = append(warnings, scopesWarning{
+					Pos:     call.Pos(),
+					Message: "WithContext() in Scopes callback causes transaction leak (calls Session internally)",
+				})
+			case "Debug":
+				warnings = append(warnings, scopesWarning{
+					Pos:     call.Pos(),
+					Message: "Debug() in Scopes callback causes transaction leak (calls Session internally)",
+				})
+			}
+		}
+	}
+	return warnings
+}
+
+// storeRefersToFunction reports whether store's value is fn directly or
+// a MakeClosure wrapping fn.
+func storeRefersToFunction(store *ssa.Store, fn *ssa.Function) bool {
+	if directFn, ok := store.Val.(*ssa.Function); ok && directFn == fn {
+		return true
+	}
+	if mc, ok := store.Val.(*ssa.MakeClosure); ok {
+		if closureFn, ok := mc.Fn.(*ssa.Function); ok && closureFn == fn {
+			return true
+		}
+	}
+	return false
+}
+
+// isScopesCallback reports whether fn is a callback passed to the Scopes method,
+// via either the variadic-packing path (Store→IndexAddr→Alloc→Slice→Scopes) or a
+// direct function/closure argument.
+func isScopesCallback(fn *ssa.Function, parent *ssa.Function) bool {
+	for _, block := range parent.Blocks {
+		for _, instr := range block.Instrs {
+			if storePacksFuncIntoScopes(instr, fn) || callPassesFuncToScopes(instr, fn) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// storePacksFuncIntoScopes reports whether instr stores fn into a variadic array
+// that is then sliced and handed to Scopes.
+func storePacksFuncIntoScopes(instr ssa.Instruction, fn *ssa.Function) bool {
+	store, ok := instr.(*ssa.Store)
+	if !ok || !storeRefersToFunction(store, fn) {
+		return false
+	}
+	indexAddr, ok := store.Addr.(*ssa.IndexAddr)
+	if !ok {
+		return false
+	}
+	alloc, ok := indexAddr.X.(*ssa.Alloc)
+	if !ok {
+		return false
+	}
+	return allocFlowsToScopes(alloc)
+}
+
+// allocFlowsToScopes reports whether a slice of alloc is passed to Scopes.
+func allocFlowsToScopes(alloc *ssa.Alloc) bool {
+	refs := alloc.Referrers()
+	if refs == nil {
+		return false
+	}
+	for _, ref := range *refs {
+		if slice, ok := ref.(*ssa.Slice); ok && sliceFlowsToScopes(slice) {
+			return true
+		}
+	}
+	return false
+}
+
+// sliceFlowsToScopes reports whether slice is an argument to a Scopes call.
+func sliceFlowsToScopes(slice *ssa.Slice) bool {
+	refs := slice.Referrers()
+	if refs == nil {
+		return false
+	}
+	for _, ref := range *refs {
+		if call, ok := ref.(*ssa.Call); ok && getMethodName(call) == "Scopes" && isGormDBMethodCall(call) {
+			return true
+		}
+	}
+	return false
+}
+
+// callPassesFuncToScopes reports whether instr is a Scopes call that receives fn
+// directly as an argument (a bare function or a closure).
+func callPassesFuncToScopes(instr ssa.Instruction, fn *ssa.Function) bool {
+	call, ok := instr.(*ssa.Call)
+	if !ok || getMethodName(call) != "Scopes" || !isGormDBMethodCall(call) {
+		return false
+	}
+	for _, arg := range call.Call.Args {
+		if funcVal, ok := arg.(*ssa.Function); ok && funcVal == fn {
+			return true
+		}
+		if mc, ok := arg.(*ssa.MakeClosure); ok {
+			if closureFn, ok := mc.Fn.(*ssa.Function); ok && closureFn == fn {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getMethodName extracts the method name from a call instruction.
+func getMethodName(call *ssa.Call) string {
+	if call.Call.IsInvoke() {
+		return call.Call.Method.Name()
+	}
+	if callee := call.Call.StaticCallee(); callee != nil {
+		return callee.Name()
+	}
+	return ""
+}
+
+// isGormDBMethodCall reports whether call is dispatching to a method on
+// *gorm.DB. We need this whenever we key off a method *name*
+// (Session/WithContext/Debug/Scopes) so that an unrelated package's
+// identically-named method doesn't trigger GORM-specific diagnostics.
+func isGormDBMethodCall(call *ssa.Call) bool {
+	if call.Call.IsInvoke() {
+		return typeutil.IsGormDB(call.Call.Value.Type())
+	}
+	callee := call.Call.StaticCallee()
+	if callee == nil || callee.Signature == nil || callee.Signature.Recv() == nil {
+		return false
+	}
+	return typeutil.IsGormDB(callee.Signature.Recv().Type())
+}

--- a/testdata/src/gormreuse/scopes_callback.go
+++ b/testdata/src/gormreuse/scopes_callback.go
@@ -55,10 +55,12 @@ func scopesCallbackSingleUse(db *gorm.DB) {
 	})
 }
 
-// SC102: Session() inside the callback isolates before branching.
+// SC102: Session() inside the callback isolates before branching, so the reuse
+// of s is fine — but Session() inside a Scopes callback trips the temporary GORM
+// transaction-leak warning (go-gorm/gorm#7592, Phase 3).
 func scopesCallbackSessionIsolated(db *gorm.DB) {
 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
-		s := tx.Session(&gorm.Session{})
+		s := tx.Session(&gorm.Session{}) // want `Session\(\) in Scopes callback causes transaction leak`
 		s.Where("a").Find(nil)
 		return s.Where("b") // OK: s is immutable (Session isolates)
 	})

--- a/testdata/src/gormreuse/scopes_callback.go.diff
+++ b/testdata/src/gormreuse/scopes_callback.go.diff
@@ -1,6 +1,6 @@
 --- scopes_callback.go	1970-01-01 00:00:00
 +++ scopes_callback.go.golden	1970-01-01 00:00:00
-@@ -1,104 +1,105 @@
+@@ -1,106 +1,107 @@
  package internal
  
  import "gorm.io/gorm"
@@ -58,10 +58,12 @@
  	})
  }
  
- // SC102: Session() inside the callback isolates before branching.
+ // SC102: Session() inside the callback isolates before branching, so the reuse
+ // of s is fine — but Session() inside a Scopes callback trips the temporary GORM
+ // transaction-leak warning (go-gorm/gorm#7592, Phase 3).
  func scopesCallbackSessionIsolated(db *gorm.DB) {
  	db.Scopes(func(tx *gorm.DB) *gorm.DB {
- 		s := tx.Session(&gorm.Session{})
+ 		s := tx.Session(&gorm.Session{}) // want `Session\(\) in Scopes callback causes transaction leak`
  		s.Where("a").Find(nil)
  		return s.Where("b") // OK: s is immutable (Session isolates)
  	})

--- a/testdata/src/gormreuse/scopes_callback.go.golden
+++ b/testdata/src/gormreuse/scopes_callback.go.golden
@@ -55,10 +55,12 @@ func scopesCallbackSingleUse(db *gorm.DB) {
 	})
 }
 
-// SC102: Session() inside the callback isolates before branching.
+// SC102: Session() inside the callback isolates before branching, so the reuse
+// of s is fine — but Session() inside a Scopes callback trips the temporary GORM
+// transaction-leak warning (go-gorm/gorm#7592, Phase 3).
 func scopesCallbackSessionIsolated(db *gorm.DB) {
 	db.Scopes(func(tx *gorm.DB) *gorm.DB {
-		s := tx.Session(&gorm.Session{})
+		s := tx.Session(&gorm.Session{}) // want `Session\(\) in Scopes callback causes transaction leak`
 		s.Where("a").Find(nil)
 		return s.Where("b") // OK: s is immutable (Session isolates)
 	})

--- a/testdata/src/gormreuse/scopes_session_warning.go
+++ b/testdata/src/gormreuse/scopes_session_warning.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// =============================================================================
+// TEMPORARY: Session/WithContext/Debug inside Scopes callbacks (GORM bug #7592)
+// Issue #56 cases 3.1–3.4. These fixtures pair with internal/scopes_session_warning.go
+// and should be deleted together once the upstream fix ships.
+// =============================================================================
+
+// 3.1: Session() inside a Scopes callback warns.
+func scopesCallbackSessionWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{}).Where("x") // want `Session\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.2: WithContext() inside a Scopes callback warns (it calls Session internally).
+func scopesCallbackWithContextWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.WithContext(context.Background()).Where("x") // want `WithContext\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.3: Debug() inside a Scopes callback warns (it calls Session internally).
+func scopesCallbackDebugWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.Debug().Where("x") // want `Debug\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.4: the same Session() inside a Preload callback is NOT flagged — Preload
+// builds a fresh DB (NewDB) and is unaffected by the bug.
+func preloadCallbackSessionClean(db *gorm.DB) {
+	db.Preload("Rel", func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{}).Where("x") // OK: Preload callback is unaffected
+	})
+}

--- a/testdata/src/gormreuse/scopes_session_warning.go.golden
+++ b/testdata/src/gormreuse/scopes_session_warning.go.golden
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// =============================================================================
+// TEMPORARY: Session/WithContext/Debug inside Scopes callbacks (GORM bug #7592)
+// Issue #56 cases 3.1–3.4. These fixtures pair with internal/scopes_session_warning.go
+// and should be deleted together once the upstream fix ships.
+// =============================================================================
+
+// 3.1: Session() inside a Scopes callback warns.
+func scopesCallbackSessionWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{}).Where("x") // want `Session\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.2: WithContext() inside a Scopes callback warns (it calls Session internally).
+func scopesCallbackWithContextWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.WithContext(context.Background()).Where("x") // want `WithContext\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.3: Debug() inside a Scopes callback warns (it calls Session internally).
+func scopesCallbackDebugWarns(db *gorm.DB) {
+	db.Scopes(func(q *gorm.DB) *gorm.DB {
+		return q.Debug().Where("x") // want `Debug\(\) in Scopes callback causes transaction leak`
+	})
+}
+
+// 3.4: the same Session() inside a Preload callback is NOT flagged — Preload
+// builds a fresh DB (NewDB) and is unaffected by the bug.
+func preloadCallbackSessionClean(db *gorm.DB) {
+	db.Preload("Rel", func(q *gorm.DB) *gorm.DB {
+		return q.Session(&gorm.Session{}).Where("x") // OK: Preload callback is unaffected
+	})
+}


### PR DESCRIPTION
## Phase 3 — temporary warning: `Session`/`WithContext`/`Debug` inside `Scopes` callbacks (#63)

> [!WARNING]
> A **temporary** rule working around an upstream GORM bug.

Calling `Session`/`WithContext`/`Debug` inside a `Scopes` callback corrupts GORM's `InstanceSet`/`InstanceGet` bookkeeping and leaks transactions ([go-gorm/gorm#7592](https://github.com/go-gorm/gorm/issues/7592), fix attempt [#7593](https://github.com/go-gorm/gorm/pull/7593)).

```go
db.Scopes(func(q *gorm.DB) *gorm.DB {
    return q.Session(&gorm.Session{}).Where("x") // ▶ Session() in Scopes callback causes transaction leak
})

db.Preload("Rel", func(q *gorm.DB) *gorm.DB {
    return q.Session(&gorm.Session{}).Where("x") // OK — Preload builds a fresh DB, unaffected
})
```

### Design — built to be deleted
- Fully isolated in `internal/scopes_session_warning.go`; the **removal condition** is documented in-line: delete that file + the single `RunSSA` call site once the upstream fix ships in a supported release. **Verified deletable — one file, one call site.**
- Scopes-only (matches the `Scopes` method name), so **Preload callbacks are not flagged** (case 3.4).
- `isScopesCallback` decomposed into small helpers to stay under the gocognit threshold while keeping the file self-contained.

### Fixtures & docs
- `scopes_session_warning.go`: cases 3.1-3.3 warn (Session/WithContext/Debug); 3.4 Preload stays clean.
- Existing `SC102` updated — using `Session()` to isolate inside a Scopes callback now trips this warning (its reuse assertion still holds).
- README documents the rule as temporary (upstream links + removal condition); CLAUDE.md notes it alongside the builtin immutable callbacks.

### Acceptance criteria (#63)
- [x] Session/WithContext/Debug in a Scopes callback warn
- [x] Preload callback with Session() stays clean
- [x] Removal condition documented in code and README
- [x] Deletable by removing one file + one call site

### Gates
`go test ./...` ✅ · `e2e/internal` ✅ · `golangci-lint` 0 issues ✅ · warning file ~100% on the reachable paths ✅

**Closes #63.** This is the final piece of Track A — with it, epic **#59** is complete.
